### PR TITLE
feat(client): unify runtime-aware operator model for desktop beta

### DIFF
--- a/client/lib/app/app_shell.dart
+++ b/client/lib/app/app_shell.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../features/advanced/presentation/advanced_page.dart';
 import '../features/dashboard/presentation/dashboard_page.dart';
 import '../features/profiles/presentation/profiles_page.dart';
+import '../features/readiness/domain/readiness_report.dart';
 import '../features/settings/presentation/settings_page.dart';
 import '../platform/services/service_registry.dart';
 
@@ -17,12 +18,15 @@ class TrojanClientAppShell extends StatefulWidget {
 
 class _TrojanClientAppShellState extends State<TrojanClientAppShell> {
   int _selectedIndex = 0;
+  int _advancedTabRequestId = 0;
+  AdvancedPageTab _requestedAdvancedTab = AdvancedPageTab.problemReport;
   DateTime? _lastHandledExternalActivationAt;
 
   @override
   void initState() {
     super.initState();
-    widget.services.desktopLifecycle.addListener(_handleDesktopLifecycleChanged);
+    widget.services.desktopLifecycle
+        .addListener(_handleDesktopLifecycleChanged);
     // initialize() 已在 bootstrap 阶段完成，此处不再重复调用
   }
 
@@ -43,7 +47,8 @@ class _TrojanClientAppShellState extends State<TrojanClientAppShell> {
     }
 
     final activatedAt = status.lastExternalActivationAt;
-    if (activatedAt == null || activatedAt == _lastHandledExternalActivationAt) {
+    if (activatedAt == null ||
+        activatedAt == _lastHandledExternalActivationAt) {
       return;
     }
 
@@ -51,6 +56,14 @@ class _TrojanClientAppShellState extends State<TrojanClientAppShell> {
     if (_selectedIndex != 0 && mounted) {
       setState(() => _selectedIndex = 0);
     }
+  }
+
+  void _openAdvanced([AdvancedPageTab tab = AdvancedPageTab.problemReport]) {
+    setState(() {
+      _selectedIndex = 3;
+      _requestedAdvancedTab = tab;
+      _advancedTabRequestId++;
+    });
   }
 
   /// 窄屏断点：低于此宽度使用 BottomNavigationBar 代替 NavigationRail。
@@ -71,12 +84,32 @@ class _TrojanClientAppShellState extends State<TrojanClientAppShell> {
         key: _pageKeys[0],
         services: widget.services,
         onOpenProfiles: () => setState(() => _selectedIndex = 1),
-        onOpenAdvanced: () => setState(() => _selectedIndex = 3),
+        onOpenAdvanced: () => _openAdvanced(),
         onOpenSettings: () => setState(() => _selectedIndex = 2),
       ),
-      ProfilesPage(key: _pageKeys[1], services: widget.services),
+      ProfilesPage(
+        key: _pageKeys[1],
+        services: widget.services,
+        onOpenAdvanced: (ReadinessAction action) {
+          switch (action) {
+            case ReadinessAction.openTroubleshooting:
+              _openAdvanced(AdvancedPageTab.problemReport);
+              return;
+            case ReadinessAction.openProfiles:
+            case ReadinessAction.openSettings:
+              _openAdvanced();
+              return;
+          }
+        },
+        onOpenSettings: () => setState(() => _selectedIndex = 2),
+      ),
       SettingsPage(key: _pageKeys[2], services: widget.services),
-      AdvancedPage(key: _pageKeys[3], services: widget.services),
+      AdvancedPage(
+        key: _pageKeys[3],
+        services: widget.services,
+        requestedTab: _requestedAdvancedTab,
+        tabRequestId: _advancedTabRequestId,
+      ),
     ];
 
     return LayoutBuilder(

--- a/client/lib/bootstrap.dart
+++ b/client/lib/bootstrap.dart
@@ -1,11 +1,8 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'features/controller/application/adapter_backed_client_controller.dart';
 import 'features/controller/application/client_controller_api.dart';
-import 'features/controller/application/fake_shell_controller_adapter.dart';
-import 'features/controller/application/real_shell_controller_adapter.dart';
-import 'features/controller/application/shell_controller_adapter.dart';
+import 'features/controller/application/shell_controller_adapter_selector.dart';
 import 'features/controller/domain/client_connection_status.dart';
 import 'features/diagnostics/application/diagnostics_export_service.dart';
 import 'features/packaging/application/packaging_export_service.dart';
@@ -74,8 +71,10 @@ class ClientBootstrap {
       fileExporter: diagnosticsFileExporter,
     );
 
+    final adapterSelection = _selectShellControllerAdapter();
+
     final controller = AdapterBackedClientController(
-      adapter: _createShellControllerAdapter(),
+      adapter: adapterSelection.adapter,
       profileSecrets: profileSecrets,
       localStateStore: localStateStore,
       filesystemLayout: filesystemLayout,
@@ -137,6 +136,8 @@ class ClientBootstrap {
       secureStorage: secureStorage,
       fileExporter: diagnosticsFileExporter,
       appRuntimeErrors: appRuntimeErrors,
+      adapterSelectionReason: adapterSelection.selectionReason,
+      expectedRealRuntimePath: adapterSelection.isRealRuntimePath,
     );
 
     final registry = ClientServiceRegistry(
@@ -220,18 +221,8 @@ class ClientBootstrap {
     );
   }
 
-  static ShellControllerAdapter _createShellControllerAdapter() {
-    final env = Platform.environment;
-    final rawFlag =
-        (env['TROJAN_CLIENT_ENABLE_REAL_ADAPTER'] ?? '').trim().toLowerCase();
-    final enableRealAdapter = rawFlag == '1' || rawFlag == 'true';
-    final binaryOverride = (env['TROJAN_CLIENT_BINARY'] ?? '').trim();
-
-    if (enableRealAdapter) {
-      return RealShellControllerAdapter(
-        binaryPathHint: binaryOverride.isEmpty ? 'ENV_UNSET' : binaryOverride,
-      );
-    }
-    return FakeShellControllerAdapter();
+  static ShellControllerAdapterSelection _selectShellControllerAdapter() {
+    final selector = ShellControllerAdapterSelector();
+    return selector.selectForCurrentPlatform();
   }
 }

--- a/client/lib/bootstrap.dart
+++ b/client/lib/bootstrap.dart
@@ -134,6 +134,7 @@ class ClientBootstrap {
       secureStorage: secureStorage,
       controller: controller,
       filesystemLayout: filesystemLayout,
+      localStateStore: localStateStore,
     );
 
     final diagnostics = DiagnosticsExportService(

--- a/client/lib/bootstrap.dart
+++ b/client/lib/bootstrap.dart
@@ -12,6 +12,7 @@ import 'features/profiles/application/profile_secrets_service.dart';
 import 'features/profiles/application/profile_serialization.dart';
 import 'features/profiles/application/profile_store.dart';
 import 'features/settings/application/settings_serialization.dart';
+import 'features/readiness/application/readiness_service.dart';
 import 'features/settings/application/settings_store.dart';
 import 'platform/secure_storage/fallback_secure_storage.dart';
 import 'platform/secure_storage/flutter_secure_storage_adapter.dart';
@@ -127,6 +128,14 @@ class ClientBootstrap {
 
     await syncDesktopQuickActions();
 
+    final readiness = ReadinessService(
+      profileStore: profileStore,
+      profileSecrets: profileSecrets,
+      secureStorage: secureStorage,
+      controller: controller,
+      filesystemLayout: filesystemLayout,
+    );
+
     final diagnostics = DiagnosticsExportService(
       profileStore: profileStore,
       profilePortability: profilePortability,
@@ -138,6 +147,7 @@ class ClientBootstrap {
       appRuntimeErrors: appRuntimeErrors,
       adapterSelectionReason: adapterSelection.selectionReason,
       expectedRealRuntimePath: adapterSelection.isRealRuntimePath,
+      readiness: readiness,
     );
 
     final registry = ClientServiceRegistry(
@@ -151,6 +161,7 @@ class ClientBootstrap {
       packagingExport: packagingExport,
       settingsStore: settingsStore,
       controller: controller,
+      readiness: readiness,
       diagnostics: diagnostics,
       desktopLifecycle: desktopLifecycle,
       appRuntimeErrors: appRuntimeErrors,

--- a/client/lib/features/advanced/presentation/advanced_page.dart
+++ b/client/lib/features/advanced/presentation/advanced_page.dart
@@ -88,55 +88,59 @@ class _AdvancedPageState extends State<AdvancedPage>
         final lastRuntimeFailure = services.controller.lastRuntimeFailure;
         final appUnhandledError = services.appRuntimeErrors.lastUnhandledError;
 
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Text(
-              'Use Advanced when you need a support-oriented overview, a problem report bundle, or update/package details.',
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-            const SizedBox(height: 12),
-            _SupportOverviewCard(
-              status: status,
-              issue: issue,
-              runtimeMode: runtimeConfig.mode,
-              endpointHint: runtimeConfig.endpointHint,
-              backendKind: telemetry.backendKind,
-              backendVersion: telemetry.backendVersion,
-              diagnosticsBackend: services.diagnosticsFileExporter.backendName,
-              lastRuntimeFailure: lastRuntimeFailure,
-              appUnhandledError: appUnhandledError,
-            ),
-            const SizedBox(height: 16),
-            _SupportActionsCard(
-              status: status,
-              onOpenProblemReport: () => _tabController.animateTo(0),
-              onOpenUpdateStatus: () => _tabController.animateTo(1),
-            ),
-            const SizedBox(height: 16),
-            TabBar(
-              controller: _tabController,
-              isScrollable: true,
-              tabs: const <Widget>[
-                Tab(text: 'Problem Report'),
-                Tab(text: 'Update Status'),
-              ],
-            ),
-            const SizedBox(height: 16),
-            Expanded(
-              child: TabBarView(
-                controller: _tabController,
-                children: <Widget>[
-                  SingleChildScrollView(
-                    child: DiagnosticsPage(services: services),
-                  ),
-                  SingleChildScrollView(
-                    child: PackagingPage(services: services),
-                  ),
-                ],
+        return NestedScrollView(
+          headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+            return <Widget>[
+              SliverToBoxAdapter(
+                child: Text(
+                  'Use Advanced when you need a support-oriented overview, a problem report bundle, or update/package details.',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
               ),
-            ),
-          ],
+              const SliverToBoxAdapter(child: SizedBox(height: 12)),
+              SliverToBoxAdapter(
+                child: _SupportOverviewCard(
+                  status: status,
+                  issue: issue,
+                  runtimeMode: runtimeConfig.mode,
+                  endpointHint: runtimeConfig.endpointHint,
+                  backendKind: telemetry.backendKind,
+                  backendVersion: telemetry.backendVersion,
+                  diagnosticsBackend:
+                      services.diagnosticsFileExporter.backendName,
+                  lastRuntimeFailure: lastRuntimeFailure,
+                  appUnhandledError: appUnhandledError,
+                ),
+              ),
+              const SliverToBoxAdapter(child: SizedBox(height: 16)),
+              SliverToBoxAdapter(
+                child: _SupportActionsCard(
+                  status: status,
+                  onOpenProblemReport: () => _tabController.animateTo(0),
+                  onOpenUpdateStatus: () => _tabController.animateTo(1),
+                ),
+              ),
+              const SliverToBoxAdapter(child: SizedBox(height: 16)),
+              SliverToBoxAdapter(
+                child: TabBar(
+                  controller: _tabController,
+                  isScrollable: true,
+                  tabs: const <Widget>[
+                    Tab(text: 'Problem Report'),
+                    Tab(text: 'Update Status'),
+                  ],
+                ),
+              ),
+              const SliverToBoxAdapter(child: SizedBox(height: 16)),
+            ];
+          },
+          body: TabBarView(
+            controller: _tabController,
+            children: <Widget>[
+              DiagnosticsPage(services: services),
+              PackagingPage(services: services),
+            ],
+          ),
         );
       },
     );

--- a/client/lib/features/advanced/presentation/advanced_page.dart
+++ b/client/lib/features/advanced/presentation/advanced_page.dart
@@ -6,6 +6,7 @@ import '../../../core/widgets/section_card.dart';
 import '../../../platform/services/app_runtime_error_store.dart';
 import '../../../platform/services/service_registry.dart';
 import '../../controller/domain/client_connection_status.dart';
+import '../../controller/domain/controller_runtime_session.dart';
 import '../../controller/domain/last_runtime_failure_summary.dart';
 import '../../controller/domain/runtime_posture.dart';
 import '../../diagnostics/application/support_issue_descriptor.dart';
@@ -92,6 +93,7 @@ class _AdvancedPageState extends State<AdvancedPage>
         final issue = SupportIssueDescriptor.fromConnectionStatus(status);
         final lastRuntimeFailure = services.controller.lastRuntimeFailure;
         final appUnhandledError = services.appRuntimeErrors.lastUnhandledError;
+        final runtimeSession = services.controller.session;
 
         return NestedScrollView(
           headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
@@ -128,6 +130,10 @@ class _AdvancedPageState extends State<AdvancedPage>
               ),
               const SliverToBoxAdapter(child: SizedBox(height: 16)),
               SliverToBoxAdapter(
+                child: _RuntimeTruthRecoveryCard(session: runtimeSession),
+              ),
+              const SliverToBoxAdapter(child: SizedBox(height: 16)),
+              SliverToBoxAdapter(
                 child: TabBar(
                   controller: _tabController,
                   isScrollable: true,
@@ -149,6 +155,46 @@ class _AdvancedPageState extends State<AdvancedPage>
           ),
         );
       },
+    );
+  }
+}
+
+class _RuntimeTruthRecoveryCard extends StatelessWidget {
+  const _RuntimeTruthRecoveryCard({required this.session});
+
+  final ControllerRuntimeSession session;
+
+  @override
+  Widget build(BuildContext context) {
+    return SectionCard(
+      title: 'Runtime truth & recovery',
+      subtitle:
+          'Make stale, residual, and stopping runtime states obvious before they turn into ghost bugs.',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Wrap(
+            spacing: 24,
+            runSpacing: 12,
+            children: <Widget>[
+              KeyValuePair(label: 'Session Truth', value: session.truth.label),
+              KeyValuePair(label: 'Snapshot Age', value: session.ageLabel),
+              KeyValuePair(label: 'Runtime Phase', value: session.phase.name),
+              KeyValuePair(
+                label: 'Needs attention',
+                value: session.needsAttention ? 'Yes' : 'No',
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Text(
+            session.truthNote,
+            style: const TextStyle(fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 8),
+          Text(session.recoveryGuidance),
+        ],
+      ),
     );
   }
 }

--- a/client/lib/features/advanced/presentation/advanced_page.dart
+++ b/client/lib/features/advanced/presentation/advanced_page.dart
@@ -11,10 +11,22 @@ import '../../diagnostics/application/support_issue_descriptor.dart';
 import '../../diagnostics/presentation/diagnostics_page.dart';
 import '../../packaging/presentation/packaging_page.dart';
 
+enum AdvancedPageTab {
+  problemReport,
+  updateStatus,
+}
+
 class AdvancedPage extends StatefulWidget {
-  const AdvancedPage({super.key, required this.services});
+  const AdvancedPage({
+    super.key,
+    required this.services,
+    this.requestedTab = AdvancedPageTab.problemReport,
+    this.tabRequestId = 0,
+  });
 
   final ClientServiceRegistry services;
+  final AdvancedPageTab requestedTab;
+  final int tabRequestId;
 
   @override
   State<AdvancedPage> createState() => _AdvancedPageState();
@@ -23,17 +35,40 @@ class AdvancedPage extends StatefulWidget {
 class _AdvancedPageState extends State<AdvancedPage>
     with SingleTickerProviderStateMixin {
   late final TabController _tabController;
+  int? _lastHandledTabRequestId;
 
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 2, vsync: this);
+    _tabController = TabController(
+      length: 2,
+      vsync: this,
+      initialIndex: _tabIndexFor(widget.requestedTab),
+    );
+    _lastHandledTabRequestId = widget.tabRequestId;
+  }
+
+  @override
+  void didUpdateWidget(covariant AdvancedPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.tabRequestId == _lastHandledTabRequestId) {
+      return;
+    }
+    _lastHandledTabRequestId = widget.tabRequestId;
+    _tabController.animateTo(_tabIndexFor(widget.requestedTab));
   }
 
   @override
   void dispose() {
     _tabController.dispose();
     super.dispose();
+  }
+
+  int _tabIndexFor(AdvancedPageTab tab) {
+    return switch (tab) {
+      AdvancedPageTab.problemReport => 0,
+      AdvancedPageTab.updateStatus => 1,
+    };
   }
 
   @override
@@ -68,8 +103,7 @@ class _AdvancedPageState extends State<AdvancedPage>
               endpointHint: runtimeConfig.endpointHint,
               backendKind: telemetry.backendKind,
               backendVersion: telemetry.backendVersion,
-              diagnosticsBackend:
-                  services.diagnosticsFileExporter.backendName,
+              diagnosticsBackend: services.diagnosticsFileExporter.backendName,
               lastRuntimeFailure: lastRuntimeFailure,
               appUnhandledError: appUnhandledError,
             ),
@@ -207,20 +241,32 @@ class _SupportOverviewCard extends StatelessWidget {
             spacing: 24,
             runSpacing: 12,
             children: <Widget>[
-              KeyValuePair(label: 'Connection phase', value: status.phase.name, width: 240),
-              KeyValuePair(label: 'Status note', value: status.message, width: 240),
-              KeyValuePair(label: 'Runtime mode', value: runtimeMode, width: 240),
+              KeyValuePair(
+                  label: 'Connection phase',
+                  value: status.phase.name,
+                  width: 240),
+              KeyValuePair(
+                  label: 'Status note', value: status.message, width: 240),
+              KeyValuePair(
+                  label: 'Runtime mode', value: runtimeMode, width: 240),
               KeyValuePair(
                 label: 'Execution path',
                 value: _executionPathLabel(runtimeMode),
                 width: 240,
               ),
-              KeyValuePair(label: 'Endpoint hint', value: endpointHint, width: 240),
+              KeyValuePair(
+                  label: 'Endpoint hint', value: endpointHint, width: 240),
               KeyValuePair(label: 'Backend', value: backendKind, width: 240),
-              KeyValuePair(label: 'Backend version', value: backendVersion, width: 240),
-              KeyValuePair(label: 'Diagnostics export', value: diagnosticsBackend, width: 240),
-              KeyValuePair(label: 'Issue category', value: issue.label, width: 240),
-              KeyValuePair(label: 'Support summary', value: issue.summary, width: 240),
+              KeyValuePair(
+                  label: 'Backend version', value: backendVersion, width: 240),
+              KeyValuePair(
+                  label: 'Diagnostics export',
+                  value: diagnosticsBackend,
+                  width: 240),
+              KeyValuePair(
+                  label: 'Issue category', value: issue.label, width: 240),
+              KeyValuePair(
+                  label: 'Support summary', value: issue.summary, width: 240),
             ],
           ),
         ],
@@ -419,4 +465,3 @@ class _SupportActionsCard extends StatelessWidget {
     );
   }
 }
-

--- a/client/lib/features/advanced/presentation/advanced_page.dart
+++ b/client/lib/features/advanced/presentation/advanced_page.dart
@@ -155,6 +155,25 @@ class _SupportOverviewCard extends StatelessWidget {
     };
   }
 
+  String _executionPathLabel(String mode) {
+    if (mode.contains('real-runtime-boundary')) {
+      return 'Real runtime path';
+    }
+    if (mode.contains('stubbed-local-boundary-fallback')) {
+      return 'Fallback stub (real runtime unavailable)';
+    }
+    if (mode.contains('stubbed-local-boundary-explicit')) {
+      return 'Explicit stub mode';
+    }
+    if (mode.contains('stubbed-local-boundary-non-desktop')) {
+      return 'Stub mode (non-desktop target)';
+    }
+    if (mode.contains('stubbed-local-boundary')) {
+      return 'Simulated runtime path';
+    }
+    return 'Unknown runtime path';
+  }
+
   @override
   Widget build(BuildContext context) {
     return SectionCard(
@@ -191,6 +210,11 @@ class _SupportOverviewCard extends StatelessWidget {
               KeyValuePair(label: 'Connection phase', value: status.phase.name, width: 240),
               KeyValuePair(label: 'Status note', value: status.message, width: 240),
               KeyValuePair(label: 'Runtime mode', value: runtimeMode, width: 240),
+              KeyValuePair(
+                label: 'Execution path',
+                value: _executionPathLabel(runtimeMode),
+                width: 240,
+              ),
               KeyValuePair(label: 'Endpoint hint', value: endpointHint, width: 240),
               KeyValuePair(label: 'Backend', value: backendKind, width: 240),
               KeyValuePair(label: 'Backend version', value: backendVersion, width: 240),

--- a/client/lib/features/advanced/presentation/advanced_page.dart
+++ b/client/lib/features/advanced/presentation/advanced_page.dart
@@ -246,6 +246,11 @@ class _SupportOverviewCard extends StatelessWidget {
                 width: 240,
               ),
               KeyValuePair(
+                label: 'Evidence grade',
+                value: posture.evidenceGradeLabel,
+                width: 240,
+              ),
+              KeyValuePair(
                 label: 'Execution path',
                 value: posture.executionPathLabel,
                 width: 240,
@@ -267,7 +272,7 @@ class _SupportOverviewCard extends StatelessWidget {
           ),
           const SizedBox(height: 16),
           Text(
-            posture.truthNote,
+            '${posture.truthNote} ${posture.evidenceGradeNote}',
             style: const TextStyle(fontWeight: FontWeight.w600),
           ),
         ],

--- a/client/lib/features/advanced/presentation/advanced_page.dart
+++ b/client/lib/features/advanced/presentation/advanced_page.dart
@@ -85,6 +85,10 @@ class _AdvancedPageState extends State<AdvancedPage>
         final status = services.controller.status;
         final runtimeConfig = services.controller.runtimeConfig;
         final telemetry = services.controller.telemetry;
+        final posture = describeRuntimePosture(
+          runtimeMode: runtimeConfig.mode,
+          backendKind: telemetry.backendKind,
+        );
         final issue = SupportIssueDescriptor.fromConnectionStatus(status);
         final lastRuntimeFailure = services.controller.lastRuntimeFailure;
         final appUnhandledError = services.appRuntimeErrors.lastUnhandledError;
@@ -117,6 +121,7 @@ class _AdvancedPageState extends State<AdvancedPage>
               SliverToBoxAdapter(
                 child: _SupportActionsCard(
                   status: status,
+                  runtimePosture: posture,
                   onOpenProblemReport: () => _tabController.animateTo(0),
                   onOpenUpdateStatus: () => _tabController.animateTo(1),
                 ),
@@ -416,11 +421,13 @@ class _IssueCategoryBanner extends StatelessWidget {
 class _SupportActionsCard extends StatelessWidget {
   const _SupportActionsCard({
     required this.status,
+    required this.runtimePosture,
     required this.onOpenProblemReport,
     required this.onOpenUpdateStatus,
   });
 
   final ClientConnectionStatus status;
+  final RuntimePosture runtimePosture;
   final VoidCallback onOpenProblemReport;
   final VoidCallback onOpenUpdateStatus;
 
@@ -449,6 +456,10 @@ class _SupportActionsCard extends StatelessWidget {
           const Text(
             'Problem Report is the export/share path. Update Status is for packaging and release context.',
           ),
+          const SizedBox(height: 8),
+          Text(runtimePosture.artifactCapabilityLabel),
+          const SizedBox(height: 4),
+          Text(runtimePosture.artifactCapabilityNote),
           const SizedBox(height: 12),
           Wrap(
             spacing: 8,
@@ -457,7 +468,11 @@ class _SupportActionsCard extends StatelessWidget {
               FilledButton.icon(
                 onPressed: onOpenProblemReport,
                 icon: const Icon(Icons.assignment_outlined),
-                label: const Text('Open Problem Report'),
+                label: Text(
+                  runtimePosture.canProduceRuntimeProofArtifact
+                      ? 'Open Problem Report'
+                      : 'Open Support Bundle',
+                ),
               ),
               OutlinedButton.icon(
                 onPressed: onOpenUpdateStatus,

--- a/client/lib/features/advanced/presentation/advanced_page.dart
+++ b/client/lib/features/advanced/presentation/advanced_page.dart
@@ -7,6 +7,7 @@ import '../../../platform/services/app_runtime_error_store.dart';
 import '../../../platform/services/service_registry.dart';
 import '../../controller/domain/client_connection_status.dart';
 import '../../controller/domain/last_runtime_failure_summary.dart';
+import '../../controller/domain/runtime_posture.dart';
 import '../../diagnostics/application/support_issue_descriptor.dart';
 import '../../diagnostics/presentation/diagnostics_page.dart';
 import '../../packaging/presentation/packaging_page.dart';
@@ -193,27 +194,13 @@ class _SupportOverviewCard extends StatelessWidget {
     };
   }
 
-  String _executionPathLabel(String mode) {
-    if (mode.contains('real-runtime-boundary')) {
-      return 'Real runtime path';
-    }
-    if (mode.contains('stubbed-local-boundary-fallback')) {
-      return 'Fallback stub (real runtime unavailable)';
-    }
-    if (mode.contains('stubbed-local-boundary-explicit')) {
-      return 'Explicit stub mode';
-    }
-    if (mode.contains('stubbed-local-boundary-non-desktop')) {
-      return 'Stub mode (non-desktop target)';
-    }
-    if (mode.contains('stubbed-local-boundary')) {
-      return 'Simulated runtime path';
-    }
-    return 'Unknown runtime path';
-  }
-
   @override
   Widget build(BuildContext context) {
+    final posture = describeRuntimePosture(
+      runtimeMode: runtimeMode,
+      backendKind: backendKind,
+    );
+
     return SectionCard(
       title: 'Troubleshooting Overview',
       subtitle:
@@ -254,8 +241,13 @@ class _SupportOverviewCard extends StatelessWidget {
               KeyValuePair(
                   label: 'Runtime mode', value: runtimeMode, width: 240),
               KeyValuePair(
+                label: 'Runtime posture',
+                value: posture.postureLabel,
+                width: 240,
+              ),
+              KeyValuePair(
                 label: 'Execution path',
-                value: _executionPathLabel(runtimeMode),
+                value: posture.executionPathLabel,
                 width: 240,
               ),
               KeyValuePair(
@@ -272,6 +264,11 @@ class _SupportOverviewCard extends StatelessWidget {
               KeyValuePair(
                   label: 'Support summary', value: issue.summary, width: 240),
             ],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            posture.truthNote,
+            style: const TextStyle(fontWeight: FontWeight.w600),
           ),
         ],
       ),

--- a/client/lib/features/controller/application/adapter_backed_client_controller.dart
+++ b/client/lib/features/controller/application/adapter_backed_client_controller.dart
@@ -210,14 +210,21 @@ class AdapterBackedClientController extends ClientControllerApi {
     );
 
     final runtimeMode = runtimeConfig.mode;
-    final acceptedPhase = commandResult.details.containsKey('pid') ||
-            runtimeMode == 'stubbed-local-boundary'
-        ? ClientConnectionPhase.connected
-        : ClientConnectionPhase.connecting;
+    final runtimeSession = _adapter.session;
+    final acceptedPhase = _acceptedPhaseForConnect(
+      runtimeMode: runtimeMode,
+      runtimeSession: runtimeSession,
+      commandResult: commandResult,
+    );
+    final acceptedMessage = _acceptedMessageForConnect(
+      runtimeMode: runtimeMode,
+      runtimeSession: runtimeSession,
+      commandResult: commandResult,
+    );
 
     _recordEvent(
       title: 'Connect requested',
-      message: commandResult.summary,
+      message: commandResult.accepted ? acceptedMessage : commandResult.summary,
       phase:
           commandResult.accepted ? acceptedPhase : ClientConnectionPhase.error,
       profileId: profile.id,
@@ -249,7 +256,7 @@ class AdapterBackedClientController extends ClientControllerApi {
 
     _status = ClientConnectionStatus(
       phase: acceptedPhase,
-      message: commandResult.summary,
+      message: acceptedMessage,
       updatedAt: DateTime.now(),
       activeProfileId: profile.id,
     );
@@ -328,14 +335,18 @@ class AdapterBackedClientController extends ClientControllerApi {
       return commandResult;
     }
 
-    final runningAfterRequest = _adapter.session.isRunning;
+    final runtimeSession = _adapter.session;
+    final runningAfterRequest = runtimeSession.isRunning;
     final nextPhase = runningAfterRequest
         ? ClientConnectionPhase.disconnecting
         : ClientConnectionPhase.disconnected;
+    final nextMessage = runningAfterRequest
+        ? _disconnectPendingMessage(runtimeSession, commandResult)
+        : commandResult.summary;
 
     _recordEvent(
       title: 'Disconnect requested',
-      message: commandResult.summary,
+      message: nextMessage,
       phase: nextPhase,
       profileId: activeProfileId,
       kind: ClientControllerEventKind.result,
@@ -347,12 +358,12 @@ class AdapterBackedClientController extends ClientControllerApi {
     _status = nextPhase == ClientConnectionPhase.disconnected
         ? ClientConnectionStatus(
             phase: ClientConnectionPhase.disconnected,
-            message: commandResult.summary,
+            message: nextMessage,
             updatedAt: DateTime.now(),
           )
         : ClientConnectionStatus(
             phase: ClientConnectionPhase.disconnecting,
-            message: commandResult.summary,
+            message: nextMessage,
             updatedAt: DateTime.now(),
             activeProfileId: activeProfileId,
           );
@@ -363,6 +374,59 @@ class AdapterBackedClientController extends ClientControllerApi {
     await _persistRuntimeSnapshot();
     _notifyIfActive();
     return commandResult;
+  }
+
+  ClientConnectionPhase _acceptedPhaseForConnect({
+    required String runtimeMode,
+    required ControllerRuntimeSession runtimeSession,
+    required ControllerCommandResult commandResult,
+  }) {
+    if (runtimeMode.startsWith('stubbed-local-boundary')) {
+      return ClientConnectionPhase.connected;
+    }
+
+    if (commandResult.details.containsKey('pid') &&
+        runtimeSession.phase == ControllerRuntimePhase.sessionReady) {
+      return ClientConnectionPhase.connected;
+    }
+
+    return ClientConnectionPhase.connecting;
+  }
+
+  String _acceptedMessageForConnect({
+    required String runtimeMode,
+    required ControllerRuntimeSession runtimeSession,
+    required ControllerCommandResult commandResult,
+  }) {
+    if (runtimeMode.startsWith('stubbed-local-boundary')) {
+      return commandResult.summary;
+    }
+
+    return switch (runtimeSession.phase) {
+      ControllerRuntimePhase.planned =>
+        'Launch plan accepted. Preparing managed runtime config.',
+      ControllerRuntimePhase.launching =>
+        'Launch plan accepted. Starting runtime process.',
+      ControllerRuntimePhase.alive =>
+        'Runtime process is alive. Waiting for session-ready signal.',
+      ControllerRuntimePhase.sessionReady =>
+        commandResult.summary,
+      ControllerRuntimePhase.failed =>
+        commandResult.summary,
+      ControllerRuntimePhase.stopped =>
+        'Launch accepted. Waiting for runtime state update.',
+    };
+  }
+
+  String _disconnectPendingMessage(
+    ControllerRuntimeSession runtimeSession,
+    ControllerCommandResult commandResult,
+  ) {
+    final pidSuffix = runtimeSession.pid == null ? '' : ' (pid=${runtimeSession.pid})';
+    if (runtimeSession.stopRequested) {
+      return 'Stop requested$pidSuffix. Waiting for the runtime process to exit cleanly.';
+    }
+    return commandResult.summary;
   }
 
   String _configPathFor(String profileId) {
@@ -382,24 +446,82 @@ class AdapterBackedClientController extends ClientControllerApi {
 
     if (session.isRunning) {
       if (_status.phase == ClientConnectionPhase.connecting) {
-        final summary = session.pid == null
-            ? 'Runtime session is active.'
-            : 'Runtime session is active. pid=${session.pid}';
-        _status = _status.copyWith(
-          phase: ClientConnectionPhase.connected,
-          message: summary,
-          updatedAt: DateTime.now(),
-        );
-        _recordEvent(
-          title: 'Runtime session active',
-          message: summary,
-          phase: ClientConnectionPhase.connected,
-          profileId: _status.activeProfileId,
-          kind: ClientControllerEventKind.progress,
-          level: ClientControllerEventLevel.info,
-        );
-        _clearLastRuntimeFailureSoon();
-        _persistRuntimeSnapshotSoon();
+        if (session.phase == ControllerRuntimePhase.sessionReady) {
+          final summary = session.pid == null
+              ? 'Runtime session is ready.'
+              : 'Runtime session is ready. pid=${session.pid}';
+          _status = _status.copyWith(
+            phase: ClientConnectionPhase.connected,
+            message: summary,
+            updatedAt: DateTime.now(),
+          );
+          _recordEvent(
+            title: 'Runtime session ready',
+            message: summary,
+            phase: ClientConnectionPhase.connected,
+            profileId: _status.activeProfileId,
+            kind: ClientControllerEventKind.progress,
+            level: ClientControllerEventLevel.info,
+          );
+          _clearLastRuntimeFailureSoon();
+          _persistRuntimeSnapshotSoon();
+          return;
+        }
+
+        final progressSummary = switch (session.phase) {
+          ControllerRuntimePhase.planned =>
+            'Launch plan prepared. Writing managed runtime config.',
+          ControllerRuntimePhase.launching =>
+            'Managed runtime is launching now.',
+          ControllerRuntimePhase.alive => session.pid == null
+              ? 'Runtime process is alive. Waiting for session-ready signal.'
+              : 'Runtime process is alive (pid=${session.pid}). Waiting for session-ready signal.',
+          ControllerRuntimePhase.failed =>
+            'Runtime launch reported a failure state.',
+          ControllerRuntimePhase.stopped =>
+            'Launch accepted. Waiting for runtime process to start.',
+          ControllerRuntimePhase.sessionReady =>
+            'Runtime session is ready.',
+        };
+
+        if (_status.message != progressSummary) {
+          _status = _status.copyWith(
+            phase: ClientConnectionPhase.connecting,
+            message: progressSummary,
+            updatedAt: DateTime.now(),
+          );
+          _recordEvent(
+            title: 'Runtime launch in progress',
+            message: progressSummary,
+            phase: ClientConnectionPhase.connecting,
+            profileId: _status.activeProfileId,
+            kind: ClientControllerEventKind.progress,
+            level: ClientControllerEventLevel.info,
+          );
+          _persistRuntimeSnapshotSoon();
+        }
+      }
+
+      if (_status.phase == ClientConnectionPhase.disconnecting) {
+        final stopSummary = session.stopRequested
+            ? 'Stop requested${session.pid == null ? '' : ' (pid=${session.pid})'}. Waiting for the runtime process to exit cleanly.'
+            : 'Disconnect requested. Waiting for the runtime process to exit.';
+        if (_status.message != stopSummary) {
+          _status = _status.copyWith(
+            phase: ClientConnectionPhase.disconnecting,
+            message: stopSummary,
+            updatedAt: DateTime.now(),
+          );
+          _recordEvent(
+            title: 'Runtime stop in progress',
+            message: stopSummary,
+            phase: ClientConnectionPhase.disconnecting,
+            profileId: _status.activeProfileId,
+            kind: ClientControllerEventKind.progress,
+            level: ClientControllerEventLevel.info,
+          );
+          _persistRuntimeSnapshotSoon();
+        }
       }
       return;
     }
@@ -581,9 +703,15 @@ class AdapterBackedClientController extends ClientControllerApi {
       statusMessage: _status.message,
       activeProfileId: _status.activeProfileId,
       statusUpdatedAt: _status.updatedAt,
+      sessionPhase: currentSession.phase.name,
       sessionIsRunning: currentSession.isRunning,
+      sessionStopRequested: currentSession.stopRequested,
+      sessionStopRequestedAt: currentSession.stopRequestedAt,
       sessionPid: currentSession.pid,
       sessionActiveConfigPath: currentSession.activeConfigPath,
+      sessionConfigProvenance: currentSession.configProvenance,
+      sessionExpectedLocalSocksPort: currentSession.expectedLocalSocksPort,
+      sessionLaunchPlanSummary: currentSession.launchPlan?.summary,
       sessionLastExitCode: currentSession.lastExitCode,
       sessionLastError: currentSession.lastError,
       sessionUpdatedAt: currentSession.updatedAt,
@@ -749,9 +877,15 @@ class _PersistedRuntimeSnapshot {
     required this.statusMessage,
     required this.activeProfileId,
     required this.statusUpdatedAt,
+    required this.sessionPhase,
     required this.sessionIsRunning,
+    required this.sessionStopRequested,
+    required this.sessionStopRequestedAt,
     required this.sessionPid,
     required this.sessionActiveConfigPath,
+    required this.sessionConfigProvenance,
+    required this.sessionExpectedLocalSocksPort,
+    required this.sessionLaunchPlanSummary,
     required this.sessionLastExitCode,
     required this.sessionLastError,
     required this.sessionUpdatedAt,
@@ -761,9 +895,15 @@ class _PersistedRuntimeSnapshot {
   final String statusMessage;
   final String? activeProfileId;
   final DateTime statusUpdatedAt;
+  final String sessionPhase;
   final bool sessionIsRunning;
+  final bool sessionStopRequested;
+  final DateTime? sessionStopRequestedAt;
   final int? sessionPid;
   final String? sessionActiveConfigPath;
+  final String? sessionConfigProvenance;
+  final int? sessionExpectedLocalSocksPort;
+  final String? sessionLaunchPlanSummary;
   final int? sessionLastExitCode;
   final String? sessionLastError;
   final DateTime sessionUpdatedAt;
@@ -774,9 +914,15 @@ class _PersistedRuntimeSnapshot {
       'statusMessage': statusMessage,
       'activeProfileId': activeProfileId,
       'statusUpdatedAt': statusUpdatedAt.toIso8601String(),
+      'sessionPhase': sessionPhase,
       'sessionIsRunning': sessionIsRunning,
+      'sessionStopRequested': sessionStopRequested,
+      'sessionStopRequestedAt': sessionStopRequestedAt?.toIso8601String(),
       'sessionPid': sessionPid,
       'sessionActiveConfigPath': sessionActiveConfigPath,
+      'sessionConfigProvenance': sessionConfigProvenance,
+      'sessionExpectedLocalSocksPort': sessionExpectedLocalSocksPort,
+      'sessionLaunchPlanSummary': sessionLaunchPlanSummary,
       'sessionLastExitCode': sessionLastExitCode,
       'sessionLastError': sessionLastError,
       'sessionUpdatedAt': sessionUpdatedAt.toIso8601String(),
@@ -789,9 +935,15 @@ class _PersistedRuntimeSnapshot {
     final statusMessage = value['statusMessage'];
     final activeProfileId = value['activeProfileId'];
     final statusUpdatedAt = value['statusUpdatedAt'];
+    final sessionPhase = value['sessionPhase'];
     final sessionIsRunning = value['sessionIsRunning'];
+    final sessionStopRequested = value['sessionStopRequested'];
+    final sessionStopRequestedAt = value['sessionStopRequestedAt'];
     final sessionPid = value['sessionPid'];
     final sessionActiveConfigPath = value['sessionActiveConfigPath'];
+    final sessionConfigProvenance = value['sessionConfigProvenance'];
+    final sessionExpectedLocalSocksPort = value['sessionExpectedLocalSocksPort'];
+    final sessionLaunchPlanSummary = value['sessionLaunchPlanSummary'];
     final sessionLastExitCode = value['sessionLastExitCode'];
     final sessionLastError = value['sessionLastError'];
     final sessionUpdatedAt = value['sessionUpdatedAt'];
@@ -815,10 +967,21 @@ class _PersistedRuntimeSnapshot {
       statusMessage: statusMessage,
       activeProfileId: activeProfileId is String ? activeProfileId : null,
       statusUpdatedAt: parsedStatusUpdatedAt,
+      sessionPhase: sessionPhase is String ? sessionPhase : 'stopped',
       sessionIsRunning: sessionIsRunning,
+      sessionStopRequested: sessionStopRequested is bool ? sessionStopRequested : false,
+      sessionStopRequestedAt: sessionStopRequestedAt is String
+          ? DateTime.tryParse(sessionStopRequestedAt)
+          : null,
       sessionPid: sessionPid is int ? sessionPid : null,
       sessionActiveConfigPath:
           sessionActiveConfigPath is String ? sessionActiveConfigPath : null,
+      sessionConfigProvenance:
+          sessionConfigProvenance is String ? sessionConfigProvenance : null,
+      sessionExpectedLocalSocksPort:
+          sessionExpectedLocalSocksPort is int ? sessionExpectedLocalSocksPort : null,
+      sessionLaunchPlanSummary:
+          sessionLaunchPlanSummary is String ? sessionLaunchPlanSummary : null,
       sessionLastExitCode:
           sessionLastExitCode is int ? sessionLastExitCode : null,
       sessionLastError: sessionLastError is String ? sessionLastError : null,

--- a/client/lib/features/controller/application/fake_shell_controller_adapter.dart
+++ b/client/lib/features/controller/application/fake_shell_controller_adapter.dart
@@ -7,11 +7,24 @@ import '../domain/controller_telemetry_snapshot.dart';
 import 'shell_controller_adapter.dart';
 
 class FakeShellControllerAdapter implements ShellControllerAdapter {
+  FakeShellControllerAdapter({
+    this.backendKind = 'fake-shell-controller',
+    this.backendVersion = 'dev-shell',
+    this.runtimeMode = 'stubbed-local-boundary',
+    this.endpointHint = 'in-process://fake-shell-controller',
+  });
+
+  final String backendKind;
+  final String backendVersion;
+  final String runtimeMode;
+  final String endpointHint;
+
   final DateTime _sessionUpdatedAt = DateTime.now();
+
   @override
   ControllerTelemetrySnapshot get telemetry => ControllerTelemetrySnapshot(
-        backendKind: 'fake-shell-controller',
-        backendVersion: 'dev-shell',
+        backendKind: backendKind,
+        backendVersion: backendVersion,
         capabilities: const <String>[
           'connect',
           'disconnect',
@@ -22,9 +35,9 @@ class FakeShellControllerAdapter implements ShellControllerAdapter {
       );
 
   @override
-  ControllerRuntimeConfig get runtimeConfig => const ControllerRuntimeConfig(
-        mode: 'stubbed-local-boundary',
-        endpointHint: 'in-process://fake-shell-controller',
+  ControllerRuntimeConfig get runtimeConfig => ControllerRuntimeConfig(
+        mode: runtimeMode,
+        endpointHint: endpointHint,
         enableVerboseTelemetry: true,
       );
 
@@ -32,6 +45,8 @@ class FakeShellControllerAdapter implements ShellControllerAdapter {
   ControllerRuntimeSession get session => ControllerRuntimeSession(
         isRunning: false,
         updatedAt: _sessionUpdatedAt,
+        phase: ControllerRuntimePhase.sessionReady,
+        configProvenance: 'simulated://fake-shell-controller',
         lastExitCode: 0,
         stdoutTail: const <String>['fake controller session active'],
       );
@@ -40,7 +55,8 @@ class FakeShellControllerAdapter implements ShellControllerAdapter {
   Future<ControllerRuntimeHealth> checkHealth() async {
     return ControllerRuntimeHealth(
       level: ControllerRuntimeHealthLevel.healthy,
-      summary: 'Fake shell controller adapter is available for product-layer validation.',
+      summary:
+          'Fake shell controller adapter is available for product-layer validation.',
       updatedAt: DateTime.now(),
     );
   }

--- a/client/lib/features/controller/application/real_shell_controller_adapter.dart
+++ b/client/lib/features/controller/application/real_shell_controller_adapter.dart
@@ -1,7 +1,9 @@
+import 'dart:async';
 import 'dart:io';
 
 import '../domain/controller_command.dart';
 import '../domain/controller_command_result.dart';
+import '../domain/controller_launch_plan.dart';
 import '../domain/controller_runtime_config.dart';
 import '../domain/controller_runtime_health.dart';
 import '../domain/controller_runtime_session.dart';
@@ -17,6 +19,9 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
   RealShellControllerAdapter({
     this.binaryPathHint = 'UNCONFIGURED',
     this.transportEndpointHint = 'local-controller://pending',
+    this.runtimeMode = 'external-runtime-boundary',
+    this.backendKind = 'real-shell-controller-pending',
+    this.backendVersion = 'unvalidated',
     RealShellRuntimePlanner? runtimePlanner,
     RealShellConnectPlanner? connectPlanner,
     TrojanClientConfigRenderer? configRenderer,
@@ -34,6 +39,9 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
 
   final String binaryPathHint;
   final String transportEndpointHint;
+  final String runtimeMode;
+  final String backendKind;
+  final String backendVersion;
   final RealShellRuntimePlanner _runtimePlanner;
   final RealShellConnectPlanner _connectPlanner;
   final TrojanClientConfigRenderer _configRenderer;
@@ -42,8 +50,13 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
   Process? _runningProcess;
   String? _activeConfigPath;
   bool _disconnectRequested = false;
+  DateTime? _stopRequestedAt;
   int? _lastExitCode;
   String? _lastError;
+  ControllerLaunchPlan? _lastLaunchPlan;
+  String? _configProvenance;
+  int? _expectedLocalSocksPort;
+  ControllerRuntimePhase _runtimePhase = ControllerRuntimePhase.stopped;
   DateTime _sessionUpdatedAt = DateTime.now();
   final List<String> _stdoutTail = <String>[];
   final List<String> _stderrTail = <String>[];
@@ -52,8 +65,8 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
 
   @override
   ControllerTelemetrySnapshot get telemetry => ControllerTelemetrySnapshot(
-        backendKind: 'real-shell-controller-pending',
-        backendVersion: 'unvalidated',
+        backendKind: backendKind,
+        backendVersion: backendVersion,
         capabilities: const <String>[
           'connect',
           'disconnect',
@@ -65,7 +78,7 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
 
   @override
   ControllerRuntimeConfig get runtimeConfig => ControllerRuntimeConfig(
-        mode: 'external-runtime-boundary',
+        mode: runtimeMode,
         endpointHint: transportEndpointHint,
         enableVerboseTelemetry: true,
       );
@@ -74,8 +87,14 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
   ControllerRuntimeSession get session => ControllerRuntimeSession(
         isRunning: _runningProcess != null,
         updatedAt: _sessionUpdatedAt,
+        phase: _runtimePhase,
+        stopRequested: _disconnectRequested,
+        stopRequestedAt: _stopRequestedAt,
         pid: _runningProcess?.pid,
         activeConfigPath: _activeConfigPath,
+        configProvenance: _configProvenance,
+        expectedLocalSocksPort: _expectedLocalSocksPort,
+        launchPlan: _lastLaunchPlan,
         lastExitCode: _lastExitCode,
         lastError: _lastError,
         stdoutTail: List<String>.unmodifiable(_stdoutTail),
@@ -87,10 +106,12 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
     final now = DateTime.now();
     final runningProcess = _runningProcess;
     if (runningProcess != null) {
+      final summary = _runtimePhase == ControllerRuntimePhase.sessionReady
+          ? 'Trojan runtime is session-ready. pid=${runningProcess.pid} config=${_activeConfigPath ?? 'unknown'}'
+          : 'Trojan runtime process is alive. pid=${runningProcess.pid} config=${_activeConfigPath ?? 'unknown'}';
       return ControllerRuntimeHealth(
         level: ControllerRuntimeHealthLevel.healthy,
-        summary:
-            'Trojan client process is running. pid=${runningProcess.pid} config=${_activeConfigPath ?? 'unknown'}',
+        summary: summary,
         updatedAt: now,
       );
     }
@@ -170,6 +191,7 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
     final killed = process.kill();
     if (killed) {
       _disconnectRequested = true;
+      _stopRequestedAt = DateTime.now();
       _markSessionUpdated();
       return ControllerCommandResult(
         commandId: command.id,
@@ -227,6 +249,13 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
       profile: input.profile,
       configPath: input.configPath,
     );
+    _lastLaunchPlan = plan;
+    _activeConfigPath = input.configPath;
+    _configProvenance = 'managed-runtime://${input.profile.id}';
+    _expectedLocalSocksPort = input.profile.localSocksPort;
+    _runtimePhase = ControllerRuntimePhase.planned;
+    _markSessionUpdated();
+
     final configPreview = _configRenderer.render(
       profile: input.profile,
       password: input.password,
@@ -246,12 +275,18 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
         await Process.run('chmod', <String>['600', input.configPath]);
       }
 
+      _runtimePhase = ControllerRuntimePhase.launching;
+      _markSessionUpdated();
+
       final process = await Process.start(plan.binaryPath, plan.arguments);
       _runningProcess = process;
       _activeConfigPath = input.configPath;
       _lastError = null;
       _lastExitCode = null;
+      _runtimePhase = ControllerRuntimePhase.alive;
       _markSessionUpdated();
+
+      unawaited(_promoteSessionReadyWhenPortOpens(process));
 
       process.stdout
           .transform(const SystemEncoding().decoder)
@@ -267,12 +302,20 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
           // not as runtime failure noise.
           _lastError = null;
         }
+        if (disconnectRequested) {
+          _runtimePhase = ControllerRuntimePhase.stopped;
+        } else if (exitCode == 0) {
+          _runtimePhase = ControllerRuntimePhase.stopped;
+        } else {
+          _runtimePhase = ControllerRuntimePhase.failed;
+        }
         _markSessionUpdated();
         if (identical(_runningProcess, process)) {
           final configPath = _activeConfigPath;
           _runningProcess = null;
           _activeConfigPath = null;
           _disconnectRequested = false;
+          _stopRequestedAt = null;
           _markSessionUpdated();
           await _cleanupConfigFile(configPath);
           await _cleanupRuntimeDirectoryIfEmpty(configPath);
@@ -288,12 +331,16 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
         details: <String, Object?>{
           'pid': process.pid,
           'launchPlan': plan.toJson(),
+          'runtimePhase': _runtimePhase.name,
           'configPath': input.configPath,
+          'configProvenance': _configProvenance,
+          'expectedLocalSocksPort': _expectedLocalSocksPort,
           'configPreview': configPreviewRedacted,
         },
       );
     } catch (error) {
       _lastError = error.toString();
+      _runtimePhase = ControllerRuntimePhase.failed;
       _markSessionUpdated();
       await _cleanupConfigFile(input.configPath);
       await _cleanupRuntimeDirectoryIfEmpty(input.configPath);
@@ -305,7 +352,10 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
         error: error.toString(),
         details: <String, Object?>{
           'launchPlan': plan.toJson(),
+          'runtimePhase': _runtimePhase.name,
           'configPath': input.configPath,
+          'configProvenance': _configProvenance,
+          'expectedLocalSocksPort': _expectedLocalSocksPort,
           'configPreview': configPreviewRedacted,
         },
       );
@@ -314,8 +364,10 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
 
   void _prepareFreshSessionForConnect() {
     _disconnectRequested = false;
+    _stopRequestedAt = null;
     _lastError = null;
     _lastExitCode = null;
+    _runtimePhase = ControllerRuntimePhase.stopped;
     _stdoutTail.clear();
     _stderrTail.clear();
     _markSessionUpdated();
@@ -345,6 +397,40 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
       }
     } catch (_) {
       // keep best-effort cleanup non-blocking
+    }
+  }
+
+  Future<void> _promoteSessionReadyWhenPortOpens(Process process) async {
+    final expectedPort = _expectedLocalSocksPort;
+    if (expectedPort == null || expectedPort <= 0) return;
+
+    final deadline = DateTime.now().add(const Duration(seconds: 3));
+    while (DateTime.now().isBefore(deadline)) {
+      if (!identical(_runningProcess, process)) return;
+
+      final isOpen = await _isLocalPortOpen(expectedPort);
+      if (isOpen) {
+        _runtimePhase = ControllerRuntimePhase.sessionReady;
+        _markSessionUpdated();
+        return;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 120));
+    }
+  }
+
+  Future<bool> _isLocalPortOpen(int port) async {
+    Socket? socket;
+    try {
+      socket = await Socket.connect(
+        InternetAddress.loopbackIPv4,
+        port,
+        timeout: const Duration(milliseconds: 200),
+      );
+      return true;
+    } catch (_) {
+      return false;
+    } finally {
+      socket?.destroy();
     }
   }
 

--- a/client/lib/features/controller/application/shell_controller_adapter_selector.dart
+++ b/client/lib/features/controller/application/shell_controller_adapter_selector.dart
@@ -1,0 +1,192 @@
+import 'dart:io';
+
+import 'fake_shell_controller_adapter.dart';
+import 'real_shell_controller_adapter.dart';
+import 'shell_controller_adapter.dart';
+import 'trojan_binary_locator.dart';
+
+/// Shell adapter selection result used by bootstrap.
+class ShellControllerAdapterSelection {
+  const ShellControllerAdapterSelection({
+    required this.adapter,
+    required this.selectionReason,
+    required this.isRealRuntimePath,
+  });
+
+  final ShellControllerAdapter adapter;
+  final String selectionReason;
+  final bool isRealRuntimePath;
+}
+
+/// Defines how the app promotes runtime execution from stub to real adapter.
+///
+/// Promotion rule (Sprint 1 first cut):
+/// - supported desktop targets default to `auto`
+/// - `auto` prefers real adapter when a launchable trojan binary exists
+/// - explicit `real` still falls back to stub with a clear degraded identity
+/// - explicit `stub` stays stub
+/// - non-desktop targets stay stub
+class ShellControllerAdapterSelector {
+  ShellControllerAdapterSelector({
+    Map<String, String>? environment,
+    TrojanBinaryLocator? binaryLocator,
+    bool? isSupportedDesktop,
+  })  : _environment = environment ?? Platform.environment,
+        _binaryLocator = binaryLocator ?? const TrojanBinaryLocator(),
+        _isSupportedDesktop =
+            isSupportedDesktop ?? _detectSupportedDesktopPlatform();
+
+  final Map<String, String> _environment;
+  final TrojanBinaryLocator _binaryLocator;
+  final bool _isSupportedDesktop;
+
+  static bool _detectSupportedDesktopPlatform() {
+    return Platform.isLinux || Platform.isMacOS || Platform.isWindows;
+  }
+
+  ShellControllerAdapterSelection selectForCurrentPlatform() {
+    final mode = _backendMode();
+    final binaryOverride = _readTrimmed('TROJAN_CLIENT_BINARY');
+    final legacyEnableReal = _legacyEnableRealFlag();
+
+    if (!_isSupportedDesktop) {
+      return ShellControllerAdapterSelection(
+        adapter: FakeShellControllerAdapter(
+          backendKind: 'fake-shell-controller-non-desktop',
+          runtimeMode: 'stubbed-local-boundary-non-desktop',
+          endpointHint: 'in-process://fake-shell-controller/non-desktop',
+        ),
+        selectionReason:
+            'Current platform is not a supported desktop target; keeping stub adapter.',
+        isRealRuntimePath: false,
+      );
+    }
+
+    if (mode == _BackendMode.stub) {
+      return ShellControllerAdapterSelection(
+        adapter: FakeShellControllerAdapter(
+          backendKind: 'fake-shell-controller-explicit',
+          runtimeMode: 'stubbed-local-boundary-explicit',
+          endpointHint: 'in-process://fake-shell-controller/explicit',
+        ),
+        selectionReason:
+            'TROJAN_CLIENT_BACKEND_MODE=stub; keeping explicit stub adapter.',
+        isRealRuntimePath: false,
+      );
+    }
+
+    final wantsRealAdapter =
+        mode == _BackendMode.real || mode == _BackendMode.auto || legacyEnableReal;
+
+    if (wantsRealAdapter) {
+      final resolvedBinaryPath = _resolveLaunchableBinaryPath(
+        binaryOverride: binaryOverride,
+      );
+      if (resolvedBinaryPath != null) {
+        final reason = mode == _BackendMode.real || legacyEnableReal
+            ? 'Real adapter forced and binary resolved.'
+            : 'Desktop auto mode resolved trojan binary; promoting real adapter.';
+        return ShellControllerAdapterSelection(
+          adapter: RealShellControllerAdapter(
+            binaryPathHint: resolvedBinaryPath,
+            transportEndpointHint: 'process://$resolvedBinaryPath',
+            runtimeMode: 'real-runtime-boundary',
+            backendKind: 'real-shell-controller',
+            backendVersion: 'runtime-path-v1',
+          ),
+          selectionReason: reason,
+          isRealRuntimePath: true,
+        );
+      }
+
+      return ShellControllerAdapterSelection(
+        adapter: FakeShellControllerAdapter(
+          backendKind: 'fake-shell-controller-fallback',
+          runtimeMode: 'stubbed-local-boundary-fallback',
+          endpointHint: 'fallback://real-runtime-unavailable',
+        ),
+        selectionReason:
+            'Real adapter requested/intended but no launchable trojan binary was found; falling back to stub.',
+        isRealRuntimePath: false,
+      );
+    }
+
+    return ShellControllerAdapterSelection(
+      adapter: FakeShellControllerAdapter(),
+      selectionReason: 'Unknown backend mode; defaulting to stub adapter.',
+      isRealRuntimePath: false,
+    );
+  }
+
+  _BackendMode _backendMode() {
+    final raw = _readTrimmed('TROJAN_CLIENT_BACKEND_MODE').toLowerCase();
+    return switch (raw) {
+      'real' => _BackendMode.real,
+      'stub' => _BackendMode.stub,
+      _ => _BackendMode.auto,
+    };
+  }
+
+  bool _legacyEnableRealFlag() {
+    final raw = _readTrimmed('TROJAN_CLIENT_ENABLE_REAL_ADAPTER').toLowerCase();
+    return raw == '1' || raw == 'true';
+  }
+
+  String _readTrimmed(String key) => (_environment[key] ?? '').trim();
+
+  String? _resolveLaunchableBinaryPath({required String binaryOverride}) {
+    if (binaryOverride.isNotEmpty) {
+      return _resolveCandidate(binaryOverride);
+    }
+
+    final preferred = _binaryLocator.preferredBinaryPath();
+    return _resolveCandidate(preferred);
+  }
+
+  String? _resolveCandidate(String candidate) {
+    final trimmed = candidate.trim();
+    if (trimmed.isEmpty) return null;
+
+    if (_looksLikePath(trimmed)) {
+      return File(trimmed).existsSync() ? trimmed : null;
+    }
+
+    return _resolveCommandFromPath(trimmed);
+  }
+
+  bool _looksLikePath(String value) {
+    return value.contains('/') || value.contains('\\');
+  }
+
+  String? _resolveCommandFromPath(String command) {
+    final pathValue = _readTrimmed('PATH');
+    if (pathValue.isEmpty) return null;
+
+    final separator = Platform.isWindows ? ';' : ':';
+    final segments = pathValue.split(separator);
+
+    for (final segment in segments) {
+      final dir = segment.trim();
+      if (dir.isEmpty) continue;
+      final basePath = '$dir${Platform.pathSeparator}$command';
+      if (File(basePath).existsSync()) {
+        return basePath;
+      }
+      if (Platform.isWindows) {
+        for (final ext in const <String>['.exe', '.bat', '.cmd']) {
+          final withExt = '$basePath$ext';
+          if (File(withExt).existsSync()) {
+            return withExt;
+          }
+        }
+      }
+    }
+    return null;
+  }
+}
+
+enum _BackendMode {
+  auto,
+  real,
+  stub,
+}

--- a/client/lib/features/controller/domain/controller_runtime_session.dart
+++ b/client/lib/features/controller/domain/controller_runtime_session.dart
@@ -9,6 +9,26 @@ enum ControllerRuntimePhase {
   failed,
 }
 
+enum ControllerRuntimeSessionTruth {
+  stopped,
+  stopping,
+  live,
+  aging,
+  stale,
+  residual,
+}
+
+extension ControllerRuntimeSessionTruthLabel on ControllerRuntimeSessionTruth {
+  String get label => switch (this) {
+        ControllerRuntimeSessionTruth.stopped => 'Stopped',
+        ControllerRuntimeSessionTruth.stopping => 'Stopping',
+        ControllerRuntimeSessionTruth.live => 'Live',
+        ControllerRuntimeSessionTruth.aging => 'Aging',
+        ControllerRuntimeSessionTruth.stale => 'Stale',
+        ControllerRuntimeSessionTruth.residual => 'Residual snapshot',
+      };
+}
+
 class ControllerRuntimeSession {
   const ControllerRuntimeSession({
     required this.isRunning,
@@ -60,4 +80,59 @@ class ControllerRuntimeSession {
       'stderrTail': stderrTail,
     };
   }
+}
+
+extension ControllerRuntimeSessionStateX on ControllerRuntimeSession {
+  Duration get age {
+    final now = DateTime.now();
+    return now.isAfter(updatedAt) ? now.difference(updatedAt) : Duration.zero;
+  }
+
+  String get ageLabel {
+    final sessionAge = age;
+    if (sessionAge.inSeconds < 5) {
+      return 'just now';
+    }
+    if (sessionAge.inMinutes < 1) {
+      return '${sessionAge.inSeconds}s ago';
+    }
+    if (sessionAge.inHours < 1) {
+      return '${sessionAge.inMinutes}m ago';
+    }
+    return '${sessionAge.inHours}h ago';
+  }
+
+  ControllerRuntimeSessionTruth get truth {
+    if (stopRequested) {
+      return ControllerRuntimeSessionTruth.stopping;
+    }
+    if (!isRunning && phase == ControllerRuntimePhase.stopped) {
+      return ControllerRuntimeSessionTruth.stopped;
+    }
+    if (!isRunning) {
+      return ControllerRuntimeSessionTruth.residual;
+    }
+    if (age >= const Duration(minutes: 2)) {
+      return ControllerRuntimeSessionTruth.stale;
+    }
+    if (age >= const Duration(seconds: 30)) {
+      return ControllerRuntimeSessionTruth.aging;
+    }
+    return ControllerRuntimeSessionTruth.live;
+  }
+
+  String get truthNote => switch (truth) {
+        ControllerRuntimeSessionTruth.stopped =>
+          'No managed runtime session is active right now.',
+        ControllerRuntimeSessionTruth.stopping =>
+          'A stop request is in flight; wait for exit confirmation before trusting the session as closed.',
+        ControllerRuntimeSessionTruth.live =>
+          'The managed runtime session looks current and recently refreshed.',
+        ControllerRuntimeSessionTruth.aging =>
+          'The managed runtime session still looks alive, but its snapshot is getting older.',
+        ControllerRuntimeSessionTruth.stale =>
+          'The managed runtime session snapshot looks stale and should be revalidated before trusting it.',
+        ControllerRuntimeSessionTruth.residual =>
+          'The shell still has a non-stopped session record even though no runtime is marked as running. Treat this as residual state until recovery clears it.',
+      };
 }

--- a/client/lib/features/controller/domain/controller_runtime_session.dart
+++ b/client/lib/features/controller/domain/controller_runtime_session.dart
@@ -1,9 +1,26 @@
+import 'controller_launch_plan.dart';
+
+enum ControllerRuntimePhase {
+  stopped,
+  planned,
+  launching,
+  alive,
+  sessionReady,
+  failed,
+}
+
 class ControllerRuntimeSession {
   const ControllerRuntimeSession({
     required this.isRunning,
     required this.updatedAt,
+    this.phase = ControllerRuntimePhase.stopped,
+    this.stopRequested = false,
+    this.stopRequestedAt,
     this.pid,
     this.activeConfigPath,
+    this.configProvenance,
+    this.expectedLocalSocksPort,
+    this.launchPlan,
     this.lastExitCode,
     this.lastError,
     this.stdoutTail = const <String>[],
@@ -12,8 +29,14 @@ class ControllerRuntimeSession {
 
   final bool isRunning;
   final DateTime updatedAt;
+  final ControllerRuntimePhase phase;
+  final bool stopRequested;
+  final DateTime? stopRequestedAt;
   final int? pid;
   final String? activeConfigPath;
+  final String? configProvenance;
+  final int? expectedLocalSocksPort;
+  final ControllerLaunchPlan? launchPlan;
   final int? lastExitCode;
   final String? lastError;
   final List<String> stdoutTail;
@@ -23,8 +46,14 @@ class ControllerRuntimeSession {
     return <String, Object?>{
       'isRunning': isRunning,
       'updatedAt': updatedAt.toIso8601String(),
+      'phase': phase.name,
+      'stopRequested': stopRequested,
+      'stopRequestedAt': stopRequestedAt?.toIso8601String(),
       'pid': pid,
       'activeConfigPath': activeConfigPath,
+      'configProvenance': configProvenance,
+      'expectedLocalSocksPort': expectedLocalSocksPort,
+      'launchPlan': launchPlan?.toJson(),
       'lastExitCode': lastExitCode,
       'lastError': lastError,
       'stdoutTail': stdoutTail,

--- a/client/lib/features/controller/domain/controller_runtime_session.dart
+++ b/client/lib/features/controller/domain/controller_runtime_session.dart
@@ -121,6 +121,15 @@ extension ControllerRuntimeSessionStateX on ControllerRuntimeSession {
     return ControllerRuntimeSessionTruth.live;
   }
 
+  bool get needsAttention => switch (truth) {
+        ControllerRuntimeSessionTruth.live => false,
+        ControllerRuntimeSessionTruth.stopped => false,
+        ControllerRuntimeSessionTruth.stopping => true,
+        ControllerRuntimeSessionTruth.aging => true,
+        ControllerRuntimeSessionTruth.stale => true,
+        ControllerRuntimeSessionTruth.residual => true,
+      };
+
   String get truthNote => switch (truth) {
         ControllerRuntimeSessionTruth.stopped =>
           'No managed runtime session is active right now.',
@@ -134,5 +143,20 @@ extension ControllerRuntimeSessionStateX on ControllerRuntimeSession {
           'The managed runtime session snapshot looks stale and should be revalidated before trusting it.',
         ControllerRuntimeSessionTruth.residual =>
           'The shell still has a non-stopped session record even though no runtime is marked as running. Treat this as residual state until recovery clears it.',
+      };
+
+  String get recoveryGuidance => switch (truth) {
+        ControllerRuntimeSessionTruth.stopped =>
+          'No recovery action is needed until you start a new runtime session.',
+        ControllerRuntimeSessionTruth.stopping =>
+          'Wait for exit confirmation before reconnecting or assuming cleanup has finished.',
+        ControllerRuntimeSessionTruth.live =>
+          'No recovery action is needed while the runtime keeps refreshing normally.',
+        ControllerRuntimeSessionTruth.aging =>
+          'If this state keeps aging, open Troubleshooting and confirm the runtime is still refreshing before treating it as fully live.',
+        ControllerRuntimeSessionTruth.stale =>
+          'Open Troubleshooting to revalidate the runtime. If the snapshot stays stale, disconnect and reconnect so the next session starts from clean evidence.',
+        ControllerRuntimeSessionTruth.residual =>
+          'Treat this as leftover session state. Open Troubleshooting for recent evidence, then retry from Profiles so the next session starts cleanly.',
       };
 }

--- a/client/lib/features/controller/domain/runtime_action_feedback.dart
+++ b/client/lib/features/controller/domain/runtime_action_feedback.dart
@@ -1,0 +1,61 @@
+import 'client_connection_status.dart';
+import 'controller_command_result.dart';
+import 'controller_runtime_session.dart';
+import 'runtime_posture.dart';
+
+enum RuntimeActionKind {
+  connect,
+  retry,
+  disconnect,
+}
+
+String buildRuntimeActionFeedback({
+  required RuntimeActionKind action,
+  required ControllerCommandResult result,
+  required ClientConnectionStatus status,
+  required ControllerRuntimeSession session,
+  required RuntimePosture posture,
+}) {
+  if (!result.accepted) {
+    return result.summary;
+  }
+
+  switch (action) {
+    case RuntimeActionKind.connect:
+    case RuntimeActionKind.retry:
+      if (status.phase == ClientConnectionPhase.connected) {
+        if (posture.isStubOnly &&
+            !session.isRunning &&
+            session.truth == ControllerRuntimeSessionTruth.residual) {
+          return 'Connected on the current ${posture.postureLabel.toLowerCase()} path. Shell validation is ready.';
+        }
+        if (session.needsAttention) {
+          return 'Connection completed, but the runtime state still needs attention: ${session.recoveryGuidance}';
+        }
+        return posture.isRuntimeTrue
+            ? 'Connected on the runtime-true path. Runtime evidence looks current.'
+            : 'Connected on the current ${posture.postureLabel.toLowerCase()} path. Shell validation is ready.';
+      }
+
+      if (status.phase == ClientConnectionPhase.connecting) {
+        return '${result.summary} ${session.recoveryGuidance}';
+      }
+
+      return result.summary;
+
+    case RuntimeActionKind.disconnect:
+      if (status.phase == ClientConnectionPhase.disconnecting) {
+        return session.stopRequested
+            ? 'Disconnect requested. Wait for exit confirmation before trusting the session as closed.'
+            : 'Disconnect requested. The runtime is still winding down.';
+      }
+
+      if (status.phase == ClientConnectionPhase.disconnected) {
+        return session.truth == ControllerRuntimeSessionTruth.residual
+            ? 'Disconnected, but residual runtime state still needs cleanup in Troubleshooting.'
+            : 'Disconnected cleanly.';
+      }
+
+      return result.summary;
+  }
+}

--- a/client/lib/features/controller/domain/runtime_action_matrix.dart
+++ b/client/lib/features/controller/domain/runtime_action_matrix.dart
@@ -1,0 +1,147 @@
+import 'client_connection_status.dart';
+import 'controller_runtime_session.dart';
+import 'runtime_action_safety.dart';
+import 'runtime_operator_advice.dart';
+import 'runtime_posture.dart';
+
+enum RuntimePrimaryActionContract {
+  keepCurrentPrimary,
+  preferTroubleshooting,
+}
+
+enum RuntimeSecondaryStateChangeContract {
+  allowFallback,
+  withholdFallback,
+}
+
+enum RuntimeEvidenceCaptureContract {
+  optional,
+  preferBeforeMutation,
+}
+
+enum RuntimeRetryContract {
+  allowShortcut,
+  blockShortcut,
+}
+
+enum RuntimeNextStepContract {
+  none,
+  openTroubleshooting,
+  captureSupportEvidence,
+}
+
+enum RuntimePreferredOperatorAction {
+  none,
+  openTroubleshooting,
+}
+
+enum RuntimePreferredEvidenceAction {
+  none,
+  generateSupportPreview,
+  exportSupportBundle,
+}
+
+class RuntimeActionMatrix {
+  const RuntimeActionMatrix({
+    required this.actionSafety,
+    required this.operatorAdvice,
+    required this.primaryActionContract,
+    required this.secondaryStateChangeContract,
+    required this.evidenceCaptureContract,
+    required this.retryContract,
+    required this.nextStepContract,
+    required this.preferredOperatorAction,
+    required this.preferredEvidenceAction,
+  });
+
+  final RuntimeActionSafety actionSafety;
+  final RuntimeOperatorAdvice operatorAdvice;
+  final RuntimePrimaryActionContract primaryActionContract;
+  final RuntimeSecondaryStateChangeContract secondaryStateChangeContract;
+  final RuntimeEvidenceCaptureContract evidenceCaptureContract;
+  final RuntimeRetryContract retryContract;
+  final RuntimeNextStepContract nextStepContract;
+  final RuntimePreferredOperatorAction preferredOperatorAction;
+  final RuntimePreferredEvidenceAction preferredEvidenceAction;
+
+  bool get preferTroubleshootingPrimary =>
+      primaryActionContract == RuntimePrimaryActionContract.preferTroubleshooting;
+
+  bool get withholdSecondaryStateChangingActions =>
+      secondaryStateChangeContract ==
+      RuntimeSecondaryStateChangeContract.withholdFallback;
+
+  bool get preferSnapshotFirst =>
+      evidenceCaptureContract ==
+      RuntimeEvidenceCaptureContract.preferBeforeMutation;
+
+  bool get blockRetryShortcut =>
+      retryContract == RuntimeRetryContract.blockShortcut;
+
+  bool get showExitConfirmationWarning =>
+      actionSafety.state == RuntimeActionSafetyState.waitForExitConfirmation;
+
+  static RuntimeActionMatrix resolve({
+    required ClientConnectionStatus status,
+    required ControllerRuntimeSession session,
+    required RuntimePosture posture,
+    required bool troubleshootingAvailable,
+  }) {
+    final actionSafety = RuntimeActionSafety.resolve(
+      status: status,
+      session: session,
+      posture: posture,
+    );
+    final operatorAdvice = RuntimeOperatorAdvice.resolve(
+      status: status,
+      session: session,
+      posture: posture,
+      troubleshootingAvailable: troubleshootingAvailable,
+    );
+
+    return RuntimeActionMatrix.fromResolved(
+      actionSafety: actionSafety,
+      operatorAdvice: operatorAdvice,
+    );
+  }
+
+  factory RuntimeActionMatrix.fromResolved({
+    required RuntimeActionSafety actionSafety,
+    required RuntimeOperatorAdvice operatorAdvice,
+  }) {
+    return RuntimeActionMatrix(
+      actionSafety: actionSafety,
+      operatorAdvice: operatorAdvice,
+      primaryActionContract:
+          operatorAdvice.actionableSessionTruth && operatorAdvice.primaryEnabled
+              ? RuntimePrimaryActionContract.preferTroubleshooting
+              : RuntimePrimaryActionContract.keepCurrentPrimary,
+      secondaryStateChangeContract:
+          actionSafety.state == RuntimeActionSafetyState.waitForExitConfirmation
+              ? RuntimeSecondaryStateChangeContract.withholdFallback
+              : RuntimeSecondaryStateChangeContract.allowFallback,
+      evidenceCaptureContract: actionSafety.recommendsSnapshotFirst
+          ? RuntimeEvidenceCaptureContract.preferBeforeMutation
+          : RuntimeEvidenceCaptureContract.optional,
+      retryContract: actionSafety.blocksRetry
+          ? RuntimeRetryContract.blockShortcut
+          : RuntimeRetryContract.allowShortcut,
+      nextStepContract:
+          actionSafety.state == RuntimeActionSafetyState.waitForExitConfirmation
+              ? RuntimeNextStepContract.captureSupportEvidence
+              : operatorAdvice.actionableSessionTruth
+                  ? RuntimeNextStepContract.openTroubleshooting
+                  : RuntimeNextStepContract.none,
+      preferredOperatorAction:
+          operatorAdvice.actionableSessionTruth && operatorAdvice.primaryEnabled
+              ? RuntimePreferredOperatorAction.openTroubleshooting
+              : RuntimePreferredOperatorAction.none,
+      preferredEvidenceAction:
+          actionSafety.state == RuntimeActionSafetyState.waitForExitConfirmation ||
+                  actionSafety.state ==
+                      RuntimeActionSafetyState.captureSnapshotFirst
+              ? RuntimePreferredEvidenceAction.generateSupportPreview
+              : RuntimePreferredEvidenceAction.none,
+    );
+  }
+}

--- a/client/lib/features/controller/domain/runtime_action_safety.dart
+++ b/client/lib/features/controller/domain/runtime_action_safety.dart
@@ -1,0 +1,88 @@
+import 'client_connection_status.dart';
+import 'controller_runtime_session.dart';
+import 'runtime_posture.dart';
+
+enum RuntimeActionSafetyState {
+  safeToProceed,
+  revalidateFirst,
+  captureSnapshotFirst,
+  waitForExitConfirmation,
+}
+
+class RuntimeActionSafety {
+  const RuntimeActionSafety({
+    required this.state,
+    required this.label,
+    required this.detail,
+  });
+
+  final RuntimeActionSafetyState state;
+  final String label;
+  final String detail;
+
+  bool get blocksRetry => switch (state) {
+        RuntimeActionSafetyState.safeToProceed => false,
+        RuntimeActionSafetyState.revalidateFirst => true,
+        RuntimeActionSafetyState.captureSnapshotFirst => true,
+        RuntimeActionSafetyState.waitForExitConfirmation => true,
+      };
+
+  bool get recommendsSnapshotFirst => switch (state) {
+        RuntimeActionSafetyState.captureSnapshotFirst => true,
+        RuntimeActionSafetyState.waitForExitConfirmation => true,
+        RuntimeActionSafetyState.safeToProceed => false,
+        RuntimeActionSafetyState.revalidateFirst => false,
+      };
+
+  static RuntimeActionSafety resolve({
+    required ClientConnectionStatus status,
+    required ControllerRuntimeSession session,
+    required RuntimePosture posture,
+  }) {
+    final actionableSessionTruth = session.needsAttention &&
+        (!posture.isStubOnly || session.isRunning || session.stopRequested);
+
+    if (!actionableSessionTruth) {
+      return const RuntimeActionSafety(
+        state: RuntimeActionSafetyState.safeToProceed,
+        label: 'Safe to proceed',
+        detail: 'No extra action-safety guardrail is required right now.',
+      );
+    }
+
+    if (status.phase == ClientConnectionPhase.disconnecting ||
+        session.truth == ControllerRuntimeSessionTruth.stopping) {
+      return const RuntimeActionSafety(
+        state: RuntimeActionSafetyState.waitForExitConfirmation,
+        label: 'Wait for exit confirmation',
+        detail:
+            'Do not retry or assume the runtime is closed yet. Capture support evidence first, then wait for exit confirmation.',
+      );
+    }
+
+    if (status.phase == ClientConnectionPhase.connected) {
+      return const RuntimeActionSafety(
+        state: RuntimeActionSafetyState.revalidateFirst,
+        label: 'Revalidate before changing state',
+        detail:
+            'Open Troubleshooting first and confirm the runtime is still trustworthy before disconnecting or reconnecting.',
+      );
+    }
+
+    if (status.phase == ClientConnectionPhase.connecting ||
+        status.phase == ClientConnectionPhase.error) {
+      return const RuntimeActionSafety(
+        state: RuntimeActionSafetyState.captureSnapshotFirst,
+        label: 'Capture snapshot before retry',
+        detail:
+            'Preserve the current runtime evidence before you retry, otherwise you may lose the signal that explains the failure.',
+      );
+    }
+
+    return const RuntimeActionSafety(
+      state: RuntimeActionSafetyState.safeToProceed,
+      label: 'Safe to proceed',
+      detail: 'No extra action-safety guardrail is required right now.',
+    );
+  }
+}

--- a/client/lib/features/controller/domain/runtime_operator_advice.dart
+++ b/client/lib/features/controller/domain/runtime_operator_advice.dart
@@ -1,0 +1,88 @@
+import 'client_connection_status.dart';
+import 'controller_runtime_session.dart';
+import 'runtime_posture.dart';
+
+enum RuntimeOperatorAdviceKind {
+  none,
+  revalidateInTroubleshooting,
+  waitForExitConfirmation,
+}
+
+class RuntimeOperatorAdvice {
+  const RuntimeOperatorAdvice({
+    required this.kind,
+    required this.actionableSessionTruth,
+    required this.headline,
+    required this.message,
+    required this.primaryLabel,
+    required this.primaryEnabled,
+  });
+
+  final RuntimeOperatorAdviceKind kind;
+  final bool actionableSessionTruth;
+  final String? headline;
+  final String? message;
+  final String? primaryLabel;
+  final bool primaryEnabled;
+
+  static const RuntimeOperatorAdvice none = RuntimeOperatorAdvice(
+    kind: RuntimeOperatorAdviceKind.none,
+    actionableSessionTruth: false,
+    headline: null,
+    message: null,
+    primaryLabel: null,
+    primaryEnabled: false,
+  );
+
+  static RuntimeOperatorAdvice resolve({
+    required ClientConnectionStatus status,
+    required ControllerRuntimeSession session,
+    required RuntimePosture posture,
+    required bool troubleshootingAvailable,
+  }) {
+    final actionableSessionTruth = session.needsAttention &&
+        (!posture.isStubOnly || session.isRunning || session.stopRequested);
+
+    if (!actionableSessionTruth) {
+      return none;
+    }
+
+    if (status.phase == ClientConnectionPhase.connected) {
+      return RuntimeOperatorAdvice(
+        kind: RuntimeOperatorAdviceKind.revalidateInTroubleshooting,
+        actionableSessionTruth: true,
+        headline: 'Connection state needs revalidation',
+        message: '${session.truthNote} ${session.recoveryGuidance}',
+        primaryLabel: 'Open Troubleshooting',
+        primaryEnabled: troubleshootingAvailable,
+      );
+    }
+
+    if (status.phase == ClientConnectionPhase.disconnecting ||
+        session.truth == ControllerRuntimeSessionTruth.stopping) {
+      return RuntimeOperatorAdvice(
+        kind: RuntimeOperatorAdviceKind.waitForExitConfirmation,
+        actionableSessionTruth: true,
+        headline: 'Exit confirmation pending',
+        message:
+            'Do not treat this runtime as fully closed yet. ${session.recoveryGuidance}',
+        primaryLabel: 'Open Troubleshooting',
+        primaryEnabled: troubleshootingAvailable,
+      );
+    }
+
+    if (status.phase == ClientConnectionPhase.connecting ||
+        status.phase == ClientConnectionPhase.error) {
+      return RuntimeOperatorAdvice(
+        kind: RuntimeOperatorAdviceKind.revalidateInTroubleshooting,
+        actionableSessionTruth: true,
+        headline: null,
+        message: session.recoveryGuidance,
+        primaryLabel: 'Open Troubleshooting',
+        primaryEnabled: troubleshootingAvailable,
+      );
+    }
+
+    return none;
+  }
+}

--- a/client/lib/features/controller/domain/runtime_posture.dart
+++ b/client/lib/features/controller/domain/runtime_posture.dart
@@ -1,0 +1,104 @@
+enum RuntimePostureKind {
+  runtimeTrue,
+  stubFallback,
+  stubExplicit,
+  stubNonDesktop,
+  stubSimulated,
+  unknown,
+}
+
+class RuntimePosture {
+  const RuntimePosture({
+    required this.kind,
+    required this.runtimeMode,
+    this.backendKind,
+  });
+
+  final RuntimePostureKind kind;
+  final String runtimeMode;
+  final String? backendKind;
+
+  bool get isRuntimeTrue => kind == RuntimePostureKind.runtimeTrue;
+
+  bool get isStubOnly => !isRuntimeTrue;
+
+  String get executionPathLabel => switch (kind) {
+        RuntimePostureKind.runtimeTrue => 'Real runtime path',
+        RuntimePostureKind.stubFallback =>
+          'Fallback stub (real runtime unavailable)',
+        RuntimePostureKind.stubExplicit => 'Explicit stub mode',
+        RuntimePostureKind.stubNonDesktop => 'Stub mode (non-desktop target)',
+        RuntimePostureKind.stubSimulated => 'Simulated runtime path',
+        RuntimePostureKind.unknown => 'Unknown runtime path',
+      };
+
+  String get postureLabel => switch (kind) {
+        RuntimePostureKind.runtimeTrue => 'Runtime-true',
+        RuntimePostureKind.stubFallback => 'Stub-only (fallback)',
+        RuntimePostureKind.stubExplicit => 'Stub-only (explicit)',
+        RuntimePostureKind.stubNonDesktop => 'Stub-only (non-desktop)',
+        RuntimePostureKind.stubSimulated => 'Stub-only',
+        RuntimePostureKind.unknown => 'Unknown posture',
+      };
+
+  String get truthNote => switch (kind) {
+        RuntimePostureKind.runtimeTrue =>
+          'This path counts as real runtime execution evidence on this device.',
+        RuntimePostureKind.stubFallback =>
+          'The shell fell back to a stub boundary because the real runtime path is unavailable.',
+        RuntimePostureKind.stubExplicit =>
+          'Stub mode was selected intentionally for shell/product testing and is not runtime-true evidence.',
+        RuntimePostureKind.stubNonDesktop =>
+          'This target is staying on a non-desktop stub path and should not be treated as runtime-true execution.',
+        RuntimePostureKind.stubSimulated =>
+          'This path is simulated and is useful for shell validation, not real runtime proof.',
+        RuntimePostureKind.unknown =>
+          'The current runtime mode is not recognized by this shell yet.',
+      };
+}
+
+RuntimePosture describeRuntimePosture({
+  required String runtimeMode,
+  String? backendKind,
+}) {
+  if (runtimeMode.contains('real-runtime-boundary')) {
+    return RuntimePosture(
+      kind: RuntimePostureKind.runtimeTrue,
+      runtimeMode: runtimeMode,
+      backendKind: backendKind,
+    );
+  }
+  if (runtimeMode.contains('stubbed-local-boundary-fallback')) {
+    return RuntimePosture(
+      kind: RuntimePostureKind.stubFallback,
+      runtimeMode: runtimeMode,
+      backendKind: backendKind,
+    );
+  }
+  if (runtimeMode.contains('stubbed-local-boundary-explicit')) {
+    return RuntimePosture(
+      kind: RuntimePostureKind.stubExplicit,
+      runtimeMode: runtimeMode,
+      backendKind: backendKind,
+    );
+  }
+  if (runtimeMode.contains('stubbed-local-boundary-non-desktop')) {
+    return RuntimePosture(
+      kind: RuntimePostureKind.stubNonDesktop,
+      runtimeMode: runtimeMode,
+      backendKind: backendKind,
+    );
+  }
+  if (runtimeMode.contains('stubbed-local-boundary')) {
+    return RuntimePosture(
+      kind: RuntimePostureKind.stubSimulated,
+      runtimeMode: runtimeMode,
+      backendKind: backendKind,
+    );
+  }
+  return RuntimePosture(
+    kind: RuntimePostureKind.unknown,
+    runtimeMode: runtimeMode,
+    backendKind: backendKind,
+  );
+}

--- a/client/lib/features/controller/domain/runtime_posture.dart
+++ b/client/lib/features/controller/domain/runtime_posture.dart
@@ -55,6 +55,20 @@ class RuntimePosture {
         RuntimePostureKind.unknown =>
           'The current runtime mode is not recognized by this shell yet.',
       };
+
+  String get actionQualifier => switch (kind) {
+        RuntimePostureKind.runtimeTrue => '',
+        RuntimePostureKind.stubFallback => ' (fallback stub)',
+        RuntimePostureKind.stubExplicit => ' (stub path)',
+        RuntimePostureKind.stubNonDesktop => ' (non-desktop stub)',
+        RuntimePostureKind.stubSimulated => ' (stub path)',
+        RuntimePostureKind.unknown => ' (unknown path)',
+      };
+
+  String qualifyAction(String baseLabel) {
+    final qualifier = actionQualifier;
+    return qualifier.isEmpty ? baseLabel : '$baseLabel$qualifier';
+  }
 }
 
 RuntimePosture describeRuntimePosture({

--- a/client/lib/features/controller/domain/runtime_posture.dart
+++ b/client/lib/features/controller/domain/runtime_posture.dart
@@ -77,6 +77,17 @@ class RuntimePosture {
           'Artifacts from this path are useful for shell/support debugging, but they do not prove real runtime execution.',
       };
 
+  bool get canProduceRuntimeProofArtifact =>
+      evidenceGrade == EvidenceGrade.evidenceGrade;
+
+  String get artifactCapabilityLabel => canProduceRuntimeProofArtifact
+      ? 'Runtime-proof artifact available'
+      : 'Runtime-proof artifact unavailable on current posture';
+
+  String get artifactCapabilityNote => canProduceRuntimeProofArtifact
+      ? 'Problem Report exports from this posture can be treated as runtime-proof artifacts on this device.'
+      : 'Problem Report exports from this posture should be treated as support bundles only.';
+
   String get actionQualifier => switch (kind) {
         RuntimePostureKind.runtimeTrue => '',
         RuntimePostureKind.stubFallback => ' (fallback stub)',

--- a/client/lib/features/controller/domain/runtime_posture.dart
+++ b/client/lib/features/controller/domain/runtime_posture.dart
@@ -7,6 +7,11 @@ enum RuntimePostureKind {
   unknown,
 }
 
+enum EvidenceGrade {
+  evidenceGrade,
+  shellGradeOnly,
+}
+
 class RuntimePosture {
   const RuntimePosture({
     required this.kind,
@@ -54,6 +59,22 @@ class RuntimePosture {
           'This path is simulated and is useful for shell validation, not real runtime proof.',
         RuntimePostureKind.unknown =>
           'The current runtime mode is not recognized by this shell yet.',
+      };
+
+  EvidenceGrade get evidenceGrade => isRuntimeTrue
+      ? EvidenceGrade.evidenceGrade
+      : EvidenceGrade.shellGradeOnly;
+
+  String get evidenceGradeLabel => switch (evidenceGrade) {
+        EvidenceGrade.evidenceGrade => 'Evidence-grade',
+        EvidenceGrade.shellGradeOnly => 'Shell-grade only',
+      };
+
+  String get evidenceGradeNote => switch (evidenceGrade) {
+        EvidenceGrade.evidenceGrade =>
+          'Artifacts from this path can be treated as runtime-true execution evidence on this device.',
+        EvidenceGrade.shellGradeOnly =>
+          'Artifacts from this path are useful for shell/support debugging, but they do not prove real runtime execution.',
       };
 
   String get actionQualifier => switch (kind) {

--- a/client/lib/features/controller/domain/runtime_posture.dart
+++ b/client/lib/features/controller/domain/runtime_posture.dart
@@ -88,6 +88,22 @@ class RuntimePosture {
       ? 'Problem Report exports from this posture can be treated as runtime-proof artifacts on this device.'
       : 'Problem Report exports from this posture should be treated as support bundles only.';
 
+  String get operatorGuidanceHeading => canProduceRuntimeProofArtifact
+      ? 'How to use runtime-proof artifacts'
+      : 'How to use support bundles on this posture';
+
+  List<String> get operatorChecklist => canProduceRuntimeProofArtifact
+      ? const <String>[
+          'Verify the posture stays Runtime-true / Evidence-grade before sharing the artifact.',
+          'Use the runtime-proof artifact when you need to justify real runtime execution on this device.',
+          'Attach the support bundle as extra context, not as a replacement for the proof artifact.',
+        ]
+      : const <String>[
+          'Use this export as a support/debug snapshot only.',
+          'Do not cite this posture as runtime-proof execution evidence.',
+          'Promote the runtime posture to Evidence-grade before generating proof-oriented artifacts.',
+        ];
+
   String get actionQualifier => switch (kind) {
         RuntimePostureKind.runtimeTrue => '',
         RuntimePostureKind.stubFallback => ' (fallback stub)',

--- a/client/lib/features/dashboard/presentation/dashboard_guide_policy.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_guide_policy.dart
@@ -1,0 +1,249 @@
+import '../../controller/domain/client_connection_status.dart';
+import '../../controller/domain/controller_runtime_session.dart';
+import '../../controller/domain/runtime_action_matrix.dart';
+import '../../controller/domain/runtime_action_safety.dart';
+import '../../controller/domain/runtime_operator_advice.dart';
+import '../../controller/domain/runtime_posture.dart';
+import '../../profiles/domain/client_profile.dart';
+import '../../readiness/domain/readiness_report.dart';
+import '../application/connection_lifecycle_view_model.dart';
+
+enum DashboardGuideAction {
+  openProfiles,
+  openAdvanced,
+  openSettings,
+  connectNow,
+  retryNow,
+  disconnectNow,
+}
+
+class DashboardGuidePolicy {
+  const DashboardGuidePolicy({
+    required this.title,
+    required this.body,
+    required this.primaryLabel,
+    required this.primaryAction,
+    required this.actionSafety,
+    this.secondaryLabel,
+    this.secondaryAction,
+    this.operatorTitle,
+    this.operatorBody,
+  });
+
+  final String title;
+  final String body;
+  final String primaryLabel;
+  final DashboardGuideAction primaryAction;
+  final RuntimeActionSafety actionSafety;
+  final String? secondaryLabel;
+  final DashboardGuideAction? secondaryAction;
+  final String? operatorTitle;
+  final String? operatorBody;
+
+  static DashboardGuidePolicy resolve({
+    required ConnectionLifecycleViewModel lifecycle,
+    required ClientProfile? selectedProfile,
+    required ClientProfile? activeProfile,
+    required ClientConnectionStatus status,
+    required RuntimePosture posture,
+    required ControllerRuntimeSession runtimeSession,
+    required RuntimeOperatorAdvice operatorAdvice,
+    required ReadinessReport? readiness,
+  }) {
+    final actionSafety = RuntimeActionSafety.resolve(
+      status: status,
+      session: runtimeSession,
+      posture: posture,
+    );
+    final actionMatrix = RuntimeActionMatrix.fromResolved(
+      actionSafety: actionSafety,
+      operatorAdvice: operatorAdvice,
+    );
+
+    if (selectedProfile == null && activeProfile == null) {
+      return DashboardGuidePolicy(
+        title: 'Start by adding one profile',
+        body:
+            'Create or import a profile first. Once that exists, the rest of the flow becomes much simpler.',
+        primaryLabel: 'Open Profiles',
+        primaryAction: DashboardGuideAction.openProfiles,
+        actionSafety: actionSafety,
+      );
+    }
+
+    if (activeProfile == null &&
+        selectedProfile != null &&
+        !selectedProfile.hasStoredPassword) {
+      return DashboardGuidePolicy(
+        title: 'Save the password before testing',
+        body:
+            'The selected profile still needs its Trojan password. Save it first, then try one connection attempt.',
+        primaryLabel: 'Open Profiles',
+        primaryAction: DashboardGuideAction.openProfiles,
+        actionSafety: actionSafety,
+      );
+    }
+
+    if (readiness != null &&
+        readiness.overallLevel == ReadinessLevel.blocked &&
+        status.phase != ClientConnectionPhase.error &&
+        status.phase != ClientConnectionPhase.connected &&
+        status.phase != ClientConnectionPhase.connecting &&
+        status.phase != ClientConnectionPhase.disconnecting) {
+      final recommendation = readiness.recommendation;
+      return DashboardGuidePolicy(
+        title: readiness.headline,
+        body: readiness.summary,
+        primaryLabel: recommendation?.label ?? 'Open Troubleshooting',
+        primaryAction: recommendation == null
+            ? DashboardGuideAction.openAdvanced
+            : _guideActionFor(recommendation.action),
+        actionSafety: actionSafety,
+        secondaryLabel: 'Open Profiles',
+        secondaryAction: DashboardGuideAction.openProfiles,
+      );
+    }
+
+    if (status.phase == ClientConnectionPhase.error) {
+      final errorBody = operatorAdvice.actionableSessionTruth
+          ? operatorAdvice.message ??
+              '${lifecycle.detail} ${runtimeSession.recoveryGuidance}'
+          : lifecycle.detail;
+      final evidenceFirst = actionMatrix.preferredEvidenceAction ==
+          RuntimePreferredEvidenceAction.generateSupportPreview;
+      return DashboardGuidePolicy(
+        title: lifecycle.headline,
+        body: errorBody,
+        primaryLabel: evidenceFirst
+            ? (operatorAdvice.primaryLabel ?? 'Open Troubleshooting')
+            : lifecycle.showRetry
+                ? posture.qualifyAction('Retry now')
+                : 'Open Profiles',
+        primaryAction: evidenceFirst
+            ? (actionMatrix.preferredOperatorAction ==
+                    RuntimePreferredOperatorAction.openTroubleshooting
+                ? DashboardGuideAction.openAdvanced
+                : DashboardGuideAction.openProfiles)
+            : lifecycle.showRetry
+                ? DashboardGuideAction.retryNow
+                : DashboardGuideAction.openProfiles,
+        actionSafety: actionSafety,
+        secondaryLabel: evidenceFirst
+            ? null
+            : lifecycle.showOpenTroubleshooting
+                ? 'Open Troubleshooting'
+                : null,
+        secondaryAction: evidenceFirst
+            ? null
+            : lifecycle.showOpenTroubleshooting
+                ? DashboardGuideAction.openAdvanced
+                : null,
+        operatorTitle: evidenceFirst
+            ? 'Recommended right now: capture a support snapshot first'
+            : null,
+        operatorBody: evidenceFirst
+            ? 'Open Troubleshooting and preserve the current runtime evidence before retrying. A fast retry now may erase the signal that explains this failure.'
+            : null,
+      );
+    }
+
+    if (status.phase == ClientConnectionPhase.connected) {
+      if (operatorAdvice.actionableSessionTruth) {
+        return DashboardGuidePolicy(
+          title: operatorAdvice.headline ?? 'Connection state needs revalidation',
+          body: operatorAdvice.message ??
+              '${runtimeSession.truthNote} ${runtimeSession.recoveryGuidance}',
+          primaryLabel: operatorAdvice.primaryLabel ?? 'Open Troubleshooting',
+          primaryAction: actionMatrix.preferredOperatorAction ==
+                  RuntimePreferredOperatorAction.openTroubleshooting
+              ? DashboardGuideAction.openAdvanced
+              : DashboardGuideAction.openProfiles,
+          actionSafety: actionSafety,
+          secondaryLabel: actionMatrix.secondaryStateChangeContract ==
+                  RuntimeSecondaryStateChangeContract.withholdFallback
+              ? null
+              : 'Disconnect now',
+          secondaryAction: actionMatrix.secondaryStateChangeContract ==
+                  RuntimeSecondaryStateChangeContract.withholdFallback
+              ? null
+              : DashboardGuideAction.disconnectNow,
+          operatorTitle: 'Recommended right now',
+          operatorBody: actionMatrix.nextStepContract ==
+                  RuntimeNextStepContract.openTroubleshooting
+              ? 'Open Troubleshooting first, confirm whether the session is still trustworthy, and only then decide whether to disconnect or reconnect.'
+              : 'Review the current runtime state before making another state-changing move.',
+        );
+      }
+      return DashboardGuidePolicy(
+        title: 'Connection is active',
+        body:
+            'You are already connected. Disconnect here if you want to end the current session, or open Profiles to switch context.',
+        primaryLabel: 'Disconnect now',
+        primaryAction: DashboardGuideAction.disconnectNow,
+        actionSafety: actionSafety,
+        secondaryLabel: 'Open Profiles',
+        secondaryAction: DashboardGuideAction.openProfiles,
+      );
+    }
+
+    if (status.phase == ClientConnectionPhase.disconnecting) {
+      return DashboardGuidePolicy(
+        title: operatorAdvice.headline ?? lifecycle.headline,
+        body: operatorAdvice.message ?? lifecycle.detail,
+        primaryLabel: operatorAdvice.primaryLabel ?? 'Open Troubleshooting',
+        primaryAction: actionMatrix.preferredOperatorAction ==
+                RuntimePreferredOperatorAction.openTroubleshooting
+            ? DashboardGuideAction.openAdvanced
+            : DashboardGuideAction.openProfiles,
+        actionSafety: actionSafety,
+        secondaryLabel: 'Open Profiles',
+        secondaryAction: DashboardGuideAction.openProfiles,
+        operatorTitle: actionMatrix.evidenceCaptureContract ==
+                RuntimeEvidenceCaptureContract.preferBeforeMutation
+            ? 'Recommended right now: capture a support snapshot first'
+            : 'Recommended right now',
+        operatorBody: actionMatrix.nextStepContract ==
+                RuntimeNextStepContract.captureSupportEvidence
+            ? 'Open Troubleshooting and capture the current support evidence before you retry or assume shutdown has finished. This keeps the stop-pending state visible while it is still fresh.'
+            : 'Open Troubleshooting before making another change.',
+      );
+    }
+
+    if (status.phase == ClientConnectionPhase.connecting) {
+      return DashboardGuidePolicy(
+        title: lifecycle.headline,
+        body: operatorAdvice.message ?? lifecycle.detail,
+        primaryLabel: operatorAdvice.primaryLabel ?? 'Open Troubleshooting',
+        primaryAction: actionMatrix.preferredOperatorAction ==
+                RuntimePreferredOperatorAction.openTroubleshooting
+            ? DashboardGuideAction.openAdvanced
+            : DashboardGuideAction.openProfiles,
+        actionSafety: actionSafety,
+        secondaryLabel: 'Open Profiles',
+        secondaryAction: DashboardGuideAction.openProfiles,
+        operatorTitle: 'Recommended right now',
+        operatorBody:
+            'Let the current connection attempt settle first. If the runtime keeps looking suspicious, open Troubleshooting before retrying again.',
+      );
+    }
+
+    return DashboardGuidePolicy(
+      title: 'You are ready for a quick test',
+      body:
+          'Use one clear Connect action here, or open Profiles if you want to review the selected profile first.',
+      primaryLabel: posture.qualifyAction('Connect now'),
+      primaryAction: DashboardGuideAction.connectNow,
+      actionSafety: actionSafety,
+      secondaryLabel: 'Open Profiles',
+      secondaryAction: DashboardGuideAction.openProfiles,
+    );
+  }
+
+  static DashboardGuideAction _guideActionFor(ReadinessAction action) {
+    return switch (action) {
+      ReadinessAction.openProfiles => DashboardGuideAction.openProfiles,
+      ReadinessAction.openTroubleshooting => DashboardGuideAction.openAdvanced,
+      ReadinessAction.openSettings => DashboardGuideAction.openSettings,
+    };
+  }
+}

--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -577,6 +577,11 @@ class _NextStepGuide extends StatelessWidget {
   }
 
   _GuideModel _model() {
+    final posture = describeRuntimePosture(
+      runtimeMode: services.controller.runtimeConfig.mode,
+      backendKind: services.controller.telemetry.backendKind,
+    );
+
     if (selectedProfile == null && activeProfile == null) {
       return const _GuideModel(
         title: 'Start by adding one profile',
@@ -619,7 +624,9 @@ class _NextStepGuide extends StatelessWidget {
       return _GuideModel(
         title: lifecycle.headline,
         body: lifecycle.detail,
-        primaryLabel: lifecycle.showRetry ? 'Retry now' : 'Open Profiles',
+        primaryLabel: lifecycle.showRetry
+            ? posture.qualifyAction('Retry now')
+            : 'Open Profiles',
         primaryAction: lifecycle.showRetry
             ? _GuideAction.retryNow
             : _GuideAction.openProfiles,
@@ -661,11 +668,11 @@ class _NextStepGuide extends StatelessWidget {
         secondaryAction: _GuideAction.openProfiles,
       );
     }
-    return const _GuideModel(
+    return _GuideModel(
       title: 'You are ready for a quick test',
       body:
           'Use one clear Connect action here, or open Profiles if you want to review the selected profile first.',
-      primaryLabel: 'Connect now',
+      primaryLabel: posture.qualifyAction('Connect now'),
       primaryAction: _GuideAction.connectNow,
       secondaryLabel: 'Open Profiles',
       secondaryAction: _GuideAction.openProfiles,

--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -33,28 +33,51 @@ class _DashboardPageState extends State<DashboardPage> {
   Future<ReadinessReport>? _readinessFuture;
   ReadinessReport? _latestReadinessReport;
   String? _lastReadinessRefreshKey;
+  int _readinessRequestToken = 0;
+  int _lastAppliedLiveReadinessToken = -1;
 
   @override
   void initState() {
     super.initState();
-    _lastReadinessRefreshKey = 'initial';
-    final profile = widget.services.profileStore.selectedProfile;
-    _restoreLastKnownReadiness(profile: profile);
-    _refreshReadiness(profile: profile);
+    final services = widget.services;
+    final profile = services.profileStore.selectedProfile;
+    _lastReadinessRefreshKey = _buildReadinessRefreshKey(
+      profile: profile,
+      activeProfileId: services.controller.status.activeProfileId,
+      storageSummary: services.profileSecrets.storageSummary,
+      runtimeMode: services.controller.runtimeConfig.mode,
+      runtimeEndpointHint: services.controller.runtimeConfig.endpointHint,
+    );
+    _startReadinessCycle(profile: profile);
   }
 
-  void _restoreLastKnownReadiness({ClientProfile? profile}) {
+  void _startReadinessCycle({ClientProfile? profile}) {
+    _readinessRequestToken++;
+    final requestToken = _readinessRequestToken;
+    _restoreLastKnownReadiness(profile: profile, requestToken: requestToken);
+    _refreshReadiness(profile: profile, requestToken: requestToken);
+  }
+
+  void _restoreLastKnownReadiness({
+    ClientProfile? profile,
+    required int requestToken,
+  }) {
     widget.services.readiness
         .readLastKnownReport(profileOverride: profile)
         .then((report) {
       if (!mounted || report == null) return;
+      if (requestToken != _readinessRequestToken) return;
+      if (_lastAppliedLiveReadinessToken == requestToken) return;
       setState(() {
         _latestReadinessReport = report;
       });
     });
   }
 
-  void _refreshReadiness({ClientProfile? profile}) {
+  void _refreshReadiness({
+    ClientProfile? profile,
+    required int requestToken,
+  }) {
     final future =
         widget.services.readiness.buildReport(profileOverride: profile);
     setState(() {
@@ -62,11 +85,31 @@ class _DashboardPageState extends State<DashboardPage> {
     });
     future.then((report) {
       if (!mounted) return;
+      if (requestToken != _readinessRequestToken) return;
       if (!identical(_readinessFuture, future)) return;
       setState(() {
+        _lastAppliedLiveReadinessToken = requestToken;
         _latestReadinessReport = report;
       });
     });
+  }
+
+  String _buildReadinessRefreshKey({
+    required ClientProfile? profile,
+    required String? activeProfileId,
+    required String storageSummary,
+    required String runtimeMode,
+    required String runtimeEndpointHint,
+  }) {
+    return [
+      buildReadinessRefreshFingerprint(
+        profile: profile,
+        storageSummary: storageSummary,
+        runtimeMode: runtimeMode,
+        runtimeEndpointHint: runtimeEndpointHint,
+      ),
+      'active:$activeProfileId',
+    ].join('|');
   }
 
   void _refreshReadinessIfInputsChanged(String key, {ClientProfile? profile}) {
@@ -74,8 +117,7 @@ class _DashboardPageState extends State<DashboardPage> {
     _lastReadinessRefreshKey = key;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      _restoreLastKnownReadiness(profile: profile);
-      _refreshReadiness(profile: profile);
+      _startReadinessCycle(profile: profile);
     });
   }
 
@@ -110,15 +152,13 @@ class _DashboardPageState extends State<DashboardPage> {
         final runtimeConfig = services.controller.runtimeConfig;
         final telemetry = services.controller.telemetry;
         final desktopLifecycleStatus = services.desktopLifecycle.status;
-        final readinessRefreshKey = [
-          buildReadinessRefreshFingerprint(
-            profile: selectedProfile,
-            storageSummary: services.profileSecrets.storageSummary,
-            runtimeMode: runtimeConfig.mode,
-            runtimeEndpointHint: runtimeConfig.endpointHint,
-          ),
-          'active:${activeProfile?.id}',
-        ].join('|');
+        final readinessRefreshKey = _buildReadinessRefreshKey(
+          profile: selectedProfile,
+          activeProfileId: activeProfile?.id,
+          storageSummary: services.profileSecrets.storageSummary,
+          runtimeMode: runtimeConfig.mode,
+          runtimeEndpointHint: runtimeConfig.endpointHint,
+        );
         _refreshReadinessIfInputsChanged(
           readinessRefreshKey,
           profile: selectedProfile,
@@ -220,7 +260,7 @@ class _DashboardPageState extends State<DashboardPage> {
               trailing: IconButton(
                 icon: const Icon(Icons.refresh),
                 tooltip: 'Refresh readiness',
-                onPressed: _refreshReadiness,
+                onPressed: () => _startReadinessCycle(profile: selectedProfile),
               ),
               child: FutureBuilder<ReadinessReport>(
                 future: _readinessFuture,

--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -6,8 +6,8 @@ import '../../../core/widgets/section_card.dart';
 import '../../../platform/services/desktop_lifecycle_models.dart';
 import '../../../platform/services/service_registry.dart';
 import '../../controller/domain/client_connection_status.dart';
-import '../../controller/domain/controller_runtime_health.dart';
 import '../../profiles/domain/client_profile.dart';
+import '../../readiness/domain/readiness_report.dart';
 import '../application/connection_lifecycle_view_model.dart';
 
 class DashboardPage extends StatefulWidget {
@@ -29,18 +29,37 @@ class DashboardPage extends StatefulWidget {
 }
 
 class _DashboardPageState extends State<DashboardPage> {
-  Future<ControllerRuntimeHealth>? _healthFuture;
+  Future<ReadinessReport>? _readinessFuture;
+  String? _lastReadinessRefreshKey;
 
   @override
   void initState() {
     super.initState();
-    _healthFuture = widget.services.controller.checkHealth();
+    _lastReadinessRefreshKey = 'initial';
+    _readinessFuture = widget.services.readiness.buildReport();
   }
 
-  void _refreshHealth() {
+  void _refreshReadiness() {
     setState(() {
-      _healthFuture = widget.services.controller.checkHealth();
+      _readinessFuture = widget.services.readiness.buildReport();
     });
+  }
+
+  void _refreshReadinessIfInputsChanged(String key) {
+    if (_lastReadinessRefreshKey == key) return;
+    _lastReadinessRefreshKey = key;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _refreshReadiness();
+    });
+  }
+
+  VoidCallback? _actionHandlerFor(ReadinessAction action) {
+    return switch (action) {
+      ReadinessAction.openProfiles => widget.onOpenProfiles,
+      ReadinessAction.openTroubleshooting => widget.onOpenAdvanced,
+      ReadinessAction.openSettings => widget.onOpenSettings,
+    };
   }
 
   @override
@@ -66,6 +85,15 @@ class _DashboardPageState extends State<DashboardPage> {
         final runtimeConfig = services.controller.runtimeConfig;
         final telemetry = services.controller.telemetry;
         final desktopLifecycleStatus = services.desktopLifecycle.status;
+        final readinessRefreshKey = <Object?>[
+          selectedProfile?.id,
+          selectedProfile?.hasStoredPassword,
+          activeProfile?.id,
+          services.profileSecrets.storageSummary,
+          runtimeConfig.mode,
+          runtimeConfig.endpointHint,
+        ].join('|');
+        _refreshReadinessIfInputsChanged(readinessRefreshKey);
 
         return ListView(
           children: <Widget>[
@@ -154,38 +182,76 @@ class _DashboardPageState extends State<DashboardPage> {
               const SizedBox(height: 16),
             ],
             SectionCard(
-              title: 'Before you connect',
-              subtitle: 'Only the facts the user needs before trying one test.',
+              title: 'Readiness doctor',
+              subtitle: 'Know if the app is ready, degraded, or blocked before connecting.',
               trailing: IconButton(
                 icon: const Icon(Icons.refresh),
-                tooltip: 'Refresh health check',
-                onPressed: _refreshHealth,
+                tooltip: 'Refresh readiness',
+                onPressed: _refreshReadiness,
               ),
-              child: FutureBuilder<ControllerRuntimeHealth>(
-                future: _healthFuture,
+              child: FutureBuilder<ReadinessReport>(
+                future: _readinessFuture,
                 builder: (BuildContext context,
-                    AsyncSnapshot<ControllerRuntimeHealth> snapshot) {
-                  final health = snapshot.data;
-                  final levelName =
-                      health == null ? 'Checking…' : health.level.name;
-                  final summary =
-                      health == null ? 'Probing local runtime' : health.summary;
+                    AsyncSnapshot<ReadinessReport> snapshot) {
+                  final report = snapshot.data;
+                  if (report == null) {
+                    return const Text('Checking readiness…');
+                  }
 
-                  return Wrap(
-                    spacing: 24,
-                    runSpacing: 12,
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      KeyValuePair(label: 'Profile Ready',
-                          value: selectedProfile == null ? 'No' : 'Yes'),
-                      KeyValuePair(
-                        label: 'Password Ready',
-                        value: _passwordReadyLabel(selectedProfile ?? activeProfile),
+                      Wrap(
+                        spacing: 24,
+                        runSpacing: 12,
+                        children: <Widget>[
+                          KeyValuePair(
+                            label: 'Overall',
+                            value: report.overallLevel.label,
+                          ),
+                          KeyValuePair(label: 'Headline', value: report.headline),
+                          KeyValuePair(label: 'Summary', value: report.summary),
+                          KeyValuePair(
+                            label: 'Runtime Mode',
+                            value: runtimeConfig.mode,
+                          ),
+                          KeyValuePair(
+                            label: 'Runtime Endpoint',
+                            value: runtimeConfig.endpointHint,
+                          ),
+                          KeyValuePair(
+                            label: 'Secure Storage',
+                            value: services.profileSecrets.storageSummary,
+                          ),
+                        ],
                       ),
-                      KeyValuePair(label: 'Secret Storage',
-                          value: services.profileSecrets.storageSummary),
-                      KeyValuePair(label: 'App Ready', value: levelName),
-                      KeyValuePair(label: 'Status Note', value: summary),
-                      KeyValuePair(label: 'Runtime Path', value: runtimeConfig.endpointHint),
+                      if (report.recommendation != null) ...<Widget>[
+                        const SizedBox(height: 12),
+                        Text(
+                          report.recommendation!.detail,
+                          style: const TextStyle(fontWeight: FontWeight.w600),
+                        ),
+                        const SizedBox(height: 8),
+                        FilledButton.icon(
+                          onPressed:
+                              _actionHandlerFor(report.recommendation!.action),
+                          icon: const Icon(Icons.play_arrow),
+                          label: Text(report.recommendation!.label),
+                        ),
+                      ],
+                      const SizedBox(height: 12),
+                      Wrap(
+                        spacing: 24,
+                        runSpacing: 12,
+                        children: report.checks
+                            .map(
+                              (check) => KeyValuePair(
+                                label: check.domain.name,
+                                value: '${check.level.label}: ${check.summary}',
+                              ),
+                            )
+                            .toList(),
+                      ),
                     ],
                   );
                 },
@@ -206,11 +272,6 @@ class _DashboardPageState extends State<DashboardPage> {
         );
       },
     );
-  }
-
-  String _passwordReadyLabel(ClientProfile? profile) {
-    if (profile == null) return 'N/A';
-    return profile.hasStoredPassword ? 'Yes' : 'No';
   }
 
   bool _showExperimentGuide(

--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -7,6 +7,7 @@ import '../../../platform/services/desktop_lifecycle_models.dart';
 import '../../../platform/services/service_registry.dart';
 import '../../controller/domain/client_connection_status.dart';
 import '../../profiles/domain/client_profile.dart';
+import '../../readiness/domain/readiness_refresh_fingerprint.dart';
 import '../../readiness/domain/readiness_report.dart';
 import '../application/connection_lifecycle_view_model.dart';
 
@@ -54,7 +55,8 @@ class _DashboardPageState extends State<DashboardPage> {
   }
 
   void _refreshReadiness({ClientProfile? profile}) {
-    final future = widget.services.readiness.buildReport(profileOverride: profile);
+    final future =
+        widget.services.readiness.buildReport(profileOverride: profile);
     setState(() {
       _readinessFuture = future;
     });
@@ -108,13 +110,14 @@ class _DashboardPageState extends State<DashboardPage> {
         final runtimeConfig = services.controller.runtimeConfig;
         final telemetry = services.controller.telemetry;
         final desktopLifecycleStatus = services.desktopLifecycle.status;
-        final readinessRefreshKey = <Object?>[
-          selectedProfile?.id,
-          selectedProfile?.hasStoredPassword,
-          activeProfile?.id,
-          services.profileSecrets.storageSummary,
-          runtimeConfig.mode,
-          runtimeConfig.endpointHint,
+        final readinessRefreshKey = [
+          buildReadinessRefreshFingerprint(
+            profile: selectedProfile,
+            storageSummary: services.profileSecrets.storageSummary,
+            runtimeMode: runtimeConfig.mode,
+            runtimeEndpointHint: runtimeConfig.endpointHint,
+          ),
+          'active:${activeProfile?.id}',
         ].join('|');
         _refreshReadinessIfInputsChanged(
           readinessRefreshKey,
@@ -123,7 +126,8 @@ class _DashboardPageState extends State<DashboardPage> {
 
         return ListView(
           children: <Widget>[
-            if (desktopLifecycleStatus.isRecentExternalActivation()) ...<Widget>[
+            if (desktopLifecycleStatus
+                .isRecentExternalActivation()) ...<Widget>[
               _ExternalActivationCard(
                 status: desktopLifecycleStatus,
                 onDismiss: () {
@@ -211,7 +215,8 @@ class _DashboardPageState extends State<DashboardPage> {
             ],
             SectionCard(
               title: 'Readiness doctor',
-              subtitle: 'Know if the app is ready, degraded, or blocked before connecting.',
+              subtitle:
+                  'Know if the app is ready, degraded, or blocked before connecting.',
               trailing: IconButton(
                 icon: const Icon(Icons.refresh),
                 tooltip: 'Refresh readiness',
@@ -237,7 +242,8 @@ class _DashboardPageState extends State<DashboardPage> {
                             label: 'Overall',
                             value: report.overallLevel.label,
                           ),
-                          KeyValuePair(label: 'Headline', value: report.headline),
+                          KeyValuePair(
+                              label: 'Headline', value: report.headline),
                           KeyValuePair(label: 'Summary', value: report.summary),
                           KeyValuePair(
                             label: 'Runtime Mode',
@@ -512,12 +518,13 @@ class _NextStepGuide extends StatelessWidget {
             ? (activeProfile ?? selectedProfile)
             : selectedProfile;
         if (currentProfile == null) return;
-        final readinessReport =
-            await services.readiness.buildReport(profileOverride: currentProfile);
+        final readinessReport = await services.readiness
+            .buildReport(profileOverride: currentProfile);
         if (!context.mounted) return;
         if (readinessReport.overallLevel == ReadinessLevel.blocked) {
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Connect blocked: ${readinessReport.summary}')),
+            SnackBar(
+                content: Text('Connect blocked: ${readinessReport.summary}')),
           );
           return;
         }
@@ -775,19 +782,26 @@ class _ConnectionHomeCard extends StatelessWidget {
                   runSpacing: 12,
                   children: <Widget>[
                     KeyValuePair(label: 'Lifecycle', value: lifecycle.label),
-                    KeyValuePair(label: 'Selected Profile', value: selectedProfile.name),
+                    KeyValuePair(
+                        label: 'Selected Profile', value: selectedProfile.name),
                     KeyValuePair(
                       label: 'Active Profile',
                       value: activeProfile?.name ??
                           lifecycle.activeProfileName ??
                           'None',
                     ),
-                    KeyValuePair(label: 'Status Note', value: lifecycle.statusSummary),
-                    KeyValuePair(label: 'Secret Storage', value: storageSummary),
+                    KeyValuePair(
+                        label: 'Status Note', value: lifecycle.statusSummary),
+                    KeyValuePair(
+                        label: 'Secret Storage', value: storageSummary),
                     KeyValuePair(label: 'Runtime Mode', value: runtimeMode),
-                    KeyValuePair(label: 'Execution Path', value: _executionPathLabel(runtimeMode)),
-                    KeyValuePair(label: 'Controller Backend', value: controllerBackend),
-                    KeyValuePair(label: 'Backend Version', value: controllerVersion),
+                    KeyValuePair(
+                        label: 'Execution Path',
+                        value: _executionPathLabel(runtimeMode)),
+                    KeyValuePair(
+                        label: 'Controller Backend', value: controllerBackend),
+                    KeyValuePair(
+                        label: 'Backend Version', value: controllerVersion),
                     KeyValuePair(label: 'Update Channel', value: updateChannel),
                   ],
                 ),
@@ -925,7 +939,8 @@ class _RuntimeSessionSummary extends StatelessWidget {
               spacing: 24,
               runSpacing: 12,
               children: <Widget>[
-                KeyValuePair(label: 'Running', value: session.isRunning ? 'Yes' : 'No'),
+                KeyValuePair(
+                    label: 'Running', value: session.isRunning ? 'Yes' : 'No'),
                 KeyValuePair(label: 'Runtime Phase', value: session.phase.name),
                 KeyValuePair(
                   label: 'Stop Requested',
@@ -937,9 +952,11 @@ class _RuntimeSessionSummary extends StatelessWidget {
                       ? 'N/A'
                       : formatTimestamp(session.stopRequestedAt!),
                 ),
-                KeyValuePair(label: 'PID', value: session.pid?.toString() ?? 'N/A'),
                 KeyValuePair(
-                    label: 'Config Path', value: session.activeConfigPath ?? 'N/A'),
+                    label: 'PID', value: session.pid?.toString() ?? 'N/A'),
+                KeyValuePair(
+                    label: 'Config Path',
+                    value: session.activeConfigPath ?? 'N/A'),
                 KeyValuePair(
                   label: 'Config Provenance',
                   value: session.configProvenance ?? 'N/A',
@@ -952,9 +969,11 @@ class _RuntimeSessionSummary extends StatelessWidget {
                   label: 'Launch Plan',
                   value: session.launchPlan?.summary ?? 'N/A',
                 ),
-                KeyValuePair(label: 'Last Exit Code',
+                KeyValuePair(
+                    label: 'Last Exit Code',
                     value: session.lastExitCode?.toString() ?? 'N/A'),
-                KeyValuePair(label: 'Last Error', value: session.lastError ?? 'None'),
+                KeyValuePair(
+                    label: 'Last Error', value: session.lastError ?? 'None'),
               ],
             ),
             const SizedBox(height: 12),

--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -6,6 +6,7 @@ import '../../../core/widgets/section_card.dart';
 import '../../../platform/services/desktop_lifecycle_models.dart';
 import '../../../platform/services/service_registry.dart';
 import '../../controller/domain/client_connection_status.dart';
+import '../../controller/domain/runtime_posture.dart';
 import '../../profiles/domain/client_profile.dart';
 import '../../readiness/domain/readiness_refresh_fingerprint.dart';
 import '../../readiness/domain/readiness_report.dart';
@@ -734,27 +735,13 @@ class _ConnectionHomeCard extends StatelessWidget {
         ConnectionLifecycleStage.error => Colors.red,
       };
 
-  String _executionPathLabel(String mode) {
-    if (mode.contains('real-runtime-boundary')) {
-      return 'Real runtime path';
-    }
-    if (mode.contains('stubbed-local-boundary-fallback')) {
-      return 'Fallback stub (real runtime unavailable)';
-    }
-    if (mode.contains('stubbed-local-boundary-explicit')) {
-      return 'Explicit stub mode';
-    }
-    if (mode.contains('stubbed-local-boundary-non-desktop')) {
-      return 'Stub mode (non-desktop target)';
-    }
-    if (mode.contains('stubbed-local-boundary')) {
-      return 'Simulated runtime path';
-    }
-    return 'Unknown runtime path';
-  }
-
   @override
   Widget build(BuildContext context) {
+    final posture = describeRuntimePosture(
+      runtimeMode: runtimeMode,
+      backendKind: controllerBackend,
+    );
+
     return SectionCard(
       title: 'Connection Home',
       subtitle:
@@ -819,14 +806,24 @@ class _ConnectionHomeCard extends StatelessWidget {
                         label: 'Secret Storage', value: storageSummary),
                     KeyValuePair(label: 'Runtime Mode', value: runtimeMode),
                     KeyValuePair(
-                        label: 'Execution Path',
-                        value: _executionPathLabel(runtimeMode)),
+                      label: 'Runtime Posture',
+                      value: posture.postureLabel,
+                    ),
+                    KeyValuePair(
+                      label: 'Execution Path',
+                      value: posture.executionPathLabel,
+                    ),
                     KeyValuePair(
                         label: 'Controller Backend', value: controllerBackend),
                     KeyValuePair(
                         label: 'Backend Version', value: controllerVersion),
                     KeyValuePair(label: 'Update Channel', value: updateChannel),
                   ],
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  posture.truthNote,
+                  style: const TextStyle(fontWeight: FontWeight.w600),
                 ),
                 const SizedBox(height: 16),
                 Wrap(

--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -30,27 +30,36 @@ class DashboardPage extends StatefulWidget {
 
 class _DashboardPageState extends State<DashboardPage> {
   Future<ReadinessReport>? _readinessFuture;
+  ReadinessReport? _latestReadinessReport;
   String? _lastReadinessRefreshKey;
 
   @override
   void initState() {
     super.initState();
     _lastReadinessRefreshKey = 'initial';
-    _readinessFuture = widget.services.readiness.buildReport();
+    _refreshReadiness(profile: widget.services.profileStore.selectedProfile);
   }
 
-  void _refreshReadiness() {
+  void _refreshReadiness({ClientProfile? profile}) {
+    final future = widget.services.readiness.buildReport(profileOverride: profile);
     setState(() {
-      _readinessFuture = widget.services.readiness.buildReport();
+      _readinessFuture = future;
+    });
+    future.then((report) {
+      if (!mounted) return;
+      if (!identical(_readinessFuture, future)) return;
+      setState(() {
+        _latestReadinessReport = report;
+      });
     });
   }
 
-  void _refreshReadinessIfInputsChanged(String key) {
+  void _refreshReadinessIfInputsChanged(String key, {ClientProfile? profile}) {
     if (_lastReadinessRefreshKey == key) return;
     _lastReadinessRefreshKey = key;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      _refreshReadiness();
+      _refreshReadiness(profile: profile);
     });
   }
 
@@ -93,7 +102,10 @@ class _DashboardPageState extends State<DashboardPage> {
           runtimeConfig.mode,
           runtimeConfig.endpointHint,
         ].join('|');
-        _refreshReadinessIfInputsChanged(readinessRefreshKey);
+        _refreshReadinessIfInputsChanged(
+          readinessRefreshKey,
+          profile: selectedProfile,
+        );
 
         return ListView(
           children: <Widget>[
@@ -153,8 +165,10 @@ class _DashboardPageState extends State<DashboardPage> {
                 activeProfile: activeProfile,
                 status: status,
                 lifecycle: lifecycle,
+                readiness: _latestReadinessReport,
                 onOpenProfiles: widget.onOpenProfiles,
                 onOpenAdvanced: widget.onOpenAdvanced,
+                onOpenSettings: widget.onOpenSettings,
               ),
             ),
             const SizedBox(height: 16),
@@ -193,7 +207,7 @@ class _DashboardPageState extends State<DashboardPage> {
                 future: _readinessFuture,
                 builder: (BuildContext context,
                     AsyncSnapshot<ReadinessReport> snapshot) {
-                  final report = snapshot.data;
+                  final report = snapshot.data ?? _latestReadinessReport;
                   if (report == null) {
                     return const Text('Checking readiness…');
                   }
@@ -419,8 +433,10 @@ class _NextStepGuide extends StatelessWidget {
     required this.activeProfile,
     required this.status,
     required this.lifecycle,
+    required this.readiness,
     required this.onOpenProfiles,
     required this.onOpenAdvanced,
+    this.onOpenSettings,
   });
 
   final ClientServiceRegistry services;
@@ -428,8 +444,10 @@ class _NextStepGuide extends StatelessWidget {
   final ClientProfile? activeProfile;
   final ClientConnectionStatus status;
   final ConnectionLifecycleViewModel lifecycle;
+  final ReadinessReport? readiness;
   final VoidCallback? onOpenProfiles;
   final VoidCallback? onOpenAdvanced;
+  final VoidCallback? onOpenSettings;
 
   @override
   Widget build(BuildContext context) {
@@ -471,12 +489,24 @@ class _NextStepGuide extends StatelessWidget {
       case _GuideAction.openAdvanced:
         onOpenAdvanced?.call();
         return;
+      case _GuideAction.openSettings:
+        onOpenSettings?.call();
+        return;
       case _GuideAction.connectNow:
       case _GuideAction.retryNow:
         final currentProfile = action == _GuideAction.retryNow
             ? (activeProfile ?? selectedProfile)
             : selectedProfile;
         if (currentProfile == null) return;
+        final readinessReport =
+            await services.readiness.buildReport(profileOverride: currentProfile);
+        if (!context.mounted) return;
+        if (readinessReport.overallLevel == ReadinessLevel.blocked) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Connect blocked: ${readinessReport.summary}')),
+          );
+          return;
+        }
         final result = await services.controller.connect(currentProfile);
         if (!context.mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
@@ -491,6 +521,14 @@ class _NextStepGuide extends StatelessWidget {
         );
         return;
     }
+  }
+
+  _GuideAction _guideActionFor(ReadinessAction action) {
+    return switch (action) {
+      ReadinessAction.openProfiles => _GuideAction.openProfiles,
+      ReadinessAction.openTroubleshooting => _GuideAction.openAdvanced,
+      ReadinessAction.openSettings => _GuideAction.openSettings,
+    };
   }
 
   _GuideModel _model() {
@@ -512,6 +550,24 @@ class _NextStepGuide extends StatelessWidget {
             'The selected profile still needs its Trojan password. Save it first, then try one connection attempt.',
         primaryLabel: 'Open Profiles',
         primaryAction: _GuideAction.openProfiles,
+      );
+    }
+    if (readiness != null &&
+        readiness!.overallLevel == ReadinessLevel.blocked &&
+        status.phase != ClientConnectionPhase.error &&
+        status.phase != ClientConnectionPhase.connected &&
+        status.phase != ClientConnectionPhase.connecting &&
+        status.phase != ClientConnectionPhase.disconnecting) {
+      final recommendation = readiness!.recommendation;
+      return _GuideModel(
+        title: readiness!.headline,
+        body: readiness!.summary,
+        primaryLabel: recommendation?.label ?? 'Open Troubleshooting',
+        primaryAction: recommendation == null
+            ? _GuideAction.openAdvanced
+            : _guideActionFor(recommendation.action),
+        secondaryLabel: 'Open Profiles',
+        secondaryAction: _GuideAction.openProfiles,
       );
     }
     if (status.phase == ClientConnectionPhase.error) {
@@ -575,6 +631,7 @@ class _NextStepGuide extends StatelessWidget {
 enum _GuideAction {
   openProfiles,
   openAdvanced,
+  openSettings,
   connectNow,
   retryNow,
   disconnectNow,

--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -257,8 +257,21 @@ class _DashboardPageState extends State<DashboardPage> {
                             label: 'Secure Storage',
                             value: services.profileSecrets.storageSummary,
                           ),
+                          KeyValuePair(
+                            label: 'Readiness Provenance',
+                            value: report.provenanceSummary,
+                          ),
                         ],
                       ),
+                      if (report.isCachedSnapshot &&
+                          snapshot.connectionState !=
+                              ConnectionState.done) ...<Widget>[
+                        const SizedBox(height: 12),
+                        const Text(
+                          'Showing a cached snapshot while the live readiness refresh runs.',
+                          style: TextStyle(fontWeight: FontWeight.w600),
+                        ),
+                      ],
                       if (report.recommendation != null) ...<Widget>[
                         const SizedBox(height: 12),
                         Text(

--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -572,6 +572,25 @@ class _ConnectionHomeCard extends StatelessWidget {
         ConnectionLifecycleStage.error => Colors.red,
       };
 
+  String _executionPathLabel(String mode) {
+    if (mode.contains('real-runtime-boundary')) {
+      return 'Real runtime path';
+    }
+    if (mode.contains('stubbed-local-boundary-fallback')) {
+      return 'Fallback stub (real runtime unavailable)';
+    }
+    if (mode.contains('stubbed-local-boundary-explicit')) {
+      return 'Explicit stub mode';
+    }
+    if (mode.contains('stubbed-local-boundary-non-desktop')) {
+      return 'Stub mode (non-desktop target)';
+    }
+    if (mode.contains('stubbed-local-boundary')) {
+      return 'Simulated runtime path';
+    }
+    return 'Unknown runtime path';
+  }
+
   @override
   Widget build(BuildContext context) {
     return SectionCard(
@@ -634,6 +653,7 @@ class _ConnectionHomeCard extends StatelessWidget {
                     KeyValuePair(label: 'Status Note', value: lifecycle.statusSummary),
                     KeyValuePair(label: 'Secret Storage', value: storageSummary),
                     KeyValuePair(label: 'Runtime Mode', value: runtimeMode),
+                    KeyValuePair(label: 'Execution Path', value: _executionPathLabel(runtimeMode)),
                     KeyValuePair(label: 'Controller Backend', value: controllerBackend),
                     KeyValuePair(label: 'Backend Version', value: controllerVersion),
                     KeyValuePair(label: 'Update Channel', value: updateChannel),
@@ -774,9 +794,32 @@ class _RuntimeSessionSummary extends StatelessWidget {
               runSpacing: 12,
               children: <Widget>[
                 KeyValuePair(label: 'Running', value: session.isRunning ? 'Yes' : 'No'),
+                KeyValuePair(label: 'Runtime Phase', value: session.phase.name),
+                KeyValuePair(
+                  label: 'Stop Requested',
+                  value: session.stopRequested ? 'Yes' : 'No',
+                ),
+                KeyValuePair(
+                  label: 'Stop Requested At',
+                  value: session.stopRequestedAt == null
+                      ? 'N/A'
+                      : formatTimestamp(session.stopRequestedAt!),
+                ),
                 KeyValuePair(label: 'PID', value: session.pid?.toString() ?? 'N/A'),
                 KeyValuePair(
                     label: 'Config Path', value: session.activeConfigPath ?? 'N/A'),
+                KeyValuePair(
+                  label: 'Config Provenance',
+                  value: session.configProvenance ?? 'N/A',
+                ),
+                KeyValuePair(
+                  label: 'Expected Local SOCKS Port',
+                  value: session.expectedLocalSocksPort?.toString() ?? 'N/A',
+                ),
+                KeyValuePair(
+                  label: 'Launch Plan',
+                  value: session.launchPlan?.summary ?? 'N/A',
+                ),
                 KeyValuePair(label: 'Last Exit Code',
                     value: session.lastExitCode?.toString() ?? 'N/A'),
                 KeyValuePair(label: 'Last Error', value: session.lastError ?? 'None'),

--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -37,7 +37,20 @@ class _DashboardPageState extends State<DashboardPage> {
   void initState() {
     super.initState();
     _lastReadinessRefreshKey = 'initial';
-    _refreshReadiness(profile: widget.services.profileStore.selectedProfile);
+    final profile = widget.services.profileStore.selectedProfile;
+    _restoreLastKnownReadiness(profile: profile);
+    _refreshReadiness(profile: profile);
+  }
+
+  void _restoreLastKnownReadiness({ClientProfile? profile}) {
+    widget.services.readiness
+        .readLastKnownReport(profileOverride: profile)
+        .then((report) {
+      if (!mounted || report == null) return;
+      setState(() {
+        _latestReadinessReport = report;
+      });
+    });
   }
 
   void _refreshReadiness({ClientProfile? profile}) {
@@ -59,6 +72,7 @@ class _DashboardPageState extends State<DashboardPage> {
     _lastReadinessRefreshKey = key;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      _restoreLastKnownReadiness(profile: profile);
       _refreshReadiness(profile: profile);
     });
   }

--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -9,6 +9,7 @@ import '../../controller/domain/client_connection_status.dart';
 import '../../profiles/domain/client_profile.dart';
 import '../../readiness/domain/readiness_refresh_fingerprint.dart';
 import '../../readiness/domain/readiness_report.dart';
+import '../../readiness/presentation/readiness_surface_controller.dart';
 import '../application/connection_lifecycle_view_model.dart';
 
 class DashboardPage extends StatefulWidget {
@@ -30,68 +31,30 @@ class DashboardPage extends StatefulWidget {
 }
 
 class _DashboardPageState extends State<DashboardPage> {
-  Future<ReadinessReport>? _readinessFuture;
-  ReadinessReport? _latestReadinessReport;
-  String? _lastReadinessRefreshKey;
-  int _readinessRequestToken = 0;
-  int _lastAppliedLiveReadinessToken = -1;
+  late final ReadinessSurfaceController _readinessController;
 
   @override
   void initState() {
     super.initState();
+    _readinessController = ReadinessSurfaceController(
+      isMounted: () => mounted,
+      applyState: setState,
+    );
     final services = widget.services;
     final profile = services.profileStore.selectedProfile;
-    _lastReadinessRefreshKey = _buildReadinessRefreshKey(
-      profile: profile,
-      activeProfileId: services.controller.status.activeProfileId,
-      storageSummary: services.profileSecrets.storageSummary,
-      runtimeMode: services.controller.runtimeConfig.mode,
-      runtimeEndpointHint: services.controller.runtimeConfig.endpointHint,
+    _readinessController.initialize(
+      refreshKey: _buildReadinessRefreshKey(
+        profile: profile,
+        activeProfileId: services.controller.status.activeProfileId,
+        storageSummary: services.profileSecrets.storageSummary,
+        runtimeMode: services.controller.runtimeConfig.mode,
+        runtimeEndpointHint: services.controller.runtimeConfig.endpointHint,
+      ),
+      restoreReport: () =>
+          services.readiness.readLastKnownReport(profileOverride: profile),
+      buildReport: () =>
+          services.readiness.buildReport(profileOverride: profile),
     );
-    _startReadinessCycle(profile: profile);
-  }
-
-  void _startReadinessCycle({ClientProfile? profile}) {
-    _readinessRequestToken++;
-    final requestToken = _readinessRequestToken;
-    _restoreLastKnownReadiness(profile: profile, requestToken: requestToken);
-    _refreshReadiness(profile: profile, requestToken: requestToken);
-  }
-
-  void _restoreLastKnownReadiness({
-    ClientProfile? profile,
-    required int requestToken,
-  }) {
-    widget.services.readiness
-        .readLastKnownReport(profileOverride: profile)
-        .then((report) {
-      if (!mounted || report == null) return;
-      if (requestToken != _readinessRequestToken) return;
-      if (_lastAppliedLiveReadinessToken == requestToken) return;
-      setState(() {
-        _latestReadinessReport = report;
-      });
-    });
-  }
-
-  void _refreshReadiness({
-    ClientProfile? profile,
-    required int requestToken,
-  }) {
-    final future =
-        widget.services.readiness.buildReport(profileOverride: profile);
-    setState(() {
-      _readinessFuture = future;
-    });
-    future.then((report) {
-      if (!mounted) return;
-      if (requestToken != _readinessRequestToken) return;
-      if (!identical(_readinessFuture, future)) return;
-      setState(() {
-        _lastAppliedLiveReadinessToken = requestToken;
-        _latestReadinessReport = report;
-      });
-    });
   }
 
   String _buildReadinessRefreshKey({
@@ -113,12 +76,13 @@ class _DashboardPageState extends State<DashboardPage> {
   }
 
   void _refreshReadinessIfInputsChanged(String key, {ClientProfile? profile}) {
-    if (_lastReadinessRefreshKey == key) return;
-    _lastReadinessRefreshKey = key;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      _startReadinessCycle(profile: profile);
-    });
+    _readinessController.refreshIfKeyChanged(
+      key,
+      restoreReport: () => widget.services.readiness
+          .readLastKnownReport(profileOverride: profile),
+      buildReport: () =>
+          widget.services.readiness.buildReport(profileOverride: profile),
+    );
   }
 
   VoidCallback? _actionHandlerFor(ReadinessAction action) {
@@ -223,7 +187,7 @@ class _DashboardPageState extends State<DashboardPage> {
                 activeProfile: activeProfile,
                 status: status,
                 lifecycle: lifecycle,
-                readiness: _latestReadinessReport,
+                readiness: _readinessController.latestReport,
                 onOpenProfiles: widget.onOpenProfiles,
                 onOpenAdvanced: widget.onOpenAdvanced,
                 onOpenSettings: widget.onOpenSettings,
@@ -260,13 +224,19 @@ class _DashboardPageState extends State<DashboardPage> {
               trailing: IconButton(
                 icon: const Icon(Icons.refresh),
                 tooltip: 'Refresh readiness',
-                onPressed: () => _startReadinessCycle(profile: selectedProfile),
+                onPressed: () => _readinessController.startCycle(
+                  restoreReport: () => widget.services.readiness
+                      .readLastKnownReport(profileOverride: selectedProfile),
+                  buildReport: () => widget.services.readiness
+                      .buildReport(profileOverride: selectedProfile),
+                ),
               ),
               child: FutureBuilder<ReadinessReport>(
-                future: _readinessFuture,
+                future: _readinessController.future,
                 builder: (BuildContext context,
                     AsyncSnapshot<ReadinessReport> snapshot) {
-                  final report = snapshot.data ?? _latestReadinessReport;
+                  final report =
+                      snapshot.data ?? _readinessController.latestReport;
                   if (report == null) {
                     return const Text('Checking readiness…');
                   }

--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -817,6 +817,10 @@ class _ConnectionHomeCard extends StatelessWidget {
                       value: posture.postureLabel,
                     ),
                     KeyValuePair(
+                      label: 'Evidence Grade',
+                      value: posture.evidenceGradeLabel,
+                    ),
+                    KeyValuePair(
                       label: 'Execution Path',
                       value: posture.executionPathLabel,
                     ),
@@ -829,7 +833,7 @@ class _ConnectionHomeCard extends StatelessWidget {
                 ),
                 const SizedBox(height: 16),
                 Text(
-                  posture.truthNote,
+                  '${posture.truthNote} ${posture.evidenceGradeNote}',
                   style: const TextStyle(fontWeight: FontWeight.w600),
                 ),
                 const SizedBox(height: 16),

--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -6,7 +6,12 @@ import '../../../core/widgets/section_card.dart';
 import '../../../platform/services/desktop_lifecycle_models.dart';
 import '../../../platform/services/service_registry.dart';
 import '../../controller/domain/client_connection_status.dart';
+import '../../controller/domain/controller_runtime_session.dart';
+import '../../controller/domain/runtime_action_feedback.dart';
+import '../../controller/domain/runtime_action_safety.dart';
+import '../../controller/domain/runtime_operator_advice.dart';
 import '../../controller/domain/runtime_posture.dart';
+import 'dashboard_guide_policy.dart';
 import '../../profiles/domain/client_profile.dart';
 import '../../readiness/domain/readiness_refresh_fingerprint.dart';
 import '../../readiness/domain/readiness_report.dart';
@@ -504,6 +509,52 @@ class _NextStepGuide extends StatelessWidget {
         const SizedBox(height: 6),
         Text(model.body),
         const SizedBox(height: 12),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.indigo.withValues(alpha: 0.08),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: Colors.indigo.withValues(alpha: 0.2)),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              const Text(
+                'Action safety',
+                style: TextStyle(fontWeight: FontWeight.w700),
+              ),
+              const SizedBox(height: 6),
+              Text(model.actionSafety.label),
+              const SizedBox(height: 4),
+              Text(model.actionSafety.detail),
+            ],
+          ),
+        ),
+        if (model.operatorTitle != null && model.operatorBody != null) ...<Widget>[
+          const SizedBox(height: 12),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.blue.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: Colors.blue.withValues(alpha: 0.2)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  model.operatorTitle!,
+                  style: const TextStyle(fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: 6),
+                Text(model.operatorBody!),
+              ],
+            ),
+          ),
+        ],
+        const SizedBox(height: 12),
         Wrap(
           spacing: 8,
           runSpacing: 8,
@@ -554,26 +605,40 @@ class _NextStepGuide extends StatelessWidget {
         }
         final result = await services.controller.connect(currentProfile);
         if (!context.mounted) return;
+        final feedback = buildRuntimeActionFeedback(
+          action: action == _GuideAction.retryNow
+              ? RuntimeActionKind.retry
+              : RuntimeActionKind.connect,
+          result: result,
+          status: services.controller.status,
+          session: services.controller.session,
+          posture: describeRuntimePosture(
+            runtimeMode: services.controller.runtimeConfig.mode,
+            backendKind: services.controller.telemetry.backendKind,
+          ),
+        );
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(result.summary)),
+          SnackBar(content: Text(feedback)),
         );
         return;
       case _GuideAction.disconnectNow:
         final result = await services.controller.disconnect();
         if (!context.mounted) return;
+        final feedback = buildRuntimeActionFeedback(
+          action: RuntimeActionKind.disconnect,
+          result: result,
+          status: services.controller.status,
+          session: services.controller.session,
+          posture: describeRuntimePosture(
+            runtimeMode: services.controller.runtimeConfig.mode,
+            backendKind: services.controller.telemetry.backendKind,
+          ),
+        );
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(result.summary)),
+          SnackBar(content: Text(feedback)),
         );
         return;
     }
-  }
-
-  _GuideAction _guideActionFor(ReadinessAction action) {
-    return switch (action) {
-      ReadinessAction.openProfiles => _GuideAction.openProfiles,
-      ReadinessAction.openTroubleshooting => _GuideAction.openAdvanced,
-      ReadinessAction.openSettings => _GuideAction.openSettings,
-    };
   }
 
   _GuideModel _model() {
@@ -581,102 +646,49 @@ class _NextStepGuide extends StatelessWidget {
       runtimeMode: services.controller.runtimeConfig.mode,
       backendKind: services.controller.telemetry.backendKind,
     );
-
-    if (selectedProfile == null && activeProfile == null) {
-      return const _GuideModel(
-        title: 'Start by adding one profile',
-        body:
-            'Create or import a profile first. Once that exists, the rest of the flow becomes much simpler.',
-        primaryLabel: 'Open Profiles',
-        primaryAction: _GuideAction.openProfiles,
-      );
-    }
-    if (activeProfile == null &&
-        selectedProfile != null &&
-        !selectedProfile!.hasStoredPassword) {
-      return const _GuideModel(
-        title: 'Save the password before testing',
-        body:
-            'The selected profile still needs its Trojan password. Save it first, then try one connection attempt.',
-        primaryLabel: 'Open Profiles',
-        primaryAction: _GuideAction.openProfiles,
-      );
-    }
-    if (readiness != null &&
-        readiness!.overallLevel == ReadinessLevel.blocked &&
-        status.phase != ClientConnectionPhase.error &&
-        status.phase != ClientConnectionPhase.connected &&
-        status.phase != ClientConnectionPhase.connecting &&
-        status.phase != ClientConnectionPhase.disconnecting) {
-      final recommendation = readiness!.recommendation;
-      return _GuideModel(
-        title: readiness!.headline,
-        body: readiness!.summary,
-        primaryLabel: recommendation?.label ?? 'Open Troubleshooting',
-        primaryAction: recommendation == null
-            ? _GuideAction.openAdvanced
-            : _guideActionFor(recommendation.action),
-        secondaryLabel: 'Open Profiles',
-        secondaryAction: _GuideAction.openProfiles,
-      );
-    }
-    if (status.phase == ClientConnectionPhase.error) {
-      return _GuideModel(
-        title: lifecycle.headline,
-        body: lifecycle.detail,
-        primaryLabel: lifecycle.showRetry
-            ? posture.qualifyAction('Retry now')
-            : 'Open Profiles',
-        primaryAction: lifecycle.showRetry
-            ? _GuideAction.retryNow
-            : _GuideAction.openProfiles,
-        secondaryLabel:
-            lifecycle.showOpenTroubleshooting ? 'Open Troubleshooting' : null,
-        secondaryAction: lifecycle.showOpenTroubleshooting
-            ? _GuideAction.openAdvanced
-            : null,
-      );
-    }
-    if (status.phase == ClientConnectionPhase.connected) {
-      return const _GuideModel(
-        title: 'Connection is active',
-        body:
-            'You are already connected. Disconnect here if you want to end the current session, or open Profiles to switch context.',
-        primaryLabel: 'Disconnect now',
-        primaryAction: _GuideAction.disconnectNow,
-        secondaryLabel: 'Open Profiles',
-        secondaryAction: _GuideAction.openProfiles,
-      );
-    }
-    if (status.phase == ClientConnectionPhase.disconnecting) {
-      return _GuideModel(
-        title: lifecycle.headline,
-        body: lifecycle.detail,
-        primaryLabel: 'Open Troubleshooting',
-        primaryAction: _GuideAction.openAdvanced,
-        secondaryLabel: 'Open Profiles',
-        secondaryAction: _GuideAction.openProfiles,
-      );
-    }
-    if (status.phase == ClientConnectionPhase.connecting) {
-      return _GuideModel(
-        title: lifecycle.headline,
-        body: lifecycle.detail,
-        primaryLabel: 'Open Troubleshooting',
-        primaryAction: _GuideAction.openAdvanced,
-        secondaryLabel: 'Open Profiles',
-        secondaryAction: _GuideAction.openProfiles,
-      );
-    }
-    return _GuideModel(
-      title: 'You are ready for a quick test',
-      body:
-          'Use one clear Connect action here, or open Profiles if you want to review the selected profile first.',
-      primaryLabel: posture.qualifyAction('Connect now'),
-      primaryAction: _GuideAction.connectNow,
-      secondaryLabel: 'Open Profiles',
-      secondaryAction: _GuideAction.openProfiles,
+    final runtimeSession = services.controller.session;
+    final operatorAdvice = RuntimeOperatorAdvice.resolve(
+      status: status,
+      session: runtimeSession,
+      posture: posture,
+      troubleshootingAvailable: onOpenAdvanced != null,
     );
+
+    final policy = DashboardGuidePolicy.resolve(
+      lifecycle: lifecycle,
+      selectedProfile: selectedProfile,
+      activeProfile: activeProfile,
+      status: status,
+      posture: posture,
+      runtimeSession: runtimeSession,
+      operatorAdvice: operatorAdvice,
+      readiness: readiness,
+    );
+
+    return _GuideModel(
+      title: policy.title,
+      body: policy.body,
+      primaryLabel: policy.primaryLabel,
+      primaryAction: _mapGuideAction(policy.primaryAction),
+      secondaryLabel: policy.secondaryLabel,
+      secondaryAction: policy.secondaryAction == null
+          ? null
+          : _mapGuideAction(policy.secondaryAction!),
+      operatorTitle: policy.operatorTitle,
+      operatorBody: policy.operatorBody,
+      actionSafety: policy.actionSafety,
+    );
+  }
+
+  _GuideAction _mapGuideAction(DashboardGuideAction action) {
+    return switch (action) {
+      DashboardGuideAction.openProfiles => _GuideAction.openProfiles,
+      DashboardGuideAction.openAdvanced => _GuideAction.openAdvanced,
+      DashboardGuideAction.openSettings => _GuideAction.openSettings,
+      DashboardGuideAction.connectNow => _GuideAction.connectNow,
+      DashboardGuideAction.retryNow => _GuideAction.retryNow,
+      DashboardGuideAction.disconnectNow => _GuideAction.disconnectNow,
+    };
   }
 }
 
@@ -695,16 +707,22 @@ class _GuideModel {
     required this.body,
     required this.primaryLabel,
     required this.primaryAction,
+    required this.actionSafety,
     this.secondaryLabel,
     this.secondaryAction,
+    this.operatorTitle,
+    this.operatorBody,
   });
 
   final String title;
   final String body;
   final String primaryLabel;
   final _GuideAction primaryAction;
+  final RuntimeActionSafety actionSafety;
   final String? secondaryLabel;
   final _GuideAction? secondaryAction;
+  final String? operatorTitle;
+  final String? operatorBody;
 }
 
 class _ConnectionHomeCard extends StatelessWidget {
@@ -950,6 +968,40 @@ class _StateCalloutCard extends StatelessWidget {
   }
 }
 
+class _RuntimeTruthPill extends StatelessWidget {
+  const _RuntimeTruthPill({
+    required this.label,
+    required this.highlighted,
+  });
+
+  final String label;
+  final bool highlighted;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = highlighted ? Colors.orange : Colors.blueGrey;
+
+    return Semantics(
+      label: label,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.1),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: color.withValues(alpha: 0.25)),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: color,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _RuntimeSessionSummary extends StatelessWidget {
   const _RuntimeSessionSummary({required this.services});
 
@@ -966,12 +1018,57 @@ class _RuntimeSessionSummary extends StatelessWidget {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: session.needsAttention
+                    ? Colors.orange.withValues(alpha: 0.08)
+                    : Colors.blue.withValues(alpha: 0.06),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: session.needsAttention
+                      ? Colors.orange.withValues(alpha: 0.25)
+                      : Colors.blue.withValues(alpha: 0.2),
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 12,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: <Widget>[
+                      _RuntimeTruthPill(
+                        label: 'Session Truth: ${session.truth.label}',
+                        highlighted: session.needsAttention,
+                      ),
+                      _RuntimeTruthPill(
+                        label: 'Updated ${session.ageLabel}',
+                        highlighted: false,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    session.truthNote,
+                    style: const TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(session.recoveryGuidance),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
             Wrap(
               spacing: 24,
               runSpacing: 12,
               children: <Widget>[
                 KeyValuePair(
                     label: 'Running', value: session.isRunning ? 'Yes' : 'No'),
+                KeyValuePair(label: 'Runtime Truth', value: session.truth.label),
+                KeyValuePair(label: 'Snapshot Age', value: session.ageLabel),
                 KeyValuePair(label: 'Runtime Phase', value: session.phase.name),
                 KeyValuePair(
                   label: 'Stop Requested',

--- a/client/lib/features/diagnostics/application/diagnostics_export_service.dart
+++ b/client/lib/features/diagnostics/application/diagnostics_export_service.dart
@@ -29,6 +29,8 @@ class DiagnosticsExportService {
     required this.secureStorage,
     required this.fileExporter,
     AppRuntimeErrorStore? appRuntimeErrors,
+    this.adapterSelectionReason,
+    this.expectedRealRuntimePath,
   }) : appRuntimeErrors = appRuntimeErrors ?? AppRuntimeErrorStore();
 
   final ProfileStore profileStore;
@@ -39,6 +41,8 @@ class DiagnosticsExportService {
   final SecureStorage secureStorage;
   final DiagnosticsFileExporter fileExporter;
   final AppRuntimeErrorStore appRuntimeErrors;
+  final String? adapterSelectionReason;
+  final bool? expectedRealRuntimePath;
 
   Future<String> buildPreviewBundle() async {
     final selected = profileStore.selectedProfile;
@@ -80,6 +84,10 @@ class DiagnosticsExportService {
           'updatedAt': controllerHealth.updatedAt.toIso8601String(),
         },
         'runtimeSession': controller.session.toJson(),
+        'selection': {
+          'expectedRealRuntimePath': expectedRealRuntimePath,
+          'reason': adapterSelectionReason,
+        },
         'recentEvents': controller.recentEvents
             .map(
               (event) => <String, Object?>{

--- a/client/lib/features/diagnostics/application/diagnostics_export_service.dart
+++ b/client/lib/features/diagnostics/application/diagnostics_export_service.dart
@@ -4,6 +4,7 @@ import '../../../platform/secure_storage/secure_storage.dart';
 import '../../../platform/services/app_runtime_error_store.dart';
 import '../../../platform/services/diagnostics_file_exporter.dart';
 import '../../controller/application/client_controller_api.dart';
+import '../../controller/domain/controller_runtime_session.dart';
 import '../../controller/domain/runtime_posture.dart';
 import '../../packaging/application/packaging_store.dart';
 import '../../profiles/application/profile_portability_service.dart';
@@ -70,9 +71,13 @@ class DiagnosticsExportService {
     final keys = await secureStorage.listKeys();
     final controllerHealth = await controller.checkHealth();
     final readinessReport = await readiness.buildReport();
+    final controllerStatus = controller.status;
+    final controllerTelemetry = controller.telemetry;
+    final controllerRuntimeConfig = controller.runtimeConfig;
+    final runtimeSession = controller.session;
     final runtimePosture = describeRuntimePosture(
-      runtimeMode: controller.runtimeConfig.mode,
-      backendKind: controller.telemetry.backendKind,
+      runtimeMode: controllerRuntimeConfig.mode,
+      backendKind: controllerTelemetry.backendKind,
     );
     final releaseManifest = packagingStore.buildReleaseManifest();
     final updateMetadata = packagingStore.buildUpdateMetadataSnapshot();
@@ -95,23 +100,29 @@ class DiagnosticsExportService {
             },
       'readiness': readinessReport.toJson(),
       'controller': {
-        'phase': controller.status.phase.name,
-        'message': controller.status.message,
-        'activeProfileId': controller.status.activeProfileId,
-        'updatedAt': controller.status.updatedAt.toIso8601String(),
+        'phase': controllerStatus.phase.name,
+        'message': controllerStatus.message,
+        'activeProfileId': controllerStatus.activeProfileId,
+        'updatedAt': controllerStatus.updatedAt.toIso8601String(),
         'telemetry': {
-          'backendKind': controller.telemetry.backendKind,
-          'backendVersion': controller.telemetry.backendVersion,
-          'capabilities': controller.telemetry.capabilities,
-          'lastUpdatedAt': controller.telemetry.lastUpdatedAt.toIso8601String(),
+          'backendKind': controllerTelemetry.backendKind,
+          'backendVersion': controllerTelemetry.backendVersion,
+          'capabilities': controllerTelemetry.capabilities,
+          'lastUpdatedAt': controllerTelemetry.lastUpdatedAt.toIso8601String(),
         },
-        'runtimeConfig': controller.runtimeConfig.toJson(),
+        'runtimeConfig': controllerRuntimeConfig.toJson(),
         'runtimeHealth': {
           'level': controllerHealth.level.name,
           'summary': controllerHealth.summary,
           'updatedAt': controllerHealth.updatedAt.toIso8601String(),
         },
-        'runtimeSession': controller.session.toJson(),
+        'runtimeSession': {
+          ...runtimeSession.toJson(),
+          'truth': runtimeSession.truth.label,
+          'needsAttention': runtimeSession.needsAttention,
+          'truthNote': runtimeSession.truthNote,
+          'recoveryGuidance': runtimeSession.recoveryGuidance,
+        },
         'selection': {
           'expectedRealRuntimePath': expectedRealRuntimePath,
           'reason': adapterSelectionReason,

--- a/client/lib/features/diagnostics/application/diagnostics_export_service.dart
+++ b/client/lib/features/diagnostics/application/diagnostics_export_service.dart
@@ -123,6 +123,12 @@ class DiagnosticsExportService {
           'executionPath': runtimePosture.executionPathLabel,
           'truthNote': runtimePosture.truthNote,
           'evidenceNote': runtimePosture.evidenceGradeNote,
+          'artifactCapability': runtimePosture.artifactCapabilityLabel,
+          'artifactCapabilityNote': runtimePosture.artifactCapabilityNote,
+          'operatorGuidance': {
+            'heading': runtimePosture.operatorGuidanceHeading,
+            'checklist': runtimePosture.operatorChecklist,
+          },
         },
         'recentEvents': controller.recentEvents
             .map(

--- a/client/lib/features/diagnostics/application/diagnostics_export_service.dart
+++ b/client/lib/features/diagnostics/application/diagnostics_export_service.dart
@@ -4,6 +4,7 @@ import '../../../platform/secure_storage/secure_storage.dart';
 import '../../../platform/services/app_runtime_error_store.dart';
 import '../../../platform/services/diagnostics_file_exporter.dart';
 import '../../controller/application/client_controller_api.dart';
+import '../../controller/domain/runtime_posture.dart';
 import '../../packaging/application/packaging_store.dart';
 import '../../profiles/application/profile_portability_service.dart';
 import '../../profiles/application/profile_store.dart';
@@ -52,6 +53,10 @@ class DiagnosticsExportService {
     final keys = await secureStorage.listKeys();
     final controllerHealth = await controller.checkHealth();
     final readinessReport = await readiness.buildReport();
+    final runtimePosture = describeRuntimePosture(
+      runtimeMode: controller.runtimeConfig.mode,
+      backendKind: controller.telemetry.backendKind,
+    );
     final releaseManifest = packagingStore.buildReleaseManifest();
     final updateMetadata = packagingStore.buildUpdateMetadataSnapshot();
     final storageStatus = secureStorage.status;
@@ -92,6 +97,14 @@ class DiagnosticsExportService {
         'selection': {
           'expectedRealRuntimePath': expectedRealRuntimePath,
           'reason': adapterSelectionReason,
+        },
+        'runtimePosture': {
+          'kind': runtimePosture.kind.name,
+          'label': runtimePosture.postureLabel,
+          'evidenceGrade': runtimePosture.evidenceGradeLabel,
+          'executionPath': runtimePosture.executionPathLabel,
+          'truthNote': runtimePosture.truthNote,
+          'evidenceNote': runtimePosture.evidenceGradeNote,
         },
         'recentEvents': controller.recentEvents
             .map(

--- a/client/lib/features/diagnostics/application/diagnostics_export_service.dart
+++ b/client/lib/features/diagnostics/application/diagnostics_export_service.dart
@@ -48,7 +48,24 @@ class DiagnosticsExportService {
   final String? adapterSelectionReason;
   final bool? expectedRealRuntimePath;
 
-  Future<String> buildPreviewBundle() async {
+  Future<String> buildPreviewBundle() {
+    return _buildBundle(bundleKind: 'support-bundle');
+  }
+
+  Future<String> buildRuntimeProofArtifact() async {
+    final contents = await _buildBundle(bundleKind: 'runtime-proof-artifact');
+    final payload = jsonDecode(contents) as Map<String, dynamic>;
+    final runtimePosture = (payload['controller']
+        as Map<String, dynamic>)['runtimePosture'] as Map<String, dynamic>;
+    if (runtimePosture['evidenceGrade'] != 'Evidence-grade') {
+      throw StateError(
+        'Runtime-proof artifact export requires an Evidence-grade posture.',
+      );
+    }
+    return contents;
+  }
+
+  Future<String> _buildBundle({required String bundleKind}) async {
     final selected = profileStore.selectedProfile;
     final keys = await secureStorage.listKeys();
     final controllerHealth = await controller.checkHealth();
@@ -63,6 +80,7 @@ class DiagnosticsExportService {
     final appUnhandledError = appRuntimeErrors.lastUnhandledError;
 
     final payload = <String, Object?>{
+      'bundleKind': bundleKind,
       'generatedAt': DateTime.now().toIso8601String(),
       'profileCount': profileStore.profiles.length,
       'selectedProfile': selected == null
@@ -167,6 +185,16 @@ class DiagnosticsExportService {
     final timestamp = DateTime.now().toIso8601String().replaceAll(':', '-');
     final target = await fileExporter.exportText(
       fileName: 'trojan-pro-support-$timestamp.json',
+      contents: contents,
+    );
+    return DiagnosticsExportResult(target: target, contents: contents);
+  }
+
+  Future<DiagnosticsExportResult> exportRuntimeProofArtifact() async {
+    final contents = await buildRuntimeProofArtifact();
+    final timestamp = DateTime.now().toIso8601String().replaceAll(':', '-');
+    final target = await fileExporter.exportText(
+      fileName: 'trojan-pro-runtime-proof-$timestamp.json',
       contents: contents,
     );
     return DiagnosticsExportResult(target: target, contents: contents);

--- a/client/lib/features/diagnostics/application/diagnostics_export_service.dart
+++ b/client/lib/features/diagnostics/application/diagnostics_export_service.dart
@@ -7,6 +7,7 @@ import '../../controller/application/client_controller_api.dart';
 import '../../packaging/application/packaging_store.dart';
 import '../../profiles/application/profile_portability_service.dart';
 import '../../profiles/application/profile_store.dart';
+import '../../readiness/application/readiness_service.dart';
 import '../../settings/application/settings_store.dart';
 
 class DiagnosticsExportResult {
@@ -28,6 +29,7 @@ class DiagnosticsExportService {
     required this.controller,
     required this.secureStorage,
     required this.fileExporter,
+    required this.readiness,
     AppRuntimeErrorStore? appRuntimeErrors,
     this.adapterSelectionReason,
     this.expectedRealRuntimePath,
@@ -40,6 +42,7 @@ class DiagnosticsExportService {
   final ClientControllerApi controller;
   final SecureStorage secureStorage;
   final DiagnosticsFileExporter fileExporter;
+  final ReadinessService readiness;
   final AppRuntimeErrorStore appRuntimeErrors;
   final String? adapterSelectionReason;
   final bool? expectedRealRuntimePath;
@@ -48,6 +51,7 @@ class DiagnosticsExportService {
     final selected = profileStore.selectedProfile;
     final keys = await secureStorage.listKeys();
     final controllerHealth = await controller.checkHealth();
+    final readinessReport = await readiness.buildReport();
     final releaseManifest = packagingStore.buildReleaseManifest();
     final updateMetadata = packagingStore.buildUpdateMetadataSnapshot();
     final storageStatus = secureStorage.status;
@@ -66,6 +70,7 @@ class DiagnosticsExportService {
               'sni': selected.sni,
               'hasStoredPassword': selected.hasStoredPassword,
             },
+      'readiness': readinessReport.toJson(),
       'controller': {
         'phase': controller.status.phase.name,
         'message': controller.status.message,

--- a/client/lib/features/diagnostics/presentation/diagnostics_page.dart
+++ b/client/lib/features/diagnostics/presentation/diagnostics_page.dart
@@ -17,8 +17,9 @@ class DiagnosticsPage extends StatefulWidget {
 
 class _DiagnosticsPageState extends State<DiagnosticsPage> {
   String _preview =
-      'Press “Generate preview” to build a support bundle payload.';
+      'Press “Generate support preview” to build a support bundle payload.';
   String? _lastExportTarget;
+  String? _lastExportKindLabel;
   SupportIssueDescriptor? _lastExportIssue;
   bool _busy = false;
 
@@ -28,13 +29,6 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
       runtimeMode: widget.services.controller.runtimeConfig.mode,
       backendKind: widget.services.controller.telemetry.backendKind,
     );
-
-    final previewLabel = runtimePosture.canProduceRuntimeProofArtifact
-        ? 'Generate preview'
-        : 'Generate support preview';
-    final exportLabel = runtimePosture.canProduceRuntimeProofArtifact
-        ? 'Export bundle'
-        : 'Export support bundle';
 
     return SingleChildScrollView(
       child: SectionCard(
@@ -58,14 +52,22 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
             OutlinedButton.icon(
               onPressed: _preview.startsWith('Press “Generate') || _busy
                   ? null
-                  : _export,
+                  : _exportSupportBundle,
               icon: const Icon(Icons.save_alt),
-              label: Text(exportLabel),
+              label: const Text('Export support bundle'),
             ),
+            if (runtimePosture.canProduceRuntimeProofArtifact)
+              OutlinedButton.icon(
+                onPressed: _preview.startsWith('Press “Generate') || _busy
+                    ? null
+                    : _exportRuntimeProofArtifact,
+                icon: const Icon(Icons.verified_outlined),
+                label: const Text('Export runtime-proof artifact'),
+              ),
             FilledButton.icon(
               onPressed: _busy ? null : _generate,
               icon: const Icon(Icons.download),
-              label: Text(previewLabel),
+              label: const Text('Generate support preview'),
             ),
           ],
         ),
@@ -79,7 +81,9 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
             ),
             const SizedBox(height: 16),
             if (_lastExportTarget != null) ...<Widget>[
-              Text('Last export target: $_lastExportTarget'),
+              Text(
+                'Last export target (${_lastExportKindLabel ?? 'support bundle'}): $_lastExportTarget',
+              ),
               const SizedBox(height: 12),
             ],
             if (_lastExportIssue != null) ...<Widget>[
@@ -129,7 +133,7 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
     }
   }
 
-  Future<void> _export() async {
+  Future<void> _exportSupportBundle() async {
     setState(() => _busy = true);
     try {
       final result = await widget.services.diagnostics.exportSupportBundle();
@@ -137,6 +141,7 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
       setState(() {
         _preview = result.contents;
         _lastExportTarget = result.target;
+        _lastExportKindLabel = 'support bundle';
         _lastExportIssue = null;
       });
     } catch (error) {
@@ -147,6 +152,42 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
       });
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Failed to export diagnostics bundle: $error')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _busy = false);
+      }
+    }
+  }
+
+  Future<void> _exportRuntimeProofArtifact() async {
+    setState(() => _busy = true);
+    try {
+      final result =
+          await widget.services.diagnostics.exportRuntimeProofArtifact();
+      if (!mounted) return;
+      setState(() {
+        _lastExportTarget = result.target;
+        _lastExportKindLabel = 'runtime-proof artifact';
+        _lastExportIssue = null;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Runtime-proof artifact exported to ${result.target}.',
+          ),
+        ),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      final issue = SupportIssueDescriptor.fromExportError(error);
+      setState(() {
+        _lastExportIssue = issue;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Failed to export runtime-proof artifact: $error'),
+        ),
       );
     } finally {
       if (mounted) {

--- a/client/lib/features/diagnostics/presentation/diagnostics_page.dart
+++ b/client/lib/features/diagnostics/presentation/diagnostics_page.dart
@@ -2,9 +2,12 @@ import 'package:flutter/material.dart';
 
 import '../../../core/widgets/section_card.dart';
 import '../../../platform/services/service_registry.dart';
+import '../../controller/domain/controller_runtime_session.dart';
+import '../../controller/domain/runtime_operator_advice.dart';
 import '../../controller/domain/runtime_posture.dart';
 import '../application/support_issue_descriptor.dart';
 import '../../profiles/presentation/import_export_dialog.dart';
+import 'diagnostics_support_policy.dart';
 
 class DiagnosticsPage extends StatefulWidget {
   const DiagnosticsPage({super.key, required this.services});
@@ -21,6 +24,8 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
   String? _lastExportTarget;
   String? _lastExportKindLabel;
   SupportIssueDescriptor? _lastExportIssue;
+  ControllerRuntimeSession? _lastExportRuntimeSession;
+  DateTime? _lastExportCapturedAt;
   bool _busy = false;
 
   @override
@@ -28,6 +33,21 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
     final runtimePosture = describeRuntimePosture(
       runtimeMode: widget.services.controller.runtimeConfig.mode,
       backendKind: widget.services.controller.telemetry.backendKind,
+    );
+    final runtimeSession = widget.services.controller.session;
+    final operatorAdvice = RuntimeOperatorAdvice.resolve(
+      status: widget.services.controller.status,
+      session: runtimeSession,
+      posture: runtimePosture,
+      troubleshootingAvailable: true,
+    );
+
+    final supportPolicy = DiagnosticsSupportPolicy.resolve(
+      runtimeSession: runtimeSession,
+      runtimePosture: runtimePosture,
+      operatorAdvice: operatorAdvice,
+      exportedRuntimeSession: _lastExportRuntimeSession,
+      exportedBundleKindLabel: _lastExportKindLabel,
     );
 
     return SingleChildScrollView(
@@ -80,6 +100,13 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
               runtimePosture: runtimePosture,
             ),
             const SizedBox(height: 16),
+            _RuntimeTruthSupportCard(
+              runtimeSession: runtimeSession,
+              runtimePosture: runtimePosture,
+              supportPolicy: supportPolicy,
+              exportCapturedAt: _lastExportCapturedAt,
+            ),
+            const SizedBox(height: 16),
             if (_lastExportTarget != null) ...<Widget>[
               Text(
                 'Last export target (${_lastExportKindLabel ?? 'support bundle'}): $_lastExportTarget',
@@ -115,10 +142,14 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
     setState(() => _busy = true);
     try {
       final preview = await widget.services.diagnostics.buildPreviewBundle();
+      final capturedSession = widget.services.controller.session;
       if (!mounted) return;
       setState(() {
         _preview = preview;
         _lastExportIssue = null;
+        _lastExportRuntimeSession = capturedSession;
+        _lastExportCapturedAt = DateTime.now();
+        _lastExportKindLabel = 'support preview';
       });
     } catch (error) {
       if (!mounted) return;
@@ -137,12 +168,15 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
     setState(() => _busy = true);
     try {
       final result = await widget.services.diagnostics.exportSupportBundle();
+      final capturedSession = widget.services.controller.session;
       if (!mounted) return;
       setState(() {
         _preview = result.contents;
         _lastExportTarget = result.target;
         _lastExportKindLabel = 'support bundle';
         _lastExportIssue = null;
+        _lastExportRuntimeSession = capturedSession;
+        _lastExportCapturedAt = DateTime.now();
       });
     } catch (error) {
       if (!mounted) return;
@@ -165,11 +199,14 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
     try {
       final result =
           await widget.services.diagnostics.exportRuntimeProofArtifact();
+      final capturedSession = widget.services.controller.session;
       if (!mounted) return;
       setState(() {
         _lastExportTarget = result.target;
         _lastExportKindLabel = 'runtime-proof artifact';
         _lastExportIssue = null;
+        _lastExportRuntimeSession = capturedSession;
+        _lastExportCapturedAt = DateTime.now();
       });
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -226,6 +263,167 @@ class _ExportIssueBanner extends StatelessWidget {
           Text(issue.guidance),
           const SizedBox(height: 6),
           Text('Detail: ${issue.summary}'),
+        ],
+      ),
+    );
+  }
+}
+
+class _RuntimeTruthSupportCard extends StatelessWidget {
+  const _RuntimeTruthSupportCard({
+    required this.runtimeSession,
+    required this.runtimePosture,
+    required this.supportPolicy,
+    this.exportCapturedAt,
+  });
+
+  final ControllerRuntimeSession runtimeSession;
+  final RuntimePosture runtimePosture;
+  final DiagnosticsSupportPolicy supportPolicy;
+  final DateTime? exportCapturedAt;
+
+  @override
+  Widget build(BuildContext context) {
+    final attentionColor = runtimeSession.needsAttention
+        ? Colors.orange
+        : Theme.of(context).colorScheme.primary;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: attentionColor.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: attentionColor.withValues(alpha: 0.22)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            'Runtime truth & recovery',
+            style: Theme.of(context)
+                .textTheme
+                .titleSmall
+                ?.copyWith(fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Support output should explain whether the runtime looks live, stale, or residual before you export anything.',
+          ),
+          const SizedBox(height: 12),
+          Text(
+            supportPolicy.currentTruthTitle,
+            style: const TextStyle(fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 6),
+          Text('Snapshot age: ${runtimeSession.ageLabel}'),
+          const SizedBox(height: 6),
+          Text('Needs attention: ${runtimeSession.needsAttention ? 'Yes' : 'No'}'),
+          if (supportPolicy.exportSnapshotLabel != null) ...<Widget>[
+            const SizedBox(height: 12),
+            Text(
+              'Last captured export snapshot',
+              style: TextStyle(
+                fontWeight: FontWeight.w700,
+                color: attentionColor,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(supportPolicy.exportSnapshotLabel!),
+            if (exportCapturedAt != null)
+              Text('Captured at: ${exportCapturedAt!.toIso8601String()}'),
+            const SizedBox(height: 6),
+            Text(supportPolicy.exportSnapshotDetail!),
+          ],
+          const SizedBox(height: 12),
+          Text(
+            supportPolicy.currentTruthSubtitle,
+            style: const TextStyle(fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 6),
+          Text(supportPolicy.currentTruthMessage),
+          if (supportPolicy.showExitConfirmationWarning) ...<Widget>[
+            const SizedBox(height: 12),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.orange.withValues(alpha: 0.1),
+                borderRadius: const BorderRadius.all(Radius.circular(12)),
+                border: Border.all(color: Colors.orange.withValues(alpha: 0.24)),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    supportPolicy.exitConfirmationTitle ??
+                        'Exit confirmation pending',
+                    style: const TextStyle(fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(supportPolicy.exitConfirmationBody!),
+                ],
+              ),
+            ),
+          ],
+          const SizedBox(height: 12),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.indigo.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: Colors.indigo.withValues(alpha: 0.2)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                const Text(
+                  'Action safety',
+                  style: TextStyle(fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: 6),
+                Text(supportPolicy.actionSafety.label),
+                const SizedBox(height: 4),
+                Text(supportPolicy.actionSafety.detail),
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.06),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: Theme.of(context)
+                    .colorScheme
+                    .primary
+                    .withValues(alpha: 0.18),
+              ),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  supportPolicy.primaryOperatorTitle,
+                  style: const TextStyle(fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: 6),
+                Text(supportPolicy.primaryOperatorBody),
+                if (supportPolicy.preferredEvidenceActionLabel != null) ...<Widget>[
+                  const SizedBox(height: 8),
+                  Text(
+                    'Preferred evidence action: ${supportPolicy.preferredEvidenceActionLabel}',
+                    style: const TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(supportPolicy.postureGuidance),
         ],
       ),
     );

--- a/client/lib/features/diagnostics/presentation/diagnostics_page.dart
+++ b/client/lib/features/diagnostics/presentation/diagnostics_page.dart
@@ -279,6 +279,18 @@ class _SupportBundleSummaryCard extends StatelessWidget {
           const SizedBox(height: 6),
           Text(runtimePosture.artifactCapabilityNote),
           const SizedBox(height: 12),
+          Text(
+            runtimePosture.operatorGuidanceHeading,
+            style: const TextStyle(fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 8),
+          ...runtimePosture.operatorChecklist.map(
+            (item) => Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Text('• $item'),
+            ),
+          ),
+          const SizedBox(height: 12),
           const Text('Includes'),
           const SizedBox(height: 4),
           const Text(

--- a/client/lib/features/diagnostics/presentation/diagnostics_page.dart
+++ b/client/lib/features/diagnostics/presentation/diagnostics_page.dart
@@ -29,6 +29,13 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
       backendKind: widget.services.controller.telemetry.backendKind,
     );
 
+    final previewLabel = runtimePosture.canProduceRuntimeProofArtifact
+        ? 'Generate preview'
+        : 'Generate support preview';
+    final exportLabel = runtimePosture.canProduceRuntimeProofArtifact
+        ? 'Export bundle'
+        : 'Export support bundle';
+
     return SingleChildScrollView(
       child: SectionCard(
         title: 'Problem Report',
@@ -53,12 +60,12 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
                   ? null
                   : _export,
               icon: const Icon(Icons.save_alt),
-              label: const Text('Export bundle'),
+              label: Text(exportLabel),
             ),
             FilledButton.icon(
               onPressed: _busy ? null : _generate,
               icon: const Icon(Icons.download),
-              label: const Text('Generate preview'),
+              label: Text(previewLabel),
             ),
           ],
         ),
@@ -223,6 +230,13 @@ class _SupportBundleSummaryCard extends StatelessWidget {
           ),
           const SizedBox(height: 6),
           Text(runtimePosture.evidenceGradeNote),
+          const SizedBox(height: 12),
+          Text(
+            runtimePosture.artifactCapabilityLabel,
+            style: const TextStyle(fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 6),
+          Text(runtimePosture.artifactCapabilityNote),
           const SizedBox(height: 12),
           const Text('Includes'),
           const SizedBox(height: 4),

--- a/client/lib/features/diagnostics/presentation/diagnostics_page.dart
+++ b/client/lib/features/diagnostics/presentation/diagnostics_page.dart
@@ -15,45 +15,47 @@ class DiagnosticsPage extends StatefulWidget {
 }
 
 class _DiagnosticsPageState extends State<DiagnosticsPage> {
-  String _preview = 'Press “Generate preview” to build a support bundle payload.';
+  String _preview =
+      'Press “Generate preview” to build a support bundle payload.';
   String? _lastExportTarget;
   SupportIssueDescriptor? _lastExportIssue;
   bool _busy = false;
 
   @override
   Widget build(BuildContext context) {
-    return SectionCard(
-      title: 'Problem Report',
-      subtitle:
-          'Create a support-ready snapshot when something goes wrong. Use this when you need to inspect a failure or share a support bundle. Export backend: ${widget.services.diagnosticsFileExporter.backendName}',
-      trailing: Wrap(
-        spacing: 8,
-        children: <Widget>[
-          OutlinedButton(
-            onPressed: _preview.startsWith('Press “Generate')
-                ? null
-                : () => showExportTextDialog(
-                      context,
-                      title: 'Diagnostics Preview JSON',
-                      text: _preview,
-                    ),
-            child: const Text('Open full JSON'),
-          ),
-          OutlinedButton.icon(
-            onPressed: _preview.startsWith('Press “Generate') || _busy
-                ? null
-                : _export,
-            icon: const Icon(Icons.save_alt),
-            label: const Text('Export bundle'),
-          ),
-          FilledButton.icon(
-            onPressed: _busy ? null : _generate,
-            icon: const Icon(Icons.download),
-            label: const Text('Generate preview'),
-          ),
-        ],
-      ),
-      child: SingleChildScrollView(
+    return SingleChildScrollView(
+      child: SectionCard(
+        title: 'Problem Report',
+        subtitle:
+            'Create a support-ready snapshot when something goes wrong. Use this when you need to inspect a failure or share a support bundle. Export backend: ${widget.services.diagnosticsFileExporter.backendName}',
+        trailing: Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: <Widget>[
+            OutlinedButton(
+              onPressed: _preview.startsWith('Press “Generate')
+                  ? null
+                  : () => showExportTextDialog(
+                        context,
+                        title: 'Diagnostics Preview JSON',
+                        text: _preview,
+                      ),
+              child: const Text('Open full JSON'),
+            ),
+            OutlinedButton.icon(
+              onPressed: _preview.startsWith('Press “Generate') || _busy
+                  ? null
+                  : _export,
+              icon: const Icon(Icons.save_alt),
+              label: const Text('Export bundle'),
+            ),
+            FilledButton.icon(
+              onPressed: _busy ? null : _generate,
+              icon: const Icon(Icons.download),
+              label: const Text('Generate preview'),
+            ),
+          ],
+        ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[

--- a/client/lib/features/diagnostics/presentation/diagnostics_page.dart
+++ b/client/lib/features/diagnostics/presentation/diagnostics_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../core/widgets/section_card.dart';
 import '../../../platform/services/service_registry.dart';
+import '../../controller/domain/runtime_posture.dart';
 import '../application/support_issue_descriptor.dart';
 import '../../profiles/presentation/import_export_dialog.dart';
 
@@ -23,6 +24,11 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
 
   @override
   Widget build(BuildContext context) {
+    final runtimePosture = describeRuntimePosture(
+      runtimeMode: widget.services.controller.runtimeConfig.mode,
+      backendKind: widget.services.controller.telemetry.backendKind,
+    );
+
     return SingleChildScrollView(
       child: SectionCard(
         title: 'Problem Report',
@@ -62,6 +68,7 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
             _SupportBundleSummaryCard(
               exportBackend:
                   widget.services.diagnosticsFileExporter.backendName,
+              runtimePosture: runtimePosture,
             ),
             const SizedBox(height: 16),
             if (_lastExportTarget != null) ...<Widget>[
@@ -178,9 +185,13 @@ class _ExportIssueBanner extends StatelessWidget {
 }
 
 class _SupportBundleSummaryCard extends StatelessWidget {
-  const _SupportBundleSummaryCard({required this.exportBackend});
+  const _SupportBundleSummaryCard({
+    required this.exportBackend,
+    required this.runtimePosture,
+  });
 
   final String exportBackend;
+  final RuntimePosture runtimePosture;
 
   @override
   Widget build(BuildContext context) {
@@ -205,6 +216,13 @@ class _SupportBundleSummaryCard extends StatelessWidget {
           const Text(
             'Use this when a connection test fails, the runtime exits unexpectedly, or you want to share a support-ready snapshot.',
           ),
+          const SizedBox(height: 12),
+          Text(
+            'Current evidence grade: ${runtimePosture.evidenceGradeLabel}',
+            style: const TextStyle(fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 6),
+          Text(runtimePosture.evidenceGradeNote),
           const SizedBox(height: 12),
           const Text('Includes'),
           const SizedBox(height: 4),

--- a/client/lib/features/diagnostics/presentation/diagnostics_support_policy.dart
+++ b/client/lib/features/diagnostics/presentation/diagnostics_support_policy.dart
@@ -1,0 +1,119 @@
+import '../../controller/domain/client_connection_status.dart';
+import '../../controller/domain/controller_runtime_session.dart';
+import '../../controller/domain/runtime_action_matrix.dart';
+import '../../controller/domain/runtime_action_safety.dart';
+import '../../controller/domain/runtime_operator_advice.dart';
+import '../../controller/domain/runtime_posture.dart';
+
+class DiagnosticsSupportPolicy {
+  const DiagnosticsSupportPolicy({
+    required this.currentTruthTitle,
+    required this.currentTruthSubtitle,
+    required this.currentTruthMessage,
+    required this.actionSafety,
+    required this.showExitConfirmationWarning,
+    required this.exitConfirmationTitle,
+    required this.exitConfirmationBody,
+    required this.primaryOperatorTitle,
+    required this.primaryOperatorBody,
+    required this.preferredEvidenceActionLabel,
+    required this.postureGuidance,
+    required this.exportSnapshotLabel,
+    required this.exportSnapshotDetail,
+  });
+
+  final String currentTruthTitle;
+  final String currentTruthSubtitle;
+  final String currentTruthMessage;
+  final RuntimeActionSafety actionSafety;
+  final bool showExitConfirmationWarning;
+  final String? exitConfirmationTitle;
+  final String? exitConfirmationBody;
+  final String primaryOperatorTitle;
+  final String primaryOperatorBody;
+  final String? preferredEvidenceActionLabel;
+  final String postureGuidance;
+  final String? exportSnapshotLabel;
+  final String? exportSnapshotDetail;
+
+  static DiagnosticsSupportPolicy resolve({
+    required ControllerRuntimeSession runtimeSession,
+    required RuntimePosture runtimePosture,
+    required RuntimeOperatorAdvice operatorAdvice,
+    required ControllerRuntimeSession? exportedRuntimeSession,
+    required String? exportedBundleKindLabel,
+  }) {
+    final exportSnapshotAdvice = exportedRuntimeSession == null
+        ? RuntimeOperatorAdvice.none
+        : RuntimeOperatorAdvice.resolve(
+            status: ClientConnectionStatus(
+              phase: exportedRuntimeSession.truth ==
+                      ControllerRuntimeSessionTruth.stopping
+                  ? ClientConnectionPhase.disconnecting
+                  : ClientConnectionPhase.connected,
+              message: exportedRuntimeSession.truthNote,
+              updatedAt: exportedRuntimeSession.updatedAt,
+              activeProfileId: null,
+            ),
+            session: exportedRuntimeSession,
+            posture: runtimePosture,
+            troubleshootingAvailable: true,
+          );
+
+    final actionSafety = RuntimeActionSafety.resolve(
+      status: ClientConnectionStatus(
+        phase: runtimeSession.truth == ControllerRuntimeSessionTruth.stopping
+            ? ClientConnectionPhase.disconnecting
+            : ClientConnectionPhase.connected,
+        message: runtimeSession.truthNote,
+        updatedAt: runtimeSession.updatedAt,
+        activeProfileId: null,
+      ),
+      session: runtimeSession,
+      posture: runtimePosture,
+    );
+    final actionMatrix = RuntimeActionMatrix.fromResolved(
+      actionSafety: actionSafety,
+      operatorAdvice: operatorAdvice,
+    );
+
+    return DiagnosticsSupportPolicy(
+      currentTruthTitle: 'Current runtime truth: ${runtimeSession.truth.label}',
+      currentTruthSubtitle: runtimeSession.truthNote,
+      currentTruthMessage:
+          operatorAdvice.message ?? runtimeSession.recoveryGuidance,
+      actionSafety: actionSafety,
+      showExitConfirmationWarning: actionMatrix.secondaryStateChangeContract ==
+          RuntimeSecondaryStateChangeContract.withholdFallback,
+      exitConfirmationTitle:
+          operatorAdvice.headline ?? 'Exit confirmation pending',
+      exitConfirmationBody: operatorAdvice.message ??
+          'Do not treat this runtime as fully closed yet. Wait for exit confirmation or export the current support snapshot before retrying.',
+      primaryOperatorTitle: actionMatrix.evidenceCaptureContract ==
+              RuntimeEvidenceCaptureContract.preferBeforeMutation
+          ? 'Recommended right now: capture a support snapshot first'
+          : 'Recommended right now',
+      primaryOperatorBody: actionMatrix.nextStepContract ==
+              RuntimeNextStepContract.captureSupportEvidence
+          ? 'Generate a support preview or export a support bundle before you retry or assume shutdown has finished. This preserves the stop-pending evidence while it is still current.'
+          : 'Use the preview/export actions below to capture the current runtime evidence before making bigger changes.',
+      preferredEvidenceActionLabel:
+          actionMatrix.preferredEvidenceAction ==
+                  RuntimePreferredEvidenceAction.generateSupportPreview
+              ? 'Generate support preview'
+              : actionMatrix.preferredEvidenceAction ==
+                      RuntimePreferredEvidenceAction.exportSupportBundle
+                  ? 'Export support bundle'
+                  : null,
+      postureGuidance: runtimePosture.isRuntimeTrue
+          ? 'This posture can contribute runtime-true evidence if the snapshot stays current.'
+          : 'This posture is still ${runtimePosture.postureLabel.toLowerCase()}, so export the bundle as support context rather than proof of a real runtime path.',
+      exportSnapshotLabel: exportedRuntimeSession == null
+          ? null
+          : '${exportedBundleKindLabel ?? 'latest export'} captured ${exportedRuntimeSession.truth.label}',
+      exportSnapshotDetail: exportedRuntimeSession == null
+          ? null
+          : 'Export snapshot age at capture: ${exportedRuntimeSession.ageLabel}. ${exportSnapshotAdvice.message ?? exportedRuntimeSession.recoveryGuidance}',
+    );
+  }
+}

--- a/client/lib/features/packaging/presentation/packaging_page.dart
+++ b/client/lib/features/packaging/presentation/packaging_page.dart
@@ -205,16 +205,23 @@ class PackagingPage extends StatelessWidget {
   }
 
   Widget _kv(String label, String value) {
-    return SizedBox(
-      width: 240,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Text(label, style: const TextStyle(fontWeight: FontWeight.w600)),
-          const SizedBox(height: 4),
-          Text(value),
-        ],
-      ),
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final maxWidth =
+            constraints.maxWidth.isFinite ? constraints.maxWidth : 240.0;
+        final width = maxWidth < 520 ? maxWidth : 240.0;
+        return SizedBox(
+          width: width,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(label, style: const TextStyle(fontWeight: FontWeight.w600)),
+              const SizedBox(height: 4),
+              Text(value),
+            ],
+          ),
+        );
+      },
     );
   }
 }
@@ -241,15 +248,47 @@ class _ExportHistoryRow extends StatelessWidget {
       PackagingExportStatus.failed => record.error ?? 'Unknown export failure',
     };
 
-    return ListTile(
-      contentPadding: EdgeInsets.zero,
-      leading: Icon(icon),
-      title: Text(record.status.name),
-      subtitle: Text(summary),
-      trailing: Text(
-        record.finishedAt?.toIso8601String() ??
-            record.startedAt.toIso8601String(),
-      ),
+    final timestamp = record.finishedAt?.toIso8601String() ??
+        record.startedAt.toIso8601String();
+
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final useStackedLayout = constraints.maxWidth < 560;
+        if (useStackedLayout) {
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Icon(icon),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        record.status.name,
+                        style: const TextStyle(fontWeight: FontWeight.w600),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Text(summary),
+                const SizedBox(height: 8),
+                Text(timestamp),
+              ],
+            ),
+          );
+        }
+
+        return ListTile(
+          contentPadding: EdgeInsets.zero,
+          leading: Icon(icon),
+          title: Text(record.status.name),
+          subtitle: Text(summary),
+          trailing: Text(timestamp),
+        );
+      },
     );
   }
 }
@@ -267,12 +306,44 @@ class _PlatformPackageRow extends StatelessWidget {
       DesktopPackageReadiness.validated => Icons.verified,
     };
 
-    return ListTile(
-      contentPadding: EdgeInsets.zero,
-      leading: Icon(icon),
-      title: Text(status.platform.name),
-      subtitle: Text(status.notes),
-      trailing: Text(status.readiness.name),
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final useStackedLayout = constraints.maxWidth < 560;
+        if (useStackedLayout) {
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Icon(icon),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        status.platform.name,
+                        style: const TextStyle(fontWeight: FontWeight.w600),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Text(status.notes),
+                const SizedBox(height: 8),
+                Text('Readiness: ${status.readiness.name}'),
+              ],
+            ),
+          );
+        }
+
+        return ListTile(
+          contentPadding: EdgeInsets.zero,
+          leading: Icon(icon),
+          title: Text(status.platform.name),
+          subtitle: Text(status.notes),
+          trailing: Text(status.readiness.name),
+        );
+      },
     );
   }
 }

--- a/client/lib/features/profiles/presentation/profile_connection_action_policy.dart
+++ b/client/lib/features/profiles/presentation/profile_connection_action_policy.dart
@@ -1,0 +1,180 @@
+import '../../controller/domain/client_connection_status.dart';
+import '../../controller/domain/controller_runtime_session.dart';
+import '../../controller/domain/runtime_action_matrix.dart';
+import '../../controller/domain/runtime_action_safety.dart';
+import '../../controller/domain/runtime_operator_advice.dart';
+import '../../controller/domain/runtime_posture.dart';
+import '../../readiness/domain/readiness_report.dart';
+
+enum ProfileConnectionPrimaryAction {
+  connect,
+  disconnect,
+  openTroubleshooting,
+  none,
+}
+
+class ProfileConnectionActionPolicy {
+  const ProfileConnectionActionPolicy({
+    required this.canToggleConnection,
+    required this.buttonEnabled,
+    required this.buttonLabel,
+    required this.statusHint,
+    required this.primaryAction,
+    required this.actionableSessionTruth,
+    required this.actionSafety,
+  });
+
+  final bool canToggleConnection;
+  final bool buttonEnabled;
+  final String buttonLabel;
+  final String statusHint;
+  final ProfileConnectionPrimaryAction primaryAction;
+  final bool actionableSessionTruth;
+  final RuntimeActionSafety actionSafety;
+
+  static ProfileConnectionActionPolicy resolve({
+    required bool hasStoredPassword,
+    required bool active,
+    required ClientConnectionStatus status,
+    required RuntimePosture runtimePosture,
+    required ControllerRuntimeSession runtimeSession,
+    required ReadinessReport? readinessReport,
+    required bool hasConnectedElsewhere,
+    required bool onOpenAdvancedAvailable,
+  }) {
+    final connectBlockedByReadiness = readinessReport != null &&
+        readinessReport.overallLevel == ReadinessLevel.blocked &&
+        !(active && status.phase == ClientConnectionPhase.connected);
+
+    final actionSafety = RuntimeActionSafety.resolve(
+      status: status,
+      session: runtimeSession,
+      posture: runtimePosture,
+    );
+    final operatorAdvice = active
+        ? RuntimeOperatorAdvice.resolve(
+            status: status,
+            session: runtimeSession,
+            posture: runtimePosture,
+            troubleshootingAvailable: onOpenAdvancedAvailable,
+          )
+        : RuntimeOperatorAdvice.none;
+    final actionMatrix = RuntimeActionMatrix.fromResolved(
+      actionSafety: actionSafety,
+      operatorAdvice: operatorAdvice,
+    );
+    final actionableSessionTruth = operatorAdvice.actionableSessionTruth;
+
+    if (!hasStoredPassword) {
+      return ProfileConnectionActionPolicy(
+        canToggleConnection: false,
+        buttonEnabled: false,
+        buttonLabel: 'Set Password First',
+        statusHint: 'Save the Trojan password before trying this profile.',
+        primaryAction: ProfileConnectionPrimaryAction.none,
+        actionableSessionTruth: false,
+        actionSafety: actionSafety,
+      );
+    }
+
+    if (hasConnectedElsewhere) {
+      return ProfileConnectionActionPolicy(
+        canToggleConnection: false,
+        buttonEnabled: false,
+        buttonLabel: 'Connected Elsewhere',
+        statusHint:
+            'Another profile is already connected. Disconnect it before switching here.',
+        primaryAction: ProfileConnectionPrimaryAction.none,
+        actionableSessionTruth: false,
+        actionSafety: actionSafety,
+      );
+    }
+
+    if (connectBlockedByReadiness) {
+      return ProfileConnectionActionPolicy(
+        canToggleConnection: false,
+        buttonEnabled: false,
+        buttonLabel: 'Connect Blocked',
+        statusHint: 'Readiness blocked: ${readinessReport.summary}',
+        primaryAction: ProfileConnectionPrimaryAction.none,
+        actionableSessionTruth: actionableSessionTruth,
+        actionSafety: actionSafety,
+      );
+    }
+
+    if (active && status.phase == ClientConnectionPhase.connected) {
+      if (actionableSessionTruth) {
+        return ProfileConnectionActionPolicy(
+          canToggleConnection: false,
+          buttonEnabled: actionMatrix.primaryActionContract ==
+              RuntimePrimaryActionContract.preferTroubleshooting,
+          buttonLabel:
+              operatorAdvice.kind == RuntimeOperatorAdviceKind.revalidateInTroubleshooting
+                  ? 'Revalidate in Troubleshooting'
+                  : (operatorAdvice.primaryLabel ?? 'Open Troubleshooting'),
+          statusHint: operatorAdvice.message ??
+              '${runtimeSession.truthNote} ${runtimeSession.recoveryGuidance}',
+          primaryAction: actionMatrix.preferredOperatorAction ==
+                  RuntimePreferredOperatorAction.openTroubleshooting
+              ? ProfileConnectionPrimaryAction.openTroubleshooting
+              : ProfileConnectionPrimaryAction.none,
+          actionableSessionTruth: true,
+          actionSafety: actionSafety,
+        );
+      }
+
+      return ProfileConnectionActionPolicy(
+        canToggleConnection: true,
+        buttonEnabled: true,
+        buttonLabel: 'Disconnect',
+        statusHint: 'Connected via fake controller boundary',
+        primaryAction: ProfileConnectionPrimaryAction.disconnect,
+        actionableSessionTruth: false,
+        actionSafety: actionSafety,
+      );
+    }
+
+    if (active && status.phase == ClientConnectionPhase.connecting) {
+      return ProfileConnectionActionPolicy(
+        canToggleConnection: false,
+        buttonEnabled: false,
+        buttonLabel: 'Connecting...',
+        statusHint: operatorAdvice.message ??
+            'This profile is still establishing a runtime session.',
+        primaryAction: ProfileConnectionPrimaryAction.none,
+        actionableSessionTruth: actionableSessionTruth,
+        actionSafety: actionSafety,
+      );
+    }
+
+    if (active && status.phase == ClientConnectionPhase.disconnecting) {
+      return ProfileConnectionActionPolicy(
+        canToggleConnection: false,
+        buttonEnabled: actionMatrix.primaryActionContract ==
+            RuntimePrimaryActionContract.preferTroubleshooting,
+        buttonLabel: actionMatrix.primaryActionContract ==
+                RuntimePrimaryActionContract.preferTroubleshooting
+            ? (operatorAdvice.primaryLabel ?? 'Open Troubleshooting')
+            : 'Disconnecting...',
+        statusHint: operatorAdvice.message ??
+            'This profile is disconnecting now. Wait for the shutdown to finish.',
+        primaryAction: actionMatrix.preferredOperatorAction ==
+                RuntimePreferredOperatorAction.openTroubleshooting
+            ? ProfileConnectionPrimaryAction.openTroubleshooting
+            : ProfileConnectionPrimaryAction.none,
+        actionableSessionTruth: actionableSessionTruth,
+        actionSafety: actionSafety,
+      );
+    }
+
+    return ProfileConnectionActionPolicy(
+      canToggleConnection: true,
+      buttonEnabled: true,
+      buttonLabel: runtimePosture.qualifyAction('Connect'),
+      statusHint: status.message,
+      primaryAction: ProfileConnectionPrimaryAction.connect,
+      actionableSessionTruth: actionableSessionTruth,
+      actionSafety: actionSafety,
+    );
+  }
+}

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -5,7 +5,10 @@ import 'package:flutter/material.dart';
 import '../../../core/widgets/section_card.dart';
 import '../../../platform/services/service_registry.dart';
 import '../../controller/domain/client_connection_status.dart';
+import '../../controller/domain/controller_runtime_session.dart';
+import '../../controller/domain/runtime_action_feedback.dart';
 import '../../controller/domain/runtime_posture.dart';
+import 'profile_connection_action_policy.dart';
 import '../../readiness/domain/readiness_refresh_fingerprint.dart';
 import '../../readiness/domain/readiness_report.dart';
 import '../../readiness/presentation/readiness_surface_controller.dart';
@@ -273,62 +276,24 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
   bool get _hasConnectedElsewhere =>
       !_active && status.phase == ClientConnectionPhase.connected;
 
-  bool get _connectBlockedByReadiness {
-    final report = _readinessController.latestReport;
-    if (report == null) return false;
-    final isConnectAction =
-        !(_active && status.phase == ClientConnectionPhase.connected);
-    return isConnectAction && report.overallLevel == ReadinessLevel.blocked;
-  }
+  ControllerRuntimeSession get _runtimeSession => services.controller.session;
 
-  bool get _canToggleConnection {
-    if (!selected.hasStoredPassword) return false;
-    if (status.isBusy) return false;
-    if (_hasConnectedElsewhere) return false;
-    if (_connectBlockedByReadiness) return false;
-    return true;
-  }
+  RuntimePosture get _runtimePosture => describeRuntimePosture(
+        runtimeMode: services.controller.runtimeConfig.mode,
+        backendKind: services.controller.telemetry.backendKind,
+      );
 
-  String get _connectActionLabel {
-    final posture = describeRuntimePosture(
-      runtimeMode: services.controller.runtimeConfig.mode,
-      backendKind: services.controller.telemetry.backendKind,
-    );
-    if (!selected.hasStoredPassword) return 'Set Password First';
-    if (_connectBlockedByReadiness) return 'Connect Blocked';
-    if (_active && status.phase == ClientConnectionPhase.connected) {
-      return 'Disconnect';
-    }
-    if (_active && status.phase == ClientConnectionPhase.connecting) {
-      return 'Connecting...';
-    }
-    if (_active && status.phase == ClientConnectionPhase.disconnecting) {
-      return 'Disconnecting...';
-    }
-    if (_hasConnectedElsewhere) {
-      return 'Connected Elsewhere';
-    }
-    return posture.qualifyAction('Connect');
-  }
-
-  String get _statusHint {
-    if (!selected.hasStoredPassword) {
-      return 'Save the Trojan password before trying this profile.';
-    }
-    if (_hasConnectedElsewhere) {
-      return 'Another profile is already connected. Disconnect it before switching here.';
-    }
-    if (_active && status.phase == ClientConnectionPhase.connecting) {
-      return 'This profile is still establishing a runtime session.';
-    }
-    if (_active && status.phase == ClientConnectionPhase.disconnecting) {
-      return 'This profile is disconnecting now. Wait for the shutdown to finish.';
-    }
-    if (_connectBlockedByReadiness) {
-      return 'Readiness blocked: ${_readinessController.latestReport!.summary}';
-    }
-    return status.message;
-  }
+  ProfileConnectionActionPolicy get _connectionPolicy =>
+      ProfileConnectionActionPolicy.resolve(
+        hasStoredPassword: selected.hasStoredPassword,
+        active: _active,
+        status: status,
+        runtimePosture: _runtimePosture,
+        runtimeSession: _runtimeSession,
+        readinessReport: _readinessController.latestReport,
+        hasConnectedElsewhere: _hasConnectedElsewhere,
+        onOpenAdvancedAvailable: widget.onOpenAdvanced != null,
+      );
 
   @override
   void initState() {
@@ -416,11 +381,8 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
 
   @override
   Widget build(BuildContext context) {
-    final active = _active;
-    final posture = describeRuntimePosture(
-      runtimeMode: services.controller.runtimeConfig.mode,
-      backendKind: services.controller.telemetry.backendKind,
-    );
+    final posture = _runtimePosture;
+    final connectionPolicy = _connectionPolicy;
 
     return SectionCard(
       title: selected.name,
@@ -477,39 +439,57 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
             child: const Text('Remove'),
           ),
           FilledButton(
-            onPressed: _canToggleConnection
-                ? () async {
-                    final messenger = ScaffoldMessenger.of(context);
-                    final isDisconnectAction = active &&
-                        status.phase == ClientConnectionPhase.connected;
-                    if (!isDisconnectAction) {
-                      final readinessReport = await services.readiness
-                          .buildReport(profileOverride: selected);
-                      if (!mounted) return;
-                      _readinessController.replaceLatestReport(readinessReport);
-                      if (readinessReport.overallLevel ==
-                          ReadinessLevel.blocked) {
-                        messenger.showSnackBar(
-                          SnackBar(
-                            content: Text(
-                              'Connect blocked: ${readinessReport.summary}',
-                            ),
-                          ),
-                        );
-                        return;
-                      }
-                    }
+            onPressed: !connectionPolicy.buttonEnabled
+                ? null
+                : connectionPolicy.primaryAction ==
+                        ProfileConnectionPrimaryAction.openTroubleshooting
+                    ? () => widget.onOpenAdvanced!(
+                        ReadinessAction.openTroubleshooting,
+                      )
+                    : connectionPolicy.canToggleConnection
+                        ? () async {
+                            final messenger = ScaffoldMessenger.of(context);
+                            final isDisconnectAction =
+                                connectionPolicy.primaryAction ==
+                                    ProfileConnectionPrimaryAction.disconnect;
+                            if (!isDisconnectAction) {
+                              final readinessReport = await services.readiness
+                                  .buildReport(profileOverride: selected);
+                              if (!mounted) return;
+                              _readinessController
+                                  .replaceLatestReport(readinessReport);
+                              if (readinessReport.overallLevel ==
+                                  ReadinessLevel.blocked) {
+                                messenger.showSnackBar(
+                                  SnackBar(
+                                    content: Text(
+                                      'Connect blocked: ${readinessReport.summary}',
+                                    ),
+                                  ),
+                                );
+                                return;
+                              }
+                            }
 
-                    final result = isDisconnectAction
-                        ? await services.controller.disconnect()
-                        : await services.controller.connect(selected);
-                    if (!context.mounted) return;
-                    messenger.showSnackBar(
-                      SnackBar(content: Text(result.summary)),
-                    );
-                  }
-                : null,
-            child: Text(_connectActionLabel),
+                            final result = isDisconnectAction
+                                ? await services.controller.disconnect()
+                                : await services.controller.connect(selected);
+                            if (!context.mounted) return;
+                            final feedback = buildRuntimeActionFeedback(
+                              action: isDisconnectAction
+                                  ? RuntimeActionKind.disconnect
+                                  : RuntimeActionKind.connect,
+                              result: result,
+                              status: services.controller.status,
+                              session: services.controller.session,
+                              posture: _runtimePosture,
+                            );
+                            messenger.showSnackBar(
+                              SnackBar(content: Text(feedback)),
+                            );
+                          }
+                        : null,
+            child: Text(connectionPolicy.buttonLabel),
           ),
         ],
       ),
@@ -564,7 +544,30 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
               },
             ),
             const SizedBox(height: 12),
-            Text('Controller status: $_statusHint'),
+            Text('Controller status: ${connectionPolicy.statusHint}'),
+            const SizedBox(height: 12),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.indigo.withValues(alpha: 0.08),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: Colors.indigo.withValues(alpha: 0.2)),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  const Text(
+                    'Action safety',
+                    style: TextStyle(fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(connectionPolicy.actionSafety.label),
+                  const SizedBox(height: 4),
+                  Text(connectionPolicy.actionSafety.detail),
+                ],
+              ),
+            ),
           ],
         ),
       ),

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -645,7 +645,7 @@ class _SelectedProfileCard extends StatelessWidget {
   }
 }
 
-class _ProfileReadinessNotice extends StatelessWidget {
+class _ProfileReadinessNotice extends StatefulWidget {
   const _ProfileReadinessNotice({
     required this.services,
     required this.selected,
@@ -653,6 +653,56 @@ class _ProfileReadinessNotice extends StatelessWidget {
 
   final ClientServiceRegistry services;
   final ClientProfile selected;
+
+  @override
+  State<_ProfileReadinessNotice> createState() => _ProfileReadinessNoticeState();
+}
+
+class _ProfileReadinessNoticeState extends State<_ProfileReadinessNotice> {
+  Future<ReadinessReport>? _future;
+  ReadinessReport? _latestReport;
+
+  @override
+  void initState() {
+    super.initState();
+    _restoreLastKnown();
+    _refresh();
+  }
+
+  @override
+  void didUpdateWidget(covariant _ProfileReadinessNotice oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.selected.id != widget.selected.id) {
+      _restoreLastKnown();
+      _refresh();
+    }
+  }
+
+  void _restoreLastKnown() {
+    widget.services.readiness
+        .readLastKnownReport(profileOverride: widget.selected)
+        .then((report) {
+      if (!mounted || report == null) return;
+      setState(() {
+        _latestReport = report;
+      });
+    });
+  }
+
+  void _refresh() {
+    final future =
+        widget.services.readiness.buildReport(profileOverride: widget.selected);
+    setState(() {
+      _future = future;
+    });
+    future.then((report) {
+      if (!mounted) return;
+      if (!identical(_future, future)) return;
+      setState(() {
+        _latestReport = report;
+      });
+    });
+  }
 
   Color _tone(ReadinessLevel level) {
     return switch (level) {
@@ -665,9 +715,9 @@ class _ProfileReadinessNotice extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<ReadinessReport>(
-      future: services.readiness.buildReport(profileOverride: selected),
+      future: _future,
       builder: (BuildContext context, AsyncSnapshot<ReadinessReport> snapshot) {
-        final report = snapshot.data;
+        final report = snapshot.data ?? _latestReport;
         if (report == null) {
           return const SizedBox.shrink();
         }

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import '../../../core/widgets/section_card.dart';
 import '../../../platform/services/service_registry.dart';
 import '../../controller/domain/client_connection_status.dart';
+import '../../readiness/domain/readiness_report.dart';
 import '../domain/client_profile.dart';
 import 'import_export_dialog.dart';
 import 'profile_editor_dialog.dart';
@@ -356,6 +357,22 @@ class _SelectedProfileCard extends StatelessWidget {
             onPressed: _canToggleConnection
                 ? () async {
                     final messenger = ScaffoldMessenger.of(context);
+                    if (!(active &&
+                        status.phase == ClientConnectionPhase.connected)) {
+                      final readinessReport = await services.readiness
+                          .buildReport(profileOverride: selected);
+                      if (!context.mounted) return;
+                      if (readinessReport.overallLevel == ReadinessLevel.blocked) {
+                        messenger.showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              'Connect blocked: ${readinessReport.summary}',
+                            ),
+                          ),
+                        );
+                        return;
+                      }
+                    }
                     final result = active &&
                             status.phase == ClientConnectionPhase.connected
                         ? await services.controller.disconnect()

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -247,6 +247,8 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
   Future<ReadinessReport>? _readinessFuture;
   ReadinessReport? _latestReadinessReport;
   String? _lastRefreshFingerprint;
+  int _readinessRequestToken = 0;
+  int _lastAppliedLiveReadinessToken = -1;
 
   ClientServiceRegistry get services => widget.services;
   ClientProfile get selected => widget.selected;
@@ -320,8 +322,7 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
   void initState() {
     super.initState();
     _lastRefreshFingerprint = _refreshFingerprint();
-    _restoreLastKnownReadiness();
-    _refreshReadiness();
+    _startReadinessCycle();
   }
 
   @override
@@ -362,30 +363,40 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
     final fingerprint = _refreshFingerprint();
     if (_lastRefreshFingerprint == fingerprint) return;
     _lastRefreshFingerprint = fingerprint;
-    _restoreLastKnownReadiness();
-    _refreshReadiness();
+    _startReadinessCycle();
   }
 
-  void _restoreLastKnownReadiness() {
+  void _startReadinessCycle() {
+    _readinessRequestToken++;
+    final requestToken = _readinessRequestToken;
+    _restoreLastKnownReadiness(requestToken: requestToken);
+    _refreshReadiness(requestToken: requestToken);
+  }
+
+  void _restoreLastKnownReadiness({required int requestToken}) {
     services.readiness
         .readLastKnownReport(profileOverride: selected)
         .then((report) {
       if (!mounted || report == null) return;
+      if (requestToken != _readinessRequestToken) return;
+      if (_lastAppliedLiveReadinessToken == requestToken) return;
       setState(() {
         _latestReadinessReport = report;
       });
     });
   }
 
-  void _refreshReadiness() {
+  void _refreshReadiness({required int requestToken}) {
     final future = services.readiness.buildReport(profileOverride: selected);
     setState(() {
       _readinessFuture = future;
     });
     future.then((report) {
       if (!mounted) return;
+      if (requestToken != _readinessRequestToken) return;
       if (!identical(_readinessFuture, future)) return;
       setState(() {
+        _lastAppliedLiveReadinessToken = requestToken;
         _latestReadinessReport = report;
       });
     });

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -7,6 +7,7 @@ import '../../../platform/services/service_registry.dart';
 import '../../controller/domain/client_connection_status.dart';
 import '../../readiness/domain/readiness_refresh_fingerprint.dart';
 import '../../readiness/domain/readiness_report.dart';
+import '../../readiness/presentation/readiness_surface_controller.dart';
 import '../domain/client_profile.dart';
 import 'import_export_dialog.dart';
 import 'profile_editor_dialog.dart';
@@ -244,11 +245,8 @@ class _SelectedProfileCard extends StatefulWidget {
 }
 
 class _SelectedProfileCardState extends State<_SelectedProfileCard> {
-  Future<ReadinessReport>? _readinessFuture;
-  ReadinessReport? _latestReadinessReport;
+  late final ReadinessSurfaceController _readinessController;
   String? _lastRefreshFingerprint;
-  int _readinessRequestToken = 0;
-  int _lastAppliedLiveReadinessToken = -1;
 
   ClientServiceRegistry get services => widget.services;
   ClientProfile get selected => widget.selected;
@@ -266,7 +264,7 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
       !_active && status.phase == ClientConnectionPhase.connected;
 
   bool get _connectBlockedByReadiness {
-    final report = _latestReadinessReport;
+    final report = _readinessController.latestReport;
     if (report == null) return false;
     final isConnectAction =
         !(_active && status.phase == ClientConnectionPhase.connected);
@@ -313,7 +311,7 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
       return 'This profile is disconnecting now. Wait for the shutdown to finish.';
     }
     if (_connectBlockedByReadiness) {
-      return 'Readiness blocked: ${_latestReadinessReport!.summary}';
+      return 'Readiness blocked: ${_readinessController.latestReport!.summary}';
     }
     return status.message;
   }
@@ -321,8 +319,20 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
   @override
   void initState() {
     super.initState();
+    _readinessController = ReadinessSurfaceController(
+      isMounted: () => mounted,
+      applyState: setState,
+    );
     _lastRefreshFingerprint = _refreshFingerprint();
-    _startReadinessCycle();
+    _readinessController.initialize(
+      refreshKey: _lastRefreshFingerprint!,
+      restoreReport: () => services.readiness.readLastKnownReport(
+        profileOverride: selected,
+      ),
+      buildReport: () => services.readiness.buildReport(
+        profileOverride: selected,
+      ),
+    );
   }
 
   @override
@@ -363,43 +373,14 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
     final fingerprint = _refreshFingerprint();
     if (_lastRefreshFingerprint == fingerprint) return;
     _lastRefreshFingerprint = fingerprint;
-    _startReadinessCycle();
-  }
-
-  void _startReadinessCycle() {
-    _readinessRequestToken++;
-    final requestToken = _readinessRequestToken;
-    _restoreLastKnownReadiness(requestToken: requestToken);
-    _refreshReadiness(requestToken: requestToken);
-  }
-
-  void _restoreLastKnownReadiness({required int requestToken}) {
-    services.readiness
-        .readLastKnownReport(profileOverride: selected)
-        .then((report) {
-      if (!mounted || report == null) return;
-      if (requestToken != _readinessRequestToken) return;
-      if (_lastAppliedLiveReadinessToken == requestToken) return;
-      setState(() {
-        _latestReadinessReport = report;
-      });
-    });
-  }
-
-  void _refreshReadiness({required int requestToken}) {
-    final future = services.readiness.buildReport(profileOverride: selected);
-    setState(() {
-      _readinessFuture = future;
-    });
-    future.then((report) {
-      if (!mounted) return;
-      if (requestToken != _readinessRequestToken) return;
-      if (!identical(_readinessFuture, future)) return;
-      setState(() {
-        _lastAppliedLiveReadinessToken = requestToken;
-        _latestReadinessReport = report;
-      });
-    });
+    _readinessController.startCycle(
+      restoreReport: () => services.readiness.readLastKnownReport(
+        profileOverride: selected,
+      ),
+      buildReport: () => services.readiness.buildReport(
+        profileOverride: selected,
+      ),
+    );
   }
 
   void _runRecommendation(BuildContext context, ReadinessRecommendation rec) {
@@ -506,9 +487,7 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
                       final readinessReport = await services.readiness
                           .buildReport(profileOverride: selected);
                       if (!mounted) return;
-                      setState(() {
-                        _latestReadinessReport = readinessReport;
-                      });
+                      _readinessController.replaceLatestReport(readinessReport);
                       if (readinessReport.overallLevel ==
                           ReadinessLevel.blocked) {
                         messenger.showSnackBar(
@@ -564,10 +543,11 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
             if (selected.notes.isNotEmpty) _detail('Notes', selected.notes),
             const SizedBox(height: 12),
             FutureBuilder<ReadinessReport>(
-              future: _readinessFuture,
+              future: _readinessController.future,
               builder: (BuildContext context,
                   AsyncSnapshot<ReadinessReport> snapshot) {
-                final report = snapshot.data ?? _latestReadinessReport;
+                final report =
+                    snapshot.data ?? _readinessController.latestReport;
                 return _ProfileReadinessNotice(
                   report: report,
                   showCachedRefreshHint: report?.isCachedSnapshot == true &&

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -415,6 +415,11 @@ class _SelectedProfileCard extends StatelessWidget {
             _detail('Updated', selected.updatedAt.toIso8601String()),
             if (selected.notes.isNotEmpty) _detail('Notes', selected.notes),
             const SizedBox(height: 12),
+            _ProfileReadinessNotice(
+              services: services,
+              selected: selected,
+            ),
+            const SizedBox(height: 12),
             Text('Controller status: $_statusHint'),
           ],
         ),
@@ -636,6 +641,70 @@ class _SelectedProfileCard extends StatelessWidget {
           Expanded(child: Text(value)),
         ],
       ),
+    );
+  }
+}
+
+class _ProfileReadinessNotice extends StatelessWidget {
+  const _ProfileReadinessNotice({
+    required this.services,
+    required this.selected,
+  });
+
+  final ClientServiceRegistry services;
+  final ClientProfile selected;
+
+  Color _tone(ReadinessLevel level) {
+    return switch (level) {
+      ReadinessLevel.ready => Colors.green,
+      ReadinessLevel.degraded => Colors.orange,
+      ReadinessLevel.blocked => Colors.red,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<ReadinessReport>(
+      future: services.readiness.buildReport(profileOverride: selected),
+      builder: (BuildContext context, AsyncSnapshot<ReadinessReport> snapshot) {
+        final report = snapshot.data;
+        if (report == null) {
+          return const SizedBox.shrink();
+        }
+
+        final tone = _tone(report.overallLevel);
+        final recommendation = report.recommendation;
+        return Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: tone.withValues(alpha: 0.08),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: tone.withValues(alpha: 0.25)),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                'Readiness: ${report.overallLevel.label}',
+                style: TextStyle(
+                  color: tone,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(report.summary),
+              if (recommendation != null) ...<Widget>[
+                const SizedBox(height: 8),
+                Text(
+                  'Recommended next step: ${recommendation.label}',
+                  style: const TextStyle(fontWeight: FontWeight.w600),
+                ),
+              ],
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -290,6 +290,10 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
   }
 
   String get _connectActionLabel {
+    final posture = describeRuntimePosture(
+      runtimeMode: services.controller.runtimeConfig.mode,
+      backendKind: services.controller.telemetry.backendKind,
+    );
     if (!selected.hasStoredPassword) return 'Set Password First';
     if (_connectBlockedByReadiness) return 'Connect Blocked';
     if (_active && status.phase == ClientConnectionPhase.connected) {
@@ -304,7 +308,7 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
     if (_hasConnectedElsewhere) {
       return 'Connected Elsewhere';
     }
-    return 'Connect';
+    return posture.qualifyAction('Connect');
   }
 
   String get _statusHint {

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import '../../../core/widgets/section_card.dart';
 import '../../../platform/services/service_registry.dart';
 import '../../controller/domain/client_connection_status.dart';
+import '../../controller/domain/runtime_posture.dart';
 import '../../readiness/domain/readiness_refresh_fingerprint.dart';
 import '../../readiness/domain/readiness_report.dart';
 import '../../readiness/presentation/readiness_surface_controller.dart';
@@ -350,25 +351,6 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
     _refreshReadinessIfInputsChanged();
   }
 
-  String _executionPathLabel(String mode) {
-    if (mode.contains('real-runtime-boundary')) {
-      return 'Real runtime path';
-    }
-    if (mode.contains('stubbed-local-boundary-fallback')) {
-      return 'Fallback stub (real runtime unavailable)';
-    }
-    if (mode.contains('stubbed-local-boundary-explicit')) {
-      return 'Explicit stub mode';
-    }
-    if (mode.contains('stubbed-local-boundary-non-desktop')) {
-      return 'Stub mode (non-desktop target)';
-    }
-    if (mode.contains('stubbed-local-boundary')) {
-      return 'Simulated runtime path';
-    }
-    return 'Unknown runtime path';
-  }
-
   String _refreshFingerprint() {
     return buildReadinessRefreshFingerprint(
       profile: selected,
@@ -431,6 +413,10 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
   @override
   Widget build(BuildContext context) {
     final active = _active;
+    final posture = describeRuntimePosture(
+      runtimeMode: services.controller.runtimeConfig.mode,
+      backendKind: services.controller.telemetry.backendKind,
+    );
 
     return SectionCard(
       title: selected.name,
@@ -533,10 +519,9 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
             _detail('TLS Verification',
                 selected.verifyTls ? 'Enabled' : 'Disabled'),
             _detail('Runtime Mode', services.controller.runtimeConfig.mode),
-            _detail(
-              'Execution Path',
-              _executionPathLabel(services.controller.runtimeConfig.mode),
-            ),
+            _detail('Runtime Posture', posture.postureLabel),
+            _detail('Execution Path', posture.executionPathLabel),
+            _detail('Runtime Truth', posture.truthNote),
             _detail('Runtime Endpoint',
                 services.controller.runtimeConfig.endpointHint),
             _detail(

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -35,86 +35,95 @@ class ProfilesPage extends StatelessWidget {
         final selected = services.profileStore.selectedProfile;
         final status = services.controller.status;
 
-        return SingleChildScrollView(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
+        final listSection = SectionCard(
+          title: 'Profiles',
+          subtitle: 'Desktop-first profile management shell.',
+          trailing: Wrap(
+            spacing: 8,
+            runSpacing: 8,
             children: <Widget>[
-              Expanded(
-                flex: 2,
-                child: SectionCard(
-                  title: 'Profiles',
-                  subtitle: 'Desktop-first profile management shell.',
-                  trailing: Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    children: <Widget>[
-                      OutlinedButton.icon(
-                        onPressed: () => _importProfileFromFile(context),
-                        icon: const Icon(Icons.folder_open),
-                        label: const Text('Import File'),
-                      ),
-                      OutlinedButton.icon(
-                        onPressed: () => _importProfile(context),
-                        icon: const Icon(Icons.file_upload),
-                        label: const Text('Import Text'),
-                      ),
-                      FilledButton.icon(
-                        onPressed: () => _createProfile(context),
-                        icon: const Icon(Icons.add),
-                        label: const Text('Create'),
-                      ),
-                    ],
-                  ),
-                  child: profiles.isEmpty
-                      ? const Text('No profiles yet.')
-                      : Column(
-                          children: profiles
-                              .map(
-                                (profile) => ListTile(
-                                  contentPadding: EdgeInsets.zero,
-                                  leading: Icon(
-                                    services.profileStore.selectedProfileId ==
-                                            profile.id
-                                        ? Icons.radio_button_checked
-                                        : Icons.radio_button_off,
-                                  ),
-                                  title: Text(profile.name),
-                                  subtitle: Text(
-                                      '${profile.serverHost}:${profile.serverPort}'),
-                                  trailing: status.activeProfileId ==
-                                              profile.id &&
-                                          status.phase ==
-                                              ClientConnectionPhase.connected
-                                      ? const Icon(Icons.link,
-                                          color: Colors.green)
-                                      : null,
-                                  onTap: () => services.profileStore
-                                      .selectProfile(profile.id),
-                                ),
-                              )
-                              .toList(),
-                        ),
-                ),
+              OutlinedButton.icon(
+                onPressed: () => _importProfileFromFile(context),
+                icon: const Icon(Icons.folder_open),
+                label: const Text('Import File'),
               ),
-              const SizedBox(width: 16),
-              Expanded(
-                flex: 3,
-                child: selected == null
-                    ? const SectionCard(
-                        title: 'Profile Details',
-                        child:
-                            Text('Select or create a profile to inspect it.'),
-                      )
-                    : _SelectedProfileCard(
-                        services: services,
-                        selected: selected,
-                        status: status,
-                        onOpenAdvanced: onOpenAdvanced,
-                        onOpenSettings: onOpenSettings,
-                      ),
+              OutlinedButton.icon(
+                onPressed: () => _importProfile(context),
+                icon: const Icon(Icons.file_upload),
+                label: const Text('Import Text'),
+              ),
+              FilledButton.icon(
+                onPressed: () => _createProfile(context),
+                icon: const Icon(Icons.add),
+                label: const Text('Create'),
               ),
             ],
           ),
+          child: profiles.isEmpty
+              ? const Text('No profiles yet.')
+              : Column(
+                  children: profiles
+                      .map(
+                        (profile) => ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          leading: Icon(
+                            services.profileStore.selectedProfileId ==
+                                    profile.id
+                                ? Icons.radio_button_checked
+                                : Icons.radio_button_off,
+                          ),
+                          title: Text(profile.name),
+                          subtitle: Text(
+                              '${profile.serverHost}:${profile.serverPort}'),
+                          trailing: status.activeProfileId == profile.id &&
+                                  status.phase ==
+                                      ClientConnectionPhase.connected
+                              ? const Icon(Icons.link, color: Colors.green)
+                              : null,
+                          onTap: () =>
+                              services.profileStore.selectProfile(profile.id),
+                        ),
+                      )
+                      .toList(),
+                ),
+        );
+
+        final detailSection = selected == null
+            ? const SectionCard(
+                title: 'Profile Details',
+                child: Text('Select or create a profile to inspect it.'),
+              )
+            : _SelectedProfileCard(
+                services: services,
+                selected: selected,
+                status: status,
+                onOpenAdvanced: onOpenAdvanced,
+                onOpenSettings: onOpenSettings,
+              );
+
+        return LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            final useStackedLayout = constraints.maxWidth < 900;
+            return SingleChildScrollView(
+              child: useStackedLayout
+                  ? Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: <Widget>[
+                        listSection,
+                        const SizedBox(height: 16),
+                        detailSection,
+                      ],
+                    )
+                  : Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Expanded(flex: 2, child: listSection),
+                        const SizedBox(width: 16),
+                        Expanded(flex: 3, child: detailSection),
+                      ],
+                    ),
+            );
+          },
         );
       },
     );
@@ -774,15 +783,32 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
   }
 
   Widget _detail(String label, String value) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          SizedBox(width: 140, child: Text(label)),
-          Expanded(child: Text(value)),
-        ],
-      ),
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final useStackedLayout = constraints.maxWidth < 520;
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: useStackedLayout
+              ? Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      label,
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(value),
+                  ],
+                )
+              : Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    SizedBox(width: 140, child: Text(label)),
+                    Expanded(child: Text(value)),
+                  ],
+                ),
+        );
+      },
     );
   }
 }

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -559,6 +559,8 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
                 final report = snapshot.data ?? _latestReadinessReport;
                 return _ProfileReadinessNotice(
                   report: report,
+                  showCachedRefreshHint: report?.isCachedSnapshot == true &&
+                      snapshot.connectionState != ConnectionState.done,
                   onRecommendation: report?.recommendation == null
                       ? null
                       : () => _runRecommendation(
@@ -797,10 +799,12 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
 class _ProfileReadinessNotice extends StatelessWidget {
   const _ProfileReadinessNotice({
     required this.report,
+    this.showCachedRefreshHint = false,
     this.onRecommendation,
   });
 
   final ReadinessReport? report;
+  final bool showCachedRefreshHint;
   final VoidCallback? onRecommendation;
 
   Color _tone(ReadinessLevel level) {
@@ -847,6 +851,17 @@ class _ProfileReadinessNotice extends StatelessWidget {
           ),
           const SizedBox(height: 6),
           Text(report!.summary),
+          const SizedBox(height: 8),
+          Text(
+            'Readiness source: ${report!.provenanceSummary}',
+            style: const TextStyle(fontWeight: FontWeight.w600),
+          ),
+          if (showCachedRefreshHint) ...<Widget>[
+            const SizedBox(height: 8),
+            const Text(
+              'Showing a cached snapshot while the live readiness refresh runs.',
+            ),
+          ],
           if (recommendation != null) ...<Widget>[
             const SizedBox(height: 8),
             Text(

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -275,6 +275,25 @@ class _SelectedProfileCard extends StatelessWidget {
     return status.message;
   }
 
+  String _executionPathLabel(String mode) {
+    if (mode.contains('real-runtime-boundary')) {
+      return 'Real runtime path';
+    }
+    if (mode.contains('stubbed-local-boundary-fallback')) {
+      return 'Fallback stub (real runtime unavailable)';
+    }
+    if (mode.contains('stubbed-local-boundary-explicit')) {
+      return 'Explicit stub mode';
+    }
+    if (mode.contains('stubbed-local-boundary-non-desktop')) {
+      return 'Stub mode (non-desktop target)';
+    }
+    if (mode.contains('stubbed-local-boundary')) {
+      return 'Simulated runtime path';
+    }
+    return 'Unknown runtime path';
+  }
+
   @override
   Widget build(BuildContext context) {
     final active = _active;
@@ -361,6 +380,10 @@ class _SelectedProfileCard extends StatelessWidget {
             _detail('TLS Verification',
                 selected.verifyTls ? 'Enabled' : 'Disabled'),
             _detail('Runtime Mode', services.controller.runtimeConfig.mode),
+            _detail(
+              'Execution Path',
+              _executionPathLabel(services.controller.runtimeConfig.mode),
+            ),
             _detail('Runtime Endpoint',
                 services.controller.runtimeConfig.endpointHint),
             _detail(

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -524,8 +524,12 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
                 selected.verifyTls ? 'Enabled' : 'Disabled'),
             _detail('Runtime Mode', services.controller.runtimeConfig.mode),
             _detail('Runtime Posture', posture.postureLabel),
+            _detail('Evidence Grade', posture.evidenceGradeLabel),
             _detail('Execution Path', posture.executionPathLabel),
-            _detail('Runtime Truth', posture.truthNote),
+            _detail(
+              'Runtime Truth',
+              '${posture.truthNote} ${posture.evidenceGradeNote}',
+            ),
             _detail('Runtime Endpoint',
                 services.controller.runtimeConfig.endpointHint),
             _detail(

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import '../../../core/widgets/section_card.dart';
 import '../../../platform/services/service_registry.dart';
 import '../../controller/domain/client_connection_status.dart';
+import '../../readiness/domain/readiness_refresh_fingerprint.dart';
 import '../../readiness/domain/readiness_report.dart';
 import '../domain/client_profile.dart';
 import 'import_export_dialog.dart';
@@ -12,9 +13,16 @@ import 'profile_editor_dialog.dart';
 import 'profile_secret_dialog.dart';
 
 class ProfilesPage extends StatelessWidget {
-  const ProfilesPage({super.key, required this.services});
+  const ProfilesPage({
+    super.key,
+    required this.services,
+    this.onOpenAdvanced,
+    this.onOpenSettings,
+  });
 
   final ClientServiceRegistry services;
+  final ValueChanged<ReadinessAction>? onOpenAdvanced;
+  final VoidCallback? onOpenSettings;
 
   @override
   Widget build(BuildContext context) {
@@ -100,6 +108,8 @@ class ProfilesPage extends StatelessWidget {
                         services: services,
                         selected: selected,
                         status: status,
+                        onOpenAdvanced: onOpenAdvanced,
+                        onOpenSettings: onOpenSettings,
                       ),
               ),
             ],
@@ -214,16 +224,33 @@ class ProfilesPage extends StatelessWidget {
   }
 }
 
-class _SelectedProfileCard extends StatelessWidget {
+class _SelectedProfileCard extends StatefulWidget {
   const _SelectedProfileCard({
     required this.services,
     required this.selected,
     required this.status,
+    this.onOpenAdvanced,
+    this.onOpenSettings,
   });
 
   final ClientServiceRegistry services;
   final ClientProfile selected;
   final ClientConnectionStatus status;
+  final ValueChanged<ReadinessAction>? onOpenAdvanced;
+  final VoidCallback? onOpenSettings;
+
+  @override
+  State<_SelectedProfileCard> createState() => _SelectedProfileCardState();
+}
+
+class _SelectedProfileCardState extends State<_SelectedProfileCard> {
+  Future<ReadinessReport>? _readinessFuture;
+  ReadinessReport? _latestReadinessReport;
+  String? _lastRefreshFingerprint;
+
+  ClientServiceRegistry get services => widget.services;
+  ClientProfile get selected => widget.selected;
+  ClientConnectionStatus get status => widget.status;
 
   bool get _active => status.activeProfileId == selected.id;
 
@@ -236,15 +263,25 @@ class _SelectedProfileCard extends StatelessWidget {
   bool get _hasConnectedElsewhere =>
       !_active && status.phase == ClientConnectionPhase.connected;
 
+  bool get _connectBlockedByReadiness {
+    final report = _latestReadinessReport;
+    if (report == null) return false;
+    final isConnectAction =
+        !(_active && status.phase == ClientConnectionPhase.connected);
+    return isConnectAction && report.overallLevel == ReadinessLevel.blocked;
+  }
+
   bool get _canToggleConnection {
     if (!selected.hasStoredPassword) return false;
     if (status.isBusy) return false;
     if (_hasConnectedElsewhere) return false;
+    if (_connectBlockedByReadiness) return false;
     return true;
   }
 
   String get _connectActionLabel {
     if (!selected.hasStoredPassword) return 'Set Password First';
+    if (_connectBlockedByReadiness) return 'Connect Blocked';
     if (_active && status.phase == ClientConnectionPhase.connected) {
       return 'Disconnect';
     }
@@ -273,7 +310,24 @@ class _SelectedProfileCard extends StatelessWidget {
     if (_active && status.phase == ClientConnectionPhase.disconnecting) {
       return 'This profile is disconnecting now. Wait for the shutdown to finish.';
     }
+    if (_connectBlockedByReadiness) {
+      return 'Readiness blocked: ${_latestReadinessReport!.summary}';
+    }
     return status.message;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _lastRefreshFingerprint = _refreshFingerprint();
+    _restoreLastKnownReadiness();
+    _refreshReadiness();
+  }
+
+  @override
+  void didUpdateWidget(covariant _SelectedProfileCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _refreshReadinessIfInputsChanged();
   }
 
   String _executionPathLabel(String mode) {
@@ -293,6 +347,84 @@ class _SelectedProfileCard extends StatelessWidget {
       return 'Simulated runtime path';
     }
     return 'Unknown runtime path';
+  }
+
+  String _refreshFingerprint() {
+    return buildReadinessRefreshFingerprint(
+      profile: selected,
+      storageSummary: services.profileSecrets.storageSummary,
+      runtimeMode: services.controller.runtimeConfig.mode,
+      runtimeEndpointHint: services.controller.runtimeConfig.endpointHint,
+    );
+  }
+
+  void _refreshReadinessIfInputsChanged() {
+    final fingerprint = _refreshFingerprint();
+    if (_lastRefreshFingerprint == fingerprint) return;
+    _lastRefreshFingerprint = fingerprint;
+    _restoreLastKnownReadiness();
+    _refreshReadiness();
+  }
+
+  void _restoreLastKnownReadiness() {
+    services.readiness
+        .readLastKnownReport(profileOverride: selected)
+        .then((report) {
+      if (!mounted || report == null) return;
+      setState(() {
+        _latestReadinessReport = report;
+      });
+    });
+  }
+
+  void _refreshReadiness() {
+    final future = services.readiness.buildReport(profileOverride: selected);
+    setState(() {
+      _readinessFuture = future;
+    });
+    future.then((report) {
+      if (!mounted) return;
+      if (!identical(_readinessFuture, future)) return;
+      setState(() {
+        _latestReadinessReport = report;
+      });
+    });
+  }
+
+  void _runRecommendation(BuildContext context, ReadinessRecommendation rec) {
+    switch (rec.action) {
+      case ReadinessAction.openProfiles:
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+                'You are already in Profiles. Update this profile directly.'),
+          ),
+        );
+        return;
+      case ReadinessAction.openTroubleshooting:
+        if (widget.onOpenAdvanced != null) {
+          widget.onOpenAdvanced!.call(rec.action);
+          return;
+        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content:
+                Text('Troubleshooting page is unavailable in this surface.'),
+          ),
+        );
+        return;
+      case ReadinessAction.openSettings:
+        if (widget.onOpenSettings != null) {
+          widget.onOpenSettings!.call();
+          return;
+        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Settings page is unavailable in this surface.'),
+          ),
+        );
+        return;
+    }
   }
 
   @override
@@ -357,12 +489,17 @@ class _SelectedProfileCard extends StatelessWidget {
             onPressed: _canToggleConnection
                 ? () async {
                     final messenger = ScaffoldMessenger.of(context);
-                    if (!(active &&
-                        status.phase == ClientConnectionPhase.connected)) {
+                    final isDisconnectAction = active &&
+                        status.phase == ClientConnectionPhase.connected;
+                    if (!isDisconnectAction) {
                       final readinessReport = await services.readiness
                           .buildReport(profileOverride: selected);
-                      if (!context.mounted) return;
-                      if (readinessReport.overallLevel == ReadinessLevel.blocked) {
+                      if (!mounted) return;
+                      setState(() {
+                        _latestReadinessReport = readinessReport;
+                      });
+                      if (readinessReport.overallLevel ==
+                          ReadinessLevel.blocked) {
                         messenger.showSnackBar(
                           SnackBar(
                             content: Text(
@@ -373,8 +510,8 @@ class _SelectedProfileCard extends StatelessWidget {
                         return;
                       }
                     }
-                    final result = active &&
-                            status.phase == ClientConnectionPhase.connected
+
+                    final result = isDisconnectAction
                         ? await services.controller.disconnect()
                         : await services.controller.connect(selected);
                     if (!context.mounted) return;
@@ -415,9 +552,21 @@ class _SelectedProfileCard extends StatelessWidget {
             _detail('Updated', selected.updatedAt.toIso8601String()),
             if (selected.notes.isNotEmpty) _detail('Notes', selected.notes),
             const SizedBox(height: 12),
-            _ProfileReadinessNotice(
-              services: services,
-              selected: selected,
+            FutureBuilder<ReadinessReport>(
+              future: _readinessFuture,
+              builder: (BuildContext context,
+                  AsyncSnapshot<ReadinessReport> snapshot) {
+                final report = snapshot.data ?? _latestReadinessReport;
+                return _ProfileReadinessNotice(
+                  report: report,
+                  onRecommendation: report?.recommendation == null
+                      ? null
+                      : () => _runRecommendation(
+                            context,
+                            report!.recommendation!,
+                          ),
+                );
+              },
             ),
             const SizedBox(height: 12),
             Text('Controller status: $_statusHint'),
@@ -645,64 +794,14 @@ class _SelectedProfileCard extends StatelessWidget {
   }
 }
 
-class _ProfileReadinessNotice extends StatefulWidget {
+class _ProfileReadinessNotice extends StatelessWidget {
   const _ProfileReadinessNotice({
-    required this.services,
-    required this.selected,
+    required this.report,
+    this.onRecommendation,
   });
 
-  final ClientServiceRegistry services;
-  final ClientProfile selected;
-
-  @override
-  State<_ProfileReadinessNotice> createState() => _ProfileReadinessNoticeState();
-}
-
-class _ProfileReadinessNoticeState extends State<_ProfileReadinessNotice> {
-  Future<ReadinessReport>? _future;
-  ReadinessReport? _latestReport;
-
-  @override
-  void initState() {
-    super.initState();
-    _restoreLastKnown();
-    _refresh();
-  }
-
-  @override
-  void didUpdateWidget(covariant _ProfileReadinessNotice oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.selected.id != widget.selected.id) {
-      _restoreLastKnown();
-      _refresh();
-    }
-  }
-
-  void _restoreLastKnown() {
-    widget.services.readiness
-        .readLastKnownReport(profileOverride: widget.selected)
-        .then((report) {
-      if (!mounted || report == null) return;
-      setState(() {
-        _latestReport = report;
-      });
-    });
-  }
-
-  void _refresh() {
-    final future =
-        widget.services.readiness.buildReport(profileOverride: widget.selected);
-    setState(() {
-      _future = future;
-    });
-    future.then((report) {
-      if (!mounted) return;
-      if (!identical(_future, future)) return;
-      setState(() {
-        _latestReport = report;
-      });
-    });
-  }
+  final ReadinessReport? report;
+  final VoidCallback? onRecommendation;
 
   Color _tone(ReadinessLevel level) {
     return switch (level) {
@@ -712,49 +811,57 @@ class _ProfileReadinessNoticeState extends State<_ProfileReadinessNotice> {
     };
   }
 
+  IconData _recommendationIcon(ReadinessAction action) {
+    return switch (action) {
+      ReadinessAction.openProfiles => Icons.storage_outlined,
+      ReadinessAction.openTroubleshooting => Icons.build_circle_outlined,
+      ReadinessAction.openSettings => Icons.settings_outlined,
+    };
+  }
+
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<ReadinessReport>(
-      future: _future,
-      builder: (BuildContext context, AsyncSnapshot<ReadinessReport> snapshot) {
-        final report = snapshot.data ?? _latestReport;
-        if (report == null) {
-          return const SizedBox.shrink();
-        }
+    if (report == null) {
+      return const SizedBox.shrink();
+    }
 
-        final tone = _tone(report.overallLevel);
-        final recommendation = report.recommendation;
-        return Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            color: tone.withValues(alpha: 0.08),
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: tone.withValues(alpha: 0.25)),
+    final tone = _tone(report!.overallLevel);
+    final recommendation = report!.recommendation;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: tone.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: tone.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            'Readiness: ${report!.overallLevel.label}',
+            style: TextStyle(
+              color: tone,
+              fontWeight: FontWeight.w700,
+            ),
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text(
-                'Readiness: ${report.overallLevel.label}',
-                style: TextStyle(
-                  color: tone,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              const SizedBox(height: 6),
-              Text(report.summary),
-              if (recommendation != null) ...<Widget>[
-                const SizedBox(height: 8),
-                Text(
-                  'Recommended next step: ${recommendation.label}',
-                  style: const TextStyle(fontWeight: FontWeight.w600),
-                ),
-              ],
-            ],
-          ),
-        );
-      },
+          const SizedBox(height: 6),
+          Text(report!.summary),
+          if (recommendation != null) ...<Widget>[
+            const SizedBox(height: 8),
+            Text(
+              'Recommended next step: ${recommendation.label}',
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton.icon(
+              onPressed: onRecommendation,
+              icon: Icon(_recommendationIcon(recommendation.action)),
+              label: Text(recommendation.label),
+            ),
+          ],
+        ],
+      ),
     );
   }
 }

--- a/client/lib/features/readiness/application/readiness_service.dart
+++ b/client/lib/features/readiness/application/readiness_service.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import '../../controller/application/client_controller_api.dart';
@@ -7,6 +8,7 @@ import '../../profiles/application/profile_store.dart';
 import '../../profiles/domain/client_profile.dart';
 import '../../../platform/secure_storage/secure_storage.dart';
 import '../../../platform/services/client_filesystem_layout.dart';
+import '../../../platform/services/local_state_store.dart';
 import '../domain/readiness_report.dart';
 
 class ReadinessService {
@@ -16,17 +18,20 @@ class ReadinessService {
     required SecureStorage secureStorage,
     required ClientControllerApi controller,
     ClientFilesystemLayout? filesystemLayout,
+    LocalStateStore? localStateStore,
   })  : _profileStore = profileStore,
         _profileSecrets = profileSecrets,
         _secureStorage = secureStorage,
         _controller = controller,
-        _filesystemLayout = filesystemLayout;
+        _filesystemLayout = filesystemLayout,
+        _localStateStore = localStateStore;
 
   final ProfileStore _profileStore;
   final ProfileSecretsService _profileSecrets;
   final SecureStorage _secureStorage;
   final ClientControllerApi _controller;
   final ClientFilesystemLayout? _filesystemLayout;
+  final LocalStateStore? _localStateStore;
 
   Future<ReadinessReport> buildReport({ClientProfile? profileOverride}) async {
     final checks = <ReadinessCheck>[];
@@ -41,7 +46,42 @@ class ReadinessService {
     checks.add(await _checkRuntimeBinary());
     checks.add(await _checkFilesystem());
 
-    return ReadinessReport.fromChecks(checks);
+    final report = ReadinessReport.fromChecks(checks);
+    await _persistLastKnownReport(report, profile: selectedProfile);
+    return report;
+  }
+
+  Future<ReadinessReport?> readLastKnownReport({
+    ClientProfile? profileOverride,
+  }) async {
+    final localStateStore = _localStateStore;
+    if (localStateStore == null) return null;
+    final selectedProfile = profileOverride ?? _profileStore.selectedProfile;
+    final raw = await localStateStore.read(_storageKeyFor(selectedProfile));
+    if (raw == null || raw.trim().isEmpty) return null;
+    try {
+      return ReadinessReport.fromJson(jsonDecode(raw));
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _persistLastKnownReport(
+    ReadinessReport report, {
+    required ClientProfile? profile,
+  }) async {
+    final localStateStore = _localStateStore;
+    if (localStateStore == null) return;
+    await localStateStore.write(
+      _storageKeyFor(profile),
+      jsonEncode(report.toJson()),
+    );
+  }
+
+  String _storageKeyFor(ClientProfile? profile) {
+    return profile == null
+        ? 'client.readiness.last-known.none'
+        : 'client.readiness.last-known.${profile.id}';
   }
 
   ReadinessCheck _checkProfile(ClientProfile? profile) {

--- a/client/lib/features/readiness/application/readiness_service.dart
+++ b/client/lib/features/readiness/application/readiness_service.dart
@@ -60,7 +60,8 @@ class ReadinessService {
     final raw = await localStateStore.read(_storageKeyFor(selectedProfile));
     if (raw == null || raw.trim().isEmpty) return null;
     try {
-      return ReadinessReport.fromJson(jsonDecode(raw));
+      final report = ReadinessReport.fromJson(jsonDecode(raw));
+      return report?.copyWith(isCachedSnapshot: true);
     } catch (_) {
       return null;
     }
@@ -191,7 +192,8 @@ class ReadinessService {
     }
 
     final invalidHost = profile.serverHost.trim().isEmpty;
-    final invalidServerPort = profile.serverPort <= 0 || profile.serverPort > 65535;
+    final invalidServerPort =
+        profile.serverPort <= 0 || profile.serverPort > 65535;
     final invalidLocalPort =
         profile.localSocksPort <= 0 || profile.localSocksPort > 65535;
 
@@ -270,7 +272,8 @@ class ReadinessService {
       return const ReadinessCheck(
         domain: ReadinessDomain.filesystem,
         level: ReadinessLevel.degraded,
-        summary: 'Filesystem layout is unavailable; runtime artifacts will use temp paths.',
+        summary:
+            'Filesystem layout is unavailable; runtime artifacts will use temp paths.',
         detail:
             'This can happen on unsupported platforms. It is OK for testing but not for persistent runtime use.',
       );

--- a/client/lib/features/readiness/application/readiness_service.dart
+++ b/client/lib/features/readiness/application/readiness_service.dart
@@ -1,0 +1,263 @@
+import 'dart:io';
+
+import '../../controller/application/client_controller_api.dart';
+import '../../controller/domain/controller_runtime_health.dart';
+import '../../profiles/application/profile_secrets_service.dart';
+import '../../profiles/application/profile_store.dart';
+import '../../profiles/domain/client_profile.dart';
+import '../../../platform/secure_storage/secure_storage.dart';
+import '../../../platform/services/client_filesystem_layout.dart';
+import '../domain/readiness_report.dart';
+
+class ReadinessService {
+  ReadinessService({
+    required ProfileStore profileStore,
+    required ProfileSecretsService profileSecrets,
+    required SecureStorage secureStorage,
+    required ClientControllerApi controller,
+    ClientFilesystemLayout? filesystemLayout,
+  })  : _profileStore = profileStore,
+        _profileSecrets = profileSecrets,
+        _secureStorage = secureStorage,
+        _controller = controller,
+        _filesystemLayout = filesystemLayout;
+
+  final ProfileStore _profileStore;
+  final ProfileSecretsService _profileSecrets;
+  final SecureStorage _secureStorage;
+  final ClientControllerApi _controller;
+  final ClientFilesystemLayout? _filesystemLayout;
+
+  Future<ReadinessReport> buildReport() async {
+    final checks = <ReadinessCheck>[];
+    final selectedProfile = _profileStore.selectedProfile;
+
+    checks.add(_checkProfile(selectedProfile));
+    checks.add(await _checkPassword(selectedProfile));
+    checks.add(_checkSecureStorage());
+    checks.add(_checkEnvironment());
+    checks.add(_checkConfig(selectedProfile));
+    checks.add(_checkRuntimePath());
+    checks.add(await _checkRuntimeBinary());
+    checks.add(await _checkFilesystem());
+
+    return ReadinessReport.fromChecks(checks);
+  }
+
+  ReadinessCheck _checkProfile(ClientProfile? profile) {
+    if (profile == null) {
+      return const ReadinessCheck(
+        domain: ReadinessDomain.profile,
+        level: ReadinessLevel.blocked,
+        summary: 'No profile is selected yet.',
+        detail: 'Pick or import one profile before running a connection test.',
+        action: ReadinessAction.openProfiles,
+        actionLabel: 'Open Profiles',
+      );
+    }
+    return ReadinessCheck(
+      domain: ReadinessDomain.profile,
+      level: ReadinessLevel.ready,
+      summary: 'Selected profile: ${profile.name}.',
+    );
+  }
+
+  Future<ReadinessCheck> _checkPassword(ClientProfile? profile) async {
+    if (profile == null) {
+      return const ReadinessCheck(
+        domain: ReadinessDomain.password,
+        level: ReadinessLevel.ready,
+        summary: 'Password check awaits profile selection.',
+      );
+    }
+
+    final hasPassword = await _profileSecrets.hasTrojanPassword(profile.id);
+    if (!hasPassword) {
+      return ReadinessCheck(
+        domain: ReadinessDomain.password,
+        level: ReadinessLevel.blocked,
+        summary: 'Trojan password has not been saved for ${profile.name}.',
+        detail: 'Save the password first so the connect plan can be built.',
+        action: ReadinessAction.openProfiles,
+        actionLabel: 'Open Profiles',
+      );
+    }
+
+    return ReadinessCheck(
+      domain: ReadinessDomain.password,
+      level: ReadinessLevel.ready,
+      summary: 'Password is stored for ${profile.name}.',
+    );
+  }
+
+  ReadinessCheck _checkSecureStorage() {
+    final status = _secureStorage.status;
+    if (!status.isPersistent) {
+      return ReadinessCheck(
+        domain: ReadinessDomain.secureStorage,
+        level: ReadinessLevel.degraded,
+        summary: status.userFacingSummary,
+        detail:
+            'Storage is session-only. Restarting the app may require re-entering passwords.',
+        action: ReadinessAction.openTroubleshooting,
+        actionLabel: 'Open Troubleshooting',
+      );
+    }
+
+    if (status.fallbackActive) {
+      return ReadinessCheck(
+        domain: ReadinessDomain.secureStorage,
+        level: ReadinessLevel.degraded,
+        summary: status.userFacingSummary,
+        detail: status.lastPrimaryError,
+        action: ReadinessAction.openTroubleshooting,
+        actionLabel: 'Open Troubleshooting',
+      );
+    }
+
+    return ReadinessCheck(
+      domain: ReadinessDomain.secureStorage,
+      level: ReadinessLevel.ready,
+      summary: status.userFacingSummary,
+    );
+  }
+
+  ReadinessCheck _checkEnvironment() {
+    if (_filesystemLayout == null) {
+      return const ReadinessCheck(
+        domain: ReadinessDomain.environment,
+        level: ReadinessLevel.degraded,
+        summary: 'Desktop environment capabilities are partial.',
+        detail:
+            'Platform-specific filesystem layout is unavailable; runtime artifacts may rely on temp paths.',
+        action: ReadinessAction.openTroubleshooting,
+        actionLabel: 'Open Troubleshooting',
+      );
+    }
+    return const ReadinessCheck(
+      domain: ReadinessDomain.environment,
+      level: ReadinessLevel.ready,
+      summary: 'Desktop environment capabilities look available.',
+    );
+  }
+
+  ReadinessCheck _checkConfig(ClientProfile? profile) {
+    if (profile == null) {
+      return const ReadinessCheck(
+        domain: ReadinessDomain.config,
+        level: ReadinessLevel.ready,
+        summary: 'Config check awaits profile selection.',
+      );
+    }
+
+    final invalidHost = profile.serverHost.trim().isEmpty;
+    final invalidServerPort = profile.serverPort <= 0 || profile.serverPort > 65535;
+    final invalidLocalPort =
+        profile.localSocksPort <= 0 || profile.localSocksPort > 65535;
+
+    if (invalidHost || invalidServerPort || invalidLocalPort) {
+      return ReadinessCheck(
+        domain: ReadinessDomain.config,
+        level: ReadinessLevel.blocked,
+        summary: 'Profile config for ${profile.name} is invalid.',
+        detail:
+            'Check server host / server port / local SOCKS port before connecting.',
+        action: ReadinessAction.openProfiles,
+        actionLabel: 'Open Profiles',
+      );
+    }
+
+    return ReadinessCheck(
+      domain: ReadinessDomain.config,
+      level: ReadinessLevel.ready,
+      summary: 'Profile config for ${profile.name} looks valid.',
+    );
+  }
+
+  ReadinessCheck _checkRuntimePath() {
+    final mode = _controller.runtimeConfig.mode;
+    if (mode.startsWith('stubbed-local-boundary')) {
+      return ReadinessCheck(
+        domain: ReadinessDomain.runtimePath,
+        level: ReadinessLevel.degraded,
+        summary: 'Runtime path is stubbed (${mode.replaceAll('-', ' ')}).',
+        detail:
+            'The app is not using a real runtime path yet. This is OK for product-shell testing but not a real execution proof.',
+        action: ReadinessAction.openTroubleshooting,
+        actionLabel: 'Open Troubleshooting',
+      );
+    }
+
+    return const ReadinessCheck(
+      domain: ReadinessDomain.runtimePath,
+      level: ReadinessLevel.ready,
+      summary: 'Runtime path is real.',
+    );
+  }
+
+  Future<ReadinessCheck> _checkRuntimeBinary() async {
+    final health = await _controller.checkHealth();
+    switch (health.level) {
+      case ControllerRuntimeHealthLevel.healthy:
+        return ReadinessCheck(
+          domain: ReadinessDomain.runtimeBinary,
+          level: ReadinessLevel.ready,
+          summary: health.summary,
+        );
+      case ControllerRuntimeHealthLevel.degraded:
+        return ReadinessCheck(
+          domain: ReadinessDomain.runtimeBinary,
+          level: ReadinessLevel.degraded,
+          summary: health.summary,
+          action: ReadinessAction.openTroubleshooting,
+          actionLabel: 'Open Troubleshooting',
+        );
+      case ControllerRuntimeHealthLevel.unavailable:
+        return ReadinessCheck(
+          domain: ReadinessDomain.runtimeBinary,
+          level: ReadinessLevel.blocked,
+          summary: health.summary,
+          detail: 'Fix the runtime binary before attempting a connection.',
+          action: ReadinessAction.openTroubleshooting,
+          actionLabel: 'Open Troubleshooting',
+        );
+    }
+  }
+
+  Future<ReadinessCheck> _checkFilesystem() async {
+    final layout = _filesystemLayout;
+    if (layout == null) {
+      return const ReadinessCheck(
+        domain: ReadinessDomain.filesystem,
+        level: ReadinessLevel.degraded,
+        summary: 'Filesystem layout is unavailable; runtime artifacts will use temp paths.',
+        detail:
+            'This can happen on unsupported platforms. It is OK for testing but not for persistent runtime use.',
+      );
+    }
+
+    final stateDirectory = Directory(layout.stateDirectoryPath);
+    try {
+      await stateDirectory.create(recursive: true);
+      final probeFile = File(
+        '${stateDirectory.path}${Platform.pathSeparator}readiness_probe.txt',
+      );
+      await probeFile.writeAsString('ok', flush: true);
+      await probeFile.delete();
+      return const ReadinessCheck(
+        domain: ReadinessDomain.filesystem,
+        level: ReadinessLevel.ready,
+        summary: 'Managed runtime path is writable.',
+      );
+    } catch (error) {
+      return ReadinessCheck(
+        domain: ReadinessDomain.filesystem,
+        level: ReadinessLevel.blocked,
+        summary: 'Managed runtime path is not writable.',
+        detail: error.toString(),
+        action: ReadinessAction.openTroubleshooting,
+        actionLabel: 'Open Troubleshooting',
+      );
+    }
+  }
+}

--- a/client/lib/features/readiness/application/readiness_service.dart
+++ b/client/lib/features/readiness/application/readiness_service.dart
@@ -28,9 +28,9 @@ class ReadinessService {
   final ClientControllerApi _controller;
   final ClientFilesystemLayout? _filesystemLayout;
 
-  Future<ReadinessReport> buildReport() async {
+  Future<ReadinessReport> buildReport({ClientProfile? profileOverride}) async {
     final checks = <ReadinessCheck>[];
-    final selectedProfile = _profileStore.selectedProfile;
+    final selectedProfile = profileOverride ?? _profileStore.selectedProfile;
 
     checks.add(_checkProfile(selectedProfile));
     checks.add(await _checkPassword(selectedProfile));

--- a/client/lib/features/readiness/application/readiness_service.dart
+++ b/client/lib/features/readiness/application/readiness_service.dart
@@ -9,6 +9,7 @@ import '../../profiles/domain/client_profile.dart';
 import '../../../platform/secure_storage/secure_storage.dart';
 import '../../../platform/services/client_filesystem_layout.dart';
 import '../../../platform/services/local_state_store.dart';
+import '../../controller/domain/runtime_posture.dart';
 import '../domain/readiness_report.dart';
 
 class ReadinessService {
@@ -217,14 +218,17 @@ class ReadinessService {
   }
 
   ReadinessCheck _checkRuntimePath() {
-    final mode = _controller.runtimeConfig.mode;
-    if (mode.startsWith('stubbed-local-boundary')) {
+    final posture = describeRuntimePosture(
+      runtimeMode: _controller.runtimeConfig.mode,
+      backendKind: _controller.telemetry.backendKind,
+    );
+    if (posture.isStubOnly) {
       return ReadinessCheck(
         domain: ReadinessDomain.runtimePath,
         level: ReadinessLevel.degraded,
-        summary: 'Runtime path is stubbed (${mode.replaceAll('-', ' ')}).',
-        detail:
-            'The app is not using a real runtime path yet. This is OK for product-shell testing but not a real execution proof.',
+        summary:
+            'Runtime posture is ${posture.postureLabel.toLowerCase()} (${posture.runtimeMode.replaceAll('-', ' ')}).',
+        detail: posture.truthNote,
         action: ReadinessAction.openTroubleshooting,
         actionLabel: 'Open Troubleshooting',
       );

--- a/client/lib/features/readiness/domain/readiness_refresh_fingerprint.dart
+++ b/client/lib/features/readiness/domain/readiness_refresh_fingerprint.dart
@@ -1,0 +1,23 @@
+import '../../profiles/domain/client_profile.dart';
+
+String buildReadinessRefreshFingerprint({
+  required ClientProfile? profile,
+  required String storageSummary,
+  required String runtimeMode,
+  required String runtimeEndpointHint,
+}) {
+  return <Object?>[
+    profile?.id,
+    profile?.name,
+    profile?.serverHost,
+    profile?.serverPort,
+    profile?.sni,
+    profile?.localSocksPort,
+    profile?.verifyTls,
+    profile?.hasStoredPassword,
+    profile?.updatedAt.toIso8601String(),
+    storageSummary,
+    runtimeMode,
+    runtimeEndpointHint,
+  ].join('|');
+}

--- a/client/lib/features/readiness/domain/readiness_report.dart
+++ b/client/lib/features/readiness/domain/readiness_report.dart
@@ -99,26 +99,24 @@ class ReadinessReport {
   }
 
   ReadinessRecommendation? get recommendation {
-    final candidate = checks.cast<ReadinessCheck?>().firstWhere(
+    final candidates = checks
+        .where(
           (check) =>
-              check != null &&
-              check.level == ReadinessLevel.blocked &&
+              check.level != ReadinessLevel.ready &&
               check.action != null &&
               check.actionLabel != null,
-          orElse: () => checks.cast<ReadinessCheck?>().firstWhere(
-                (check) =>
-                    check != null &&
-                    check.level == ReadinessLevel.degraded &&
-                    check.action != null &&
-                    check.actionLabel != null,
-                orElse: () => null,
-              ),
-        );
-    if (candidate == null ||
-        candidate.action == null ||
-        candidate.actionLabel == null) {
+        )
+        .toList()
+      ..sort(
+        (left, right) =>
+            _recommendationPriority(left) - _recommendationPriority(right),
+      );
+
+    if (candidates.isEmpty) {
       return null;
     }
+
+    final candidate = candidates.first;
     return ReadinessRecommendation(
       action: candidate.action!,
       label: candidate.actionLabel!,
@@ -154,6 +152,25 @@ class ReadinessReport {
       'checks': checks.map((check) => check.toJson()).toList(),
       'recommendation': recommendation?.toJson(),
     };
+  }
+
+  static int _recommendationPriority(ReadinessCheck check) {
+    final levelBase = switch (check.level) {
+      ReadinessLevel.blocked => 0,
+      ReadinessLevel.degraded => 100,
+      ReadinessLevel.ready => 1000,
+    };
+    final domainRank = switch (check.domain) {
+      ReadinessDomain.password => 0,
+      ReadinessDomain.profile => 1,
+      ReadinessDomain.config => 2,
+      ReadinessDomain.runtimeBinary => 3,
+      ReadinessDomain.filesystem => 4,
+      ReadinessDomain.secureStorage => 5,
+      ReadinessDomain.runtimePath => 6,
+      ReadinessDomain.environment => 7,
+    };
+    return levelBase + domainRank;
   }
 
   static ReadinessLevel _calculateOverallLevel(List<ReadinessCheck> checks) {

--- a/client/lib/features/readiness/domain/readiness_report.dart
+++ b/client/lib/features/readiness/domain/readiness_report.dart
@@ -29,6 +29,20 @@ enum ReadinessAction {
   openSettings,
 }
 
+enum ReadinessFreshness {
+  fresh,
+  aging,
+  stale,
+}
+
+extension ReadinessFreshnessLabel on ReadinessFreshness {
+  String get label => switch (this) {
+        ReadinessFreshness.fresh => 'Fresh',
+        ReadinessFreshness.aging => 'Aging',
+        ReadinessFreshness.stale => 'Stale',
+      };
+}
+
 class ReadinessCheck {
   const ReadinessCheck({
     required this.domain,
@@ -53,8 +67,9 @@ class ReadinessCheck {
       summary: summary,
       detail: value['detail'] is String ? value['detail'] as String : null,
       action: _enumByName(ReadinessAction.values, value['action']),
-      actionLabel:
-          value['actionLabel'] is String ? value['actionLabel'] as String : null,
+      actionLabel: value['actionLabel'] is String
+          ? value['actionLabel'] as String
+          : null,
     );
   }
 
@@ -102,11 +117,13 @@ class ReadinessReport {
     required this.overallLevel,
     required this.checks,
     required this.generatedAt,
+    this.isCachedSnapshot = false,
   });
 
   static ReadinessReport? fromJson(Object? value) {
     if (value is! Map) return null;
-    final overallLevel = _enumByName(ReadinessLevel.values, value['overallLevel']);
+    final overallLevel =
+        _enumByName(ReadinessLevel.values, value['overallLevel']);
     final generatedAtRaw = value['generatedAt'];
     final checksRaw = value['checks'];
     if (overallLevel == null ||
@@ -126,19 +143,26 @@ class ReadinessReport {
       overallLevel: overallLevel,
       checks: List<ReadinessCheck>.unmodifiable(checks),
       generatedAt: generatedAt,
+      isCachedSnapshot: value['isCachedSnapshot'] == true,
     );
   }
 
   final ReadinessLevel overallLevel;
   final List<ReadinessCheck> checks;
   final DateTime generatedAt;
+  final bool isCachedSnapshot;
 
-  static ReadinessReport fromChecks(List<ReadinessCheck> checks) {
+  static ReadinessReport fromChecks(
+    List<ReadinessCheck> checks, {
+    bool isCachedSnapshot = false,
+    DateTime? generatedAt,
+  }) {
     final overall = _calculateOverallLevel(checks);
     return ReadinessReport(
       overallLevel: overall,
       checks: List<ReadinessCheck>.unmodifiable(checks),
-      generatedAt: DateTime.now(),
+      generatedAt: generatedAt ?? DateTime.now(),
+      isCachedSnapshot: isCachedSnapshot,
     );
   }
 
@@ -174,8 +198,54 @@ class ReadinessReport {
         ReadinessLevel.ready => 'Ready for a quick test',
       };
 
+  Duration get age {
+    final now = DateTime.now();
+    return now.isAfter(generatedAt)
+        ? now.difference(generatedAt)
+        : Duration.zero;
+  }
+
+  ReadinessFreshness get freshness {
+    final reportAge = age;
+    if (reportAge >= const Duration(minutes: 5)) {
+      return ReadinessFreshness.stale;
+    }
+    if (reportAge >= const Duration(minutes: 1)) {
+      return ReadinessFreshness.aging;
+    }
+    return ReadinessFreshness.fresh;
+  }
+
+  String get sourceLabel => isCachedSnapshot ? 'Cached snapshot' : 'Live check';
+
+  String get freshnessLabel => switch (freshness) {
+        ReadinessFreshness.fresh =>
+          isCachedSnapshot ? 'Cached just now' : 'Fresh',
+        ReadinessFreshness.aging =>
+          isCachedSnapshot ? 'Cached a moment ago' : 'Aging',
+        ReadinessFreshness.stale =>
+          isCachedSnapshot ? 'Cached earlier' : 'Stale',
+      };
+
+  String get ageLabel {
+    final reportAge = age;
+    if (reportAge.inSeconds < 5) {
+      return 'just now';
+    }
+    if (reportAge.inMinutes < 1) {
+      return '${reportAge.inSeconds}s ago';
+    }
+    if (reportAge.inHours < 1) {
+      return '${reportAge.inMinutes}m ago';
+    }
+    return '${reportAge.inHours}h ago';
+  }
+
+  String get provenanceSummary => '$sourceLabel • $freshnessLabel • $ageLabel';
+
   String get summary {
-    final blocked = checks.where((check) => check.level == ReadinessLevel.blocked);
+    final blocked =
+        checks.where((check) => check.level == ReadinessLevel.blocked);
     if (blocked.isNotEmpty) {
       return blocked.first.detail ?? blocked.first.summary;
     }
@@ -187,14 +257,32 @@ class ReadinessReport {
     return 'All readiness checks look healthy.';
   }
 
+  ReadinessReport copyWith({
+    ReadinessLevel? overallLevel,
+    List<ReadinessCheck>? checks,
+    DateTime? generatedAt,
+    bool? isCachedSnapshot,
+  }) {
+    return ReadinessReport(
+      overallLevel: overallLevel ?? this.overallLevel,
+      checks: List<ReadinessCheck>.unmodifiable(checks ?? this.checks),
+      generatedAt: generatedAt ?? this.generatedAt,
+      isCachedSnapshot: isCachedSnapshot ?? this.isCachedSnapshot,
+    );
+  }
+
   Map<String, Object?> toJson() {
     return <String, Object?>{
       'overallLevel': overallLevel.name,
       'headline': headline,
       'summary': summary,
       'generatedAt': generatedAt.toIso8601String(),
+      'isCachedSnapshot': isCachedSnapshot,
       'checks': checks.map((check) => check.toJson()).toList(),
       'recommendation': recommendation?.toJson(),
+      'sourceLabel': sourceLabel,
+      'freshnessLabel': freshnessLabel,
+      'ageLabel': ageLabel,
     };
   }
 

--- a/client/lib/features/readiness/domain/readiness_report.dart
+++ b/client/lib/features/readiness/domain/readiness_report.dart
@@ -99,18 +99,24 @@ class ReadinessReport {
   }
 
   ReadinessRecommendation? get recommendation {
-    final candidate = checks.firstWhere(
-      (check) =>
-          check.level == ReadinessLevel.blocked &&
-          check.action != null &&
-          check.actionLabel != null,
-      orElse: () => const ReadinessCheck(
-        domain: ReadinessDomain.profile,
-        level: ReadinessLevel.ready,
-        summary: '',
-      ),
-    );
-    if (candidate.action == null || candidate.actionLabel == null) {
+    final candidate = checks.cast<ReadinessCheck?>().firstWhere(
+          (check) =>
+              check != null &&
+              check.level == ReadinessLevel.blocked &&
+              check.action != null &&
+              check.actionLabel != null,
+          orElse: () => checks.cast<ReadinessCheck?>().firstWhere(
+                (check) =>
+                    check != null &&
+                    check.level == ReadinessLevel.degraded &&
+                    check.action != null &&
+                    check.actionLabel != null,
+                orElse: () => null,
+              ),
+        );
+    if (candidate == null ||
+        candidate.action == null ||
+        candidate.actionLabel == null) {
       return null;
     }
     return ReadinessRecommendation(

--- a/client/lib/features/readiness/domain/readiness_report.dart
+++ b/client/lib/features/readiness/domain/readiness_report.dart
@@ -1,0 +1,162 @@
+enum ReadinessLevel {
+  ready,
+  degraded,
+  blocked,
+}
+
+extension ReadinessLevelLabel on ReadinessLevel {
+  String get label => switch (this) {
+        ReadinessLevel.ready => 'Ready',
+        ReadinessLevel.degraded => 'Ready with warnings',
+        ReadinessLevel.blocked => 'Blocked',
+      };
+}
+
+enum ReadinessDomain {
+  profile,
+  password,
+  secureStorage,
+  environment,
+  config,
+  runtimePath,
+  runtimeBinary,
+  filesystem,
+}
+
+enum ReadinessAction {
+  openProfiles,
+  openTroubleshooting,
+  openSettings,
+}
+
+class ReadinessCheck {
+  const ReadinessCheck({
+    required this.domain,
+    required this.level,
+    required this.summary,
+    this.detail,
+    this.action,
+    this.actionLabel,
+  });
+
+  final ReadinessDomain domain;
+  final ReadinessLevel level;
+  final String summary;
+  final String? detail;
+  final ReadinessAction? action;
+  final String? actionLabel;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'domain': domain.name,
+      'level': level.name,
+      'summary': summary,
+      'detail': detail,
+      'action': action?.name,
+      'actionLabel': actionLabel,
+    };
+  }
+}
+
+class ReadinessRecommendation {
+  const ReadinessRecommendation({
+    required this.action,
+    required this.label,
+    required this.detail,
+  });
+
+  final ReadinessAction action;
+  final String label;
+  final String detail;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'action': action.name,
+      'label': label,
+      'detail': detail,
+    };
+  }
+}
+
+class ReadinessReport {
+  const ReadinessReport({
+    required this.overallLevel,
+    required this.checks,
+    required this.generatedAt,
+  });
+
+  final ReadinessLevel overallLevel;
+  final List<ReadinessCheck> checks;
+  final DateTime generatedAt;
+
+  static ReadinessReport fromChecks(List<ReadinessCheck> checks) {
+    final overall = _calculateOverallLevel(checks);
+    return ReadinessReport(
+      overallLevel: overall,
+      checks: List<ReadinessCheck>.unmodifiable(checks),
+      generatedAt: DateTime.now(),
+    );
+  }
+
+  ReadinessRecommendation? get recommendation {
+    final candidate = checks.firstWhere(
+      (check) =>
+          check.level == ReadinessLevel.blocked &&
+          check.action != null &&
+          check.actionLabel != null,
+      orElse: () => const ReadinessCheck(
+        domain: ReadinessDomain.profile,
+        level: ReadinessLevel.ready,
+        summary: '',
+      ),
+    );
+    if (candidate.action == null || candidate.actionLabel == null) {
+      return null;
+    }
+    return ReadinessRecommendation(
+      action: candidate.action!,
+      label: candidate.actionLabel!,
+      detail: candidate.detail ?? candidate.summary,
+    );
+  }
+
+  String get headline => switch (overallLevel) {
+        ReadinessLevel.blocked => 'Connect blocked',
+        ReadinessLevel.degraded => 'Ready with warnings',
+        ReadinessLevel.ready => 'Ready for a quick test',
+      };
+
+  String get summary {
+    final blocked = checks.where((check) => check.level == ReadinessLevel.blocked);
+    if (blocked.isNotEmpty) {
+      return blocked.first.detail ?? blocked.first.summary;
+    }
+    final degraded =
+        checks.where((check) => check.level == ReadinessLevel.degraded);
+    if (degraded.isNotEmpty) {
+      return degraded.first.detail ?? degraded.first.summary;
+    }
+    return 'All readiness checks look healthy.';
+  }
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'overallLevel': overallLevel.name,
+      'headline': headline,
+      'summary': summary,
+      'generatedAt': generatedAt.toIso8601String(),
+      'checks': checks.map((check) => check.toJson()).toList(),
+      'recommendation': recommendation?.toJson(),
+    };
+  }
+
+  static ReadinessLevel _calculateOverallLevel(List<ReadinessCheck> checks) {
+    if (checks.any((check) => check.level == ReadinessLevel.blocked)) {
+      return ReadinessLevel.blocked;
+    }
+    if (checks.any((check) => check.level == ReadinessLevel.degraded)) {
+      return ReadinessLevel.degraded;
+    }
+    return ReadinessLevel.ready;
+  }
+}

--- a/client/lib/features/readiness/domain/readiness_report.dart
+++ b/client/lib/features/readiness/domain/readiness_report.dart
@@ -39,6 +39,25 @@ class ReadinessCheck {
     this.actionLabel,
   });
 
+  static ReadinessCheck? fromJson(Object? value) {
+    if (value is! Map) return null;
+    final domain = _enumByName(ReadinessDomain.values, value['domain']);
+    final level = _enumByName(ReadinessLevel.values, value['level']);
+    final summary = value['summary'];
+    if (domain == null || level == null || summary is! String) {
+      return null;
+    }
+    return ReadinessCheck(
+      domain: domain,
+      level: level,
+      summary: summary,
+      detail: value['detail'] is String ? value['detail'] as String : null,
+      action: _enumByName(ReadinessAction.values, value['action']),
+      actionLabel:
+          value['actionLabel'] is String ? value['actionLabel'] as String : null,
+    );
+  }
+
   final ReadinessDomain domain;
   final ReadinessLevel level;
   final String summary;
@@ -84,6 +103,31 @@ class ReadinessReport {
     required this.checks,
     required this.generatedAt,
   });
+
+  static ReadinessReport? fromJson(Object? value) {
+    if (value is! Map) return null;
+    final overallLevel = _enumByName(ReadinessLevel.values, value['overallLevel']);
+    final generatedAtRaw = value['generatedAt'];
+    final checksRaw = value['checks'];
+    if (overallLevel == null ||
+        generatedAtRaw is! String ||
+        checksRaw is! List) {
+      return null;
+    }
+    final generatedAt = DateTime.tryParse(generatedAtRaw);
+    if (generatedAt == null) {
+      return null;
+    }
+    final checks = checksRaw
+        .map(ReadinessCheck.fromJson)
+        .whereType<ReadinessCheck>()
+        .toList();
+    return ReadinessReport(
+      overallLevel: overallLevel,
+      checks: List<ReadinessCheck>.unmodifiable(checks),
+      generatedAt: generatedAt,
+    );
+  }
 
   final ReadinessLevel overallLevel;
   final List<ReadinessCheck> checks;
@@ -182,4 +226,12 @@ class ReadinessReport {
     }
     return ReadinessLevel.ready;
   }
+}
+
+T? _enumByName<T extends Enum>(List<T> values, Object? raw) {
+  if (raw is! String) return null;
+  for (final value in values) {
+    if (value.name == raw) return value;
+  }
+  return null;
 }

--- a/client/lib/features/readiness/presentation/readiness_surface_controller.dart
+++ b/client/lib/features/readiness/presentation/readiness_surface_controller.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/widgets.dart';
+
+import '../domain/readiness_report.dart';
+
+typedef ReadinessReportRestorer = Future<ReadinessReport?> Function();
+typedef ReadinessReportBuilder = Future<ReadinessReport> Function();
+
+class ReadinessSurfaceController {
+  ReadinessSurfaceController({
+    required bool Function() isMounted,
+    required StateSetter applyState,
+  })  : _isMounted = isMounted,
+        _applyState = applyState;
+
+  final bool Function() _isMounted;
+  final StateSetter _applyState;
+
+  Future<ReadinessReport>? _future;
+  ReadinessReport? _latestReport;
+  String? _lastRefreshKey;
+  int _requestToken = 0;
+  int _lastAppliedLiveToken = -1;
+
+  Future<ReadinessReport>? get future => _future;
+  ReadinessReport? get latestReport => _latestReport;
+
+  void replaceLatestReport(ReadinessReport report) {
+    _setState(() {
+      _latestReport = report;
+    });
+  }
+
+  void initialize({
+    required String refreshKey,
+    required ReadinessReportRestorer restoreReport,
+    required ReadinessReportBuilder buildReport,
+  }) {
+    _lastRefreshKey = refreshKey;
+    startCycle(
+      restoreReport: restoreReport,
+      buildReport: buildReport,
+    );
+  }
+
+  void refreshIfKeyChanged(
+    String refreshKey, {
+    required ReadinessReportRestorer restoreReport,
+    required ReadinessReportBuilder buildReport,
+  }) {
+    if (_lastRefreshKey == refreshKey) return;
+    _lastRefreshKey = refreshKey;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_isMounted()) return;
+      startCycle(
+        restoreReport: restoreReport,
+        buildReport: buildReport,
+      );
+    });
+  }
+
+  void startCycle({
+    required ReadinessReportRestorer restoreReport,
+    required ReadinessReportBuilder buildReport,
+  }) {
+    _requestToken++;
+    final requestToken = _requestToken;
+    _restoreLastKnownReadiness(
+      requestToken: requestToken,
+      restoreReport: restoreReport,
+    );
+    _refreshReadiness(
+      requestToken: requestToken,
+      buildReport: buildReport,
+    );
+  }
+
+  void _restoreLastKnownReadiness({
+    required int requestToken,
+    required ReadinessReportRestorer restoreReport,
+  }) {
+    restoreReport().then((report) {
+      if (!_isMounted() || report == null) return;
+      if (requestToken != _requestToken) return;
+      if (_lastAppliedLiveToken == requestToken) return;
+      _setState(() {
+        _latestReport = report;
+      });
+    });
+  }
+
+  void _refreshReadiness({
+    required int requestToken,
+    required ReadinessReportBuilder buildReport,
+  }) {
+    final future = buildReport();
+    _setState(() {
+      _future = future;
+    });
+    future.then((report) {
+      if (!_isMounted()) return;
+      if (requestToken != _requestToken) return;
+      if (!identical(_future, future)) return;
+      _setState(() {
+        _lastAppliedLiveToken = requestToken;
+        _latestReport = report;
+      });
+    });
+  }
+
+  void _setState(VoidCallback fn) {
+    if (!_isMounted()) return;
+    _applyState(fn);
+  }
+}

--- a/client/lib/features/settings/presentation/settings_page.dart
+++ b/client/lib/features/settings/presentation/settings_page.dart
@@ -26,208 +26,236 @@ class SettingsPage extends StatelessWidget {
         final quickActions = services.desktopLifecycle.quickActions;
         final packagingWorkflow = services.packagingStore.state;
 
-        return SectionCard(
-          title: 'Settings',
-          subtitle: 'Product-layer settings, not runtime internals.',
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              DropdownButtonFormField<ThemeMode>(
-                key: ValueKey<String>('theme-mode-${settings.themeMode.name}'),
-                initialValue: settings.themeMode,
-                decoration: const InputDecoration(labelText: 'Appearance'),
-                items: ThemeMode.values
-                    .map(
-                      (mode) => DropdownMenuItem<ThemeMode>(
-                        value: mode,
-                        child: Text(mode.name),
-                      ),
-                    )
-                    .toList(),
-                onChanged: (ThemeMode? value) {
-                  if (value != null) services.settingsStore.setThemeMode(value);
-                },
-              ),
-              const SizedBox(height: 16),
-              DropdownButtonFormField<UpdateChannel>(
-                key: ValueKey<String>(
-                  'update-channel-${settings.updateChannel.name}',
+        return SingleChildScrollView(
+          child: SectionCard(
+            title: 'Settings',
+            subtitle: 'Product-layer settings, not runtime internals.',
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                DropdownButtonFormField<ThemeMode>(
+                  key:
+                      ValueKey<String>('theme-mode-${settings.themeMode.name}'),
+                  initialValue: settings.themeMode,
+                  decoration: const InputDecoration(labelText: 'Appearance'),
+                  items: ThemeMode.values
+                      .map(
+                        (mode) => DropdownMenuItem<ThemeMode>(
+                          value: mode,
+                          child: Text(mode.name),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (ThemeMode? value) {
+                    if (value != null) {
+                      services.settingsStore.setThemeMode(value);
+                    }
+                  },
                 ),
-                initialValue: settings.updateChannel,
-                decoration: const InputDecoration(labelText: 'Update Track'),
-                items: UpdateChannel.values
-                    .map(
-                      (channel) => DropdownMenuItem<UpdateChannel>(
-                        value: channel,
-                        child: Text(channel.name),
-                      ),
-                    )
-                    .toList(),
-                onChanged: (UpdateChannel? value) {
-                  if (value != null) {
-                    services.settingsStore.setUpdateChannel(value);
+                const SizedBox(height: 16),
+                DropdownButtonFormField<UpdateChannel>(
+                  key: ValueKey<String>(
+                    'update-channel-${settings.updateChannel.name}',
+                  ),
+                  initialValue: settings.updateChannel,
+                  decoration: const InputDecoration(labelText: 'Update Track'),
+                  items: UpdateChannel.values
+                      .map(
+                        (channel) => DropdownMenuItem<UpdateChannel>(
+                          value: channel,
+                          child: Text(channel.name),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (UpdateChannel? value) {
+                    if (value != null) {
+                      services.settingsStore.setUpdateChannel(value);
+                      services.packagingStore.syncUpdatePreferences(
+                        channel: value,
+                        autoCheckForUpdates:
+                            services.settingsStore.settings.autoCheckForUpdates,
+                      );
+                    }
+                  },
+                ),
+                const SizedBox(height: 8),
+                SwitchListTile(
+                  contentPadding: EdgeInsets.zero,
+                  value: settings.autoCheckForUpdates,
+                  onChanged: (bool value) {
+                    services.settingsStore.setAutoCheckForUpdates(value);
                     services.packagingStore.syncUpdatePreferences(
-                      channel: value,
-                      autoCheckForUpdates:
-                          services.settingsStore.settings.autoCheckForUpdates,
+                      channel: services.settingsStore.settings.updateChannel,
+                      autoCheckForUpdates: value,
                     );
-                  }
-                },
-              ),
-              const SizedBox(height: 8),
-              SwitchListTile(
-                contentPadding: EdgeInsets.zero,
-                value: settings.autoCheckForUpdates,
-                onChanged: (bool value) {
-                  services.settingsStore.setAutoCheckForUpdates(value);
-                  services.packagingStore.syncUpdatePreferences(
-                    channel: services.settingsStore.settings.updateChannel,
-                    autoCheckForUpdates: value,
-                  );
-                },
-                title: const Text('Check for updates automatically'),
-              ),
-              Wrap(
-                spacing: 12,
-                runSpacing: 8,
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: <Widget>[
-                  FilledButton.tonal(
-                    onPressed: settings.autoCheckForUpdates
-                        ? () => services.packagingStore.runStubUpdateCheck()
-                        : null,
-                    child: const Text('Check for updates now'),
-                  ),
-                  Text('Status: ${packagingWorkflow.updateCheckStatusLabel}'),
-                ],
-              ),
-              const SizedBox(height: 8),
-              Text(
-                'Update boundary: contract ${packagingWorkflow.releaseMetadataContractVersion} · ${packagingWorkflow.rolloutPolicySummary}',
-              ),
-              SwitchListTile(
-                contentPadding: EdgeInsets.zero,
-                value: settings.launchOnLogin,
-                onChanged: services.settingsStore.setLaunchOnLogin,
-                title: const Text('Open on login'),
-              ),
-              const SizedBox(height: 8),
-              DropdownButtonFormField<DesktopCloseBehavior>(
-                key: ValueKey<String>(
-                  'close-behavior-${settings.desktopCloseBehavior.name}',
+                  },
+                  title: const Text('Check for updates automatically'),
                 ),
-                initialValue: settings.desktopCloseBehavior,
-                decoration:
-                    const InputDecoration(labelText: 'Window close behavior'),
-                items: DesktopCloseBehavior.values
-                    .map(
-                      (behavior) => DropdownMenuItem<DesktopCloseBehavior>(
-                        value: behavior,
-                        child: Text(_closeBehaviorLabel(behavior)),
-                      ),
-                    )
-                    .toList(),
-                onChanged: (DesktopCloseBehavior? value) {
-                  if (value != null) {
-                    services.settingsStore.setDesktopCloseBehavior(value);
-                  }
-                },
-              ),
-              SwitchListTile(
-                contentPadding: EdgeInsets.zero,
-                value: settings.collectDiagnostics,
-                onChanged: services.settingsStore.setCollectDiagnostics,
-                title: const Text('Collect troubleshooting data'),
-              ),
-              const SizedBox(height: 8),
-              Row(
-                children: <Widget>[
-                  const Expanded(child: Text('Diagnostics retention (days)')),
-                  DropdownButton<int>(
-                    value: settings.diagnosticsRetentionDays,
-                    items: const <int>[3, 7, 14, 30]
-                        .map(
-                          (int value) => DropdownMenuItem<int>(
-                            value: value,
-                            child: Text('$value'),
-                          ),
-                        )
-                        .toList(),
-                    onChanged: (int? value) {
-                      if (value != null) {
-                        services.settingsStore
-                            .setDiagnosticsRetentionDays(value);
-                      }
-                    },
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 8,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: <Widget>[
+                    FilledButton.tonal(
+                      onPressed: settings.autoCheckForUpdates
+                          ? () => services.packagingStore.runStubUpdateCheck()
+                          : null,
+                      child: const Text('Check for updates now'),
+                    ),
+                    Text('Status: ${packagingWorkflow.updateCheckStatusLabel}'),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Update boundary: contract ${packagingWorkflow.releaseMetadataContractVersion} · ${packagingWorkflow.rolloutPolicySummary}',
+                ),
+                SwitchListTile(
+                  contentPadding: EdgeInsets.zero,
+                  value: settings.launchOnLogin,
+                  onChanged: services.settingsStore.setLaunchOnLogin,
+                  title: const Text('Open on login'),
+                ),
+                const SizedBox(height: 8),
+                DropdownButtonFormField<DesktopCloseBehavior>(
+                  key: ValueKey<String>(
+                    'close-behavior-${settings.desktopCloseBehavior.name}',
                   ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              const Divider(),
-              const SizedBox(height: 12),
-              Text(
-                'Desktop lifecycle policy',
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              Text(
-                'Close: ${lifecyclePolicy.closeSemanticsSummary(trayReady: lifecycleStatus.trayReady)}',
-              ),
-              const SizedBox(height: 4),
-              Text(
-                'Minimize: ${lifecyclePolicy.minimizeSemanticsSummary()}',
-              ),
-              const SizedBox(height: 4),
-              Text('Quit: ${lifecyclePolicy.quitSemanticsSummary()}'),
-              const SizedBox(height: 8),
-              Text('Lifecycle status: ${lifecycleStatus.summary}'),
-              const SizedBox(height: 4),
-              Text(
-                'Tray integration: ${lifecycleStatus.trayReady ? 'ready' : 'unavailable'}',
-              ),
-              const SizedBox(height: 4),
-              Text(
-                'Close interception: ${lifecycleStatus.closeInterceptEnabled ? 'enabled' : 'disabled'}',
-              ),
-              const SizedBox(height: 4),
-              Text(
-                'Duplicate launch: ${lifecyclePolicy.duplicateLaunchSummary(singleInstancePrimary: lifecycleStatus.singleInstancePrimary)}',
-              ),
-              const SizedBox(height: 4),
-              Text(
-                'Tray policy: ${lifecyclePolicy.trayPolicySummary()}',
-              ),
-              const SizedBox(height: 4),
-              Text(
-                'Quick actions profile: ${quickActions.profileSummary()}',
-              ),
-              const SizedBox(height: 4),
-              Text(
-                'Quick actions readiness: ${quickActions.readinessSummary(trayReady: lifecycleStatus.trayReady)}',
-              ),
-              const SizedBox(height: 4),
-              Text(
-                'External activation: ${lifecycleStatus.externalActivationSummary()}',
-              ),
-              const SizedBox(height: 16),
-              const Divider(),
-              const SizedBox(height: 12),
-              Text(
-                'Update channel skeleton',
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              Text(
-                  'Current channel: ${packagingWorkflow.selectedChannel.name}'),
-              const SizedBox(height: 4),
-              Text(
-                'Last check: ${formatTimestamp(packagingWorkflow.lastUpdateCheckAt)}',
-              ),
-              const SizedBox(height: 4),
-              const Text(
-                'Self-update is not wired in v1.3.0; current actions only exercise the product boundary and metadata contract.',
-              ),
-            ],
+                  initialValue: settings.desktopCloseBehavior,
+                  decoration:
+                      const InputDecoration(labelText: 'Window close behavior'),
+                  items: DesktopCloseBehavior.values
+                      .map(
+                        (behavior) => DropdownMenuItem<DesktopCloseBehavior>(
+                          value: behavior,
+                          child: Text(_closeBehaviorLabel(behavior)),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (DesktopCloseBehavior? value) {
+                    if (value != null) {
+                      services.settingsStore.setDesktopCloseBehavior(value);
+                    }
+                  },
+                ),
+                SwitchListTile(
+                  contentPadding: EdgeInsets.zero,
+                  value: settings.collectDiagnostics,
+                  onChanged: services.settingsStore.setCollectDiagnostics,
+                  title: const Text('Collect troubleshooting data'),
+                ),
+                const SizedBox(height: 8),
+                LayoutBuilder(
+                  builder: (BuildContext context, BoxConstraints constraints) {
+                    final useStackedLayout = constraints.maxWidth < 520;
+                    final dropdown = DropdownButton<int>(
+                      value: settings.diagnosticsRetentionDays,
+                      items: const <int>[3, 7, 14, 30]
+                          .map(
+                            (int value) => DropdownMenuItem<int>(
+                              value: value,
+                              child: Text('$value'),
+                            ),
+                          )
+                          .toList(),
+                      onChanged: (int? value) {
+                        if (value != null) {
+                          services.settingsStore
+                              .setDiagnosticsRetentionDays(value);
+                        }
+                      },
+                    );
+
+                    if (useStackedLayout) {
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          const Text(
+                            'Diagnostics retention (days)',
+                            style: TextStyle(fontWeight: FontWeight.w600),
+                          ),
+                          const SizedBox(height: 8),
+                          dropdown,
+                        ],
+                      );
+                    }
+
+                    return Row(
+                      children: <Widget>[
+                        const Expanded(
+                          child: Text('Diagnostics retention (days)'),
+                        ),
+                        dropdown,
+                      ],
+                    );
+                  },
+                ),
+                const SizedBox(height: 16),
+                const Divider(),
+                const SizedBox(height: 12),
+                Text(
+                  'Desktop lifecycle policy',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Close: ${lifecyclePolicy.closeSemanticsSummary(trayReady: lifecycleStatus.trayReady)}',
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Minimize: ${lifecyclePolicy.minimizeSemanticsSummary()}',
+                ),
+                const SizedBox(height: 4),
+                Text('Quit: ${lifecyclePolicy.quitSemanticsSummary()}'),
+                const SizedBox(height: 8),
+                Text('Lifecycle status: ${lifecycleStatus.summary}'),
+                const SizedBox(height: 4),
+                Text(
+                  'Tray integration: ${lifecycleStatus.trayReady ? 'ready' : 'unavailable'}',
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Close interception: ${lifecycleStatus.closeInterceptEnabled ? 'enabled' : 'disabled'}',
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Duplicate launch: ${lifecyclePolicy.duplicateLaunchSummary(singleInstancePrimary: lifecycleStatus.singleInstancePrimary)}',
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Tray policy: ${lifecyclePolicy.trayPolicySummary()}',
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Quick actions profile: ${quickActions.profileSummary()}',
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Quick actions readiness: ${quickActions.readinessSummary(trayReady: lifecycleStatus.trayReady)}',
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'External activation: ${lifecycleStatus.externalActivationSummary()}',
+                ),
+                const SizedBox(height: 16),
+                const Divider(),
+                const SizedBox(height: 12),
+                Text(
+                  'Update channel skeleton',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                    'Current channel: ${packagingWorkflow.selectedChannel.name}'),
+                const SizedBox(height: 4),
+                Text(
+                  'Last check: ${formatTimestamp(packagingWorkflow.lastUpdateCheckAt)}',
+                ),
+                const SizedBox(height: 4),
+                const Text(
+                  'Self-update is not wired in v1.3.0; current actions only exercise the product boundary and metadata contract.',
+                ),
+              ],
+            ),
           ),
         );
       },

--- a/client/lib/platform/services/service_registry.dart
+++ b/client/lib/platform/services/service_registry.dart
@@ -9,6 +9,7 @@ import '../../features/packaging/application/packaging_store.dart';
 import '../../features/profiles/application/profile_portability_service.dart';
 import '../../features/profiles/application/profile_secrets_service.dart';
 import '../../features/profiles/application/profile_store.dart';
+import '../../features/readiness/application/readiness_service.dart';
 import '../../features/settings/application/settings_store.dart';
 import '../secure_storage/secure_storage.dart';
 import 'app_runtime_error_store.dart';
@@ -29,6 +30,7 @@ class ClientServiceRegistry {
     required this.packagingExport,
     required this.settingsStore,
     required this.controller,
+    required this.readiness,
     required this.diagnostics,
     DesktopLifecycleService? desktopLifecycle,
     AppRuntimeErrorStore? appRuntimeErrors,
@@ -45,6 +47,7 @@ class ClientServiceRegistry {
   final PackagingExportService packagingExport;
   final SettingsStore settingsStore;
   final ClientControllerApi controller;
+  final ReadinessService readiness;
   final DiagnosticsExportService diagnostics;
   final DesktopLifecycleService desktopLifecycle;
   final AppRuntimeErrorStore appRuntimeErrors;

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: trojan_pro_client
 description: Desktop-first, mobile-ready client shell for Trojan-Pro.
 publish_to: "none"
-version: 0.1.0+1
+version: 1.4.0-beta.1+1
 
 environment:
   sdk: ^3.3.0

--- a/client/test/app/app_shell_test.dart
+++ b/client/test/app/app_shell_test.dart
@@ -26,6 +26,13 @@ Future<void> _setDesktopSurface(WidgetTester tester) async {
   });
 }
 
+Future<void> _setCompactSurface(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(430, 1400));
+  addTearDown(() async {
+    await tester.binding.setSurfaceSize(null);
+  });
+}
+
 class _UnavailableRuntimeController extends FakeClientController {
   @override
   Future<ControllerRuntimeHealth> checkHealth() async {
@@ -95,6 +102,29 @@ ClientServiceRegistry _buildServices(
 }
 
 void main() {
+  testWidgets('shell uses bottom navigation on compact width',
+      (WidgetTester tester) async {
+    await _setCompactSurface(tester);
+    final services = _buildServices();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TrojanClientAppShell(services: services),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(NavigationBar), findsOneWidget);
+    expect(find.byType(NavigationRail), findsNothing);
+
+    await tester.tap(find.text('Profiles').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Set Password First'), findsOneWidget);
+    expect(find.textContaining('Controller status:'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('external activation switches shell back to Home tab',
       (WidgetTester tester) async {
     await _setDesktopSurface(tester);

--- a/client/test/app/app_shell_test.dart
+++ b/client/test/app/app_shell_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:trojan_pro_client/app/app_shell.dart';
+import 'package:trojan_pro_client/features/controller/application/client_controller_api.dart';
 import 'package:trojan_pro_client/features/controller/application/fake_client_controller.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_health.dart';
 import 'package:trojan_pro_client/features/diagnostics/application/diagnostics_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_store.dart';
@@ -24,7 +26,19 @@ Future<void> _setDesktopSurface(WidgetTester tester) async {
   });
 }
 
-ClientServiceRegistry _buildServices() {
+class _UnavailableRuntimeController extends FakeClientController {
+  @override
+  Future<ControllerRuntimeHealth> checkHealth() async {
+    return ControllerRuntimeHealth(
+      level: ControllerRuntimeHealthLevel.unavailable,
+      summary: 'runtime binary missing for this test',
+      updatedAt: DateTime.parse('2026-03-20T00:00:00.000Z'),
+    );
+  }
+}
+
+ClientServiceRegistry _buildServices(
+    {ClientControllerApi? controllerOverride}) {
   final localState = MemoryLocalStateStore();
   final secureStorage = MemorySecureStorage();
   final diagnosticsExporter = MemoryDiagnosticsFileExporter();
@@ -40,7 +54,7 @@ ClientServiceRegistry _buildServices() {
     localStateStore: localState,
     serialization: SettingsSerialization(),
   );
-  final controller = FakeClientController();
+  final controller = controllerOverride ?? FakeClientController();
 
   final packagingExport = PackagingExportService(
     packagingStore: packagingStore,
@@ -110,5 +124,49 @@ void main() {
 
     expect(find.text('Recent desktop activation'), findsOneWidget);
     expect(find.text('Desktop lifecycle policy'), findsNothing);
+  });
+
+  testWidgets('profiles readiness recommendation can open Advanced tab',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    final services = _buildServices(
+      controllerOverride: _UnavailableRuntimeController(),
+    );
+    final profile = services.profileStore.selectedProfile!;
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: profile.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      profile.copyWith(hasStoredPassword: true),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TrojanClientAppShell(services: services),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.descendant(
+        of: find.byType(NavigationRail),
+        matching: find.text('Profiles'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Recommended next step: Open Troubleshooting'),
+        findsOneWidget);
+
+    await tester
+        .tap(find.widgetWithText(OutlinedButton, 'Open Troubleshooting'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Troubleshooting Overview'), findsOneWidget);
+    expect(
+        find.widgetWithText(FilledButton, 'Generate preview'), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, 'Check for Updates (Stub)'),
+        findsNothing);
   });
 }

--- a/client/test/app/app_shell_test.dart
+++ b/client/test/app/app_shell_test.dart
@@ -9,6 +9,7 @@ import 'package:trojan_pro_client/features/profiles/application/profile_portabil
 import 'package:trojan_pro_client/features/profiles/application/profile_secrets_service.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_serialization.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_store.dart';
+import 'package:trojan_pro_client/features/readiness/application/readiness_service.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_serialization.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_store.dart';
 import 'package:trojan_pro_client/platform/secure_storage/memory_secure_storage.dart';
@@ -45,6 +46,13 @@ ClientServiceRegistry _buildServices() {
     packagingStore: packagingStore,
     fileExporter: diagnosticsExporter,
   );
+  final readiness = ReadinessService(
+    profileStore: profileStore,
+    profileSecrets: profileSecrets,
+    secureStorage: secureStorage,
+    controller: controller,
+  );
+
   final diagnostics = DiagnosticsExportService(
     profileStore: profileStore,
     profilePortability: profilePortability,
@@ -53,6 +61,7 @@ ClientServiceRegistry _buildServices() {
     controller: controller,
     secureStorage: secureStorage,
     fileExporter: diagnosticsExporter,
+    readiness: readiness,
   );
 
   return ClientServiceRegistry(
@@ -66,6 +75,7 @@ ClientServiceRegistry _buildServices() {
     packagingExport: packagingExport,
     settingsStore: settingsStore,
     controller: controller,
+    readiness: readiness,
     diagnostics: diagnostics,
   );
 }

--- a/client/test/app/app_shell_test.dart
+++ b/client/test/app/app_shell_test.dart
@@ -122,6 +122,17 @@ void main() {
 
     expect(find.text('Set Password First'), findsOneWidget);
     expect(find.textContaining('Controller status:'), findsOneWidget);
+
+    await tester.tap(find.text('Settings').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Window close behavior'), findsOneWidget);
+    expect(find.text('Diagnostics retention (days)'), findsOneWidget);
+
+    await tester.tap(find.text('Advanced').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Troubleshooting Overview'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 

--- a/client/test/app/app_shell_test.dart
+++ b/client/test/app/app_shell_test.dart
@@ -206,7 +206,9 @@ void main() {
 
     expect(find.text('Troubleshooting Overview'), findsOneWidget);
     expect(
-        find.widgetWithText(FilledButton, 'Generate preview'), findsOneWidget);
+      find.widgetWithText(FilledButton, 'Generate support preview'),
+      findsOneWidget,
+    );
     expect(find.widgetWithText(OutlinedButton, 'Check for Updates (Stub)'),
         findsNothing);
   });

--- a/client/test/features/advanced/presentation/advanced_page_test.dart
+++ b/client/test/features/advanced/presentation/advanced_page_test.dart
@@ -140,6 +140,8 @@ void main() {
     await tester.pump();
 
     expect(find.text('Troubleshooting Overview'), findsOneWidget);
+    expect(find.text('Runtime posture'), findsOneWidget);
+    expect(find.text('Stub-only'), findsWidgets);
     expect(find.text('What to try next'), findsOneWidget);
     expect(
       find.widgetWithText(FilledButton, 'Open Problem Report'),

--- a/client/test/features/advanced/presentation/advanced_page_test.dart
+++ b/client/test/features/advanced/presentation/advanced_page_test.dart
@@ -146,7 +146,11 @@ void main() {
     expect(find.text('Shell-grade only'), findsWidgets);
     expect(find.text('What to try next'), findsOneWidget);
     expect(
-      find.widgetWithText(FilledButton, 'Open Problem Report'),
+      find.text('Runtime-proof artifact unavailable on current posture'),
+      findsWidgets,
+    );
+    expect(
+      find.widgetWithText(FilledButton, 'Open Support Bundle'),
       findsOneWidget,
     );
   });
@@ -193,7 +197,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-        find.widgetWithText(FilledButton, 'Generate preview'), findsOneWidget);
+      find.widgetWithText(FilledButton, 'Generate support preview'),
+      findsOneWidget,
+    );
     expect(find.widgetWithText(OutlinedButton, 'Check for Updates (Stub)'),
         findsNothing);
 
@@ -202,6 +208,9 @@ void main() {
 
     expect(find.widgetWithText(OutlinedButton, 'Check for Updates (Stub)'),
         findsOneWidget);
-    expect(find.widgetWithText(FilledButton, 'Generate preview'), findsNothing);
+    expect(
+      find.widgetWithText(FilledButton, 'Generate support preview'),
+      findsNothing,
+    );
   });
 }

--- a/client/test/features/advanced/presentation/advanced_page_test.dart
+++ b/client/test/features/advanced/presentation/advanced_page_test.dart
@@ -145,6 +145,8 @@ void main() {
     expect(find.text('Stub-only'), findsWidgets);
     expect(find.text('Shell-grade only'), findsWidgets);
     expect(find.text('What to try next'), findsOneWidget);
+    expect(find.text('Runtime truth & recovery'), findsWidgets);
+    expect(find.text('Session Truth'), findsOneWidget);
     expect(
       find.text('Runtime-proof artifact unavailable on current posture'),
       findsWidgets,

--- a/client/test/features/advanced/presentation/advanced_page_test.dart
+++ b/client/test/features/advanced/presentation/advanced_page_test.dart
@@ -141,7 +141,9 @@ void main() {
 
     expect(find.text('Troubleshooting Overview'), findsOneWidget);
     expect(find.text('Runtime posture'), findsOneWidget);
+    expect(find.text('Evidence grade'), findsOneWidget);
     expect(find.text('Stub-only'), findsWidgets);
+    expect(find.text('Shell-grade only'), findsWidgets);
     expect(find.text('What to try next'), findsOneWidget);
     expect(
       find.widgetWithText(FilledButton, 'Open Problem Report'),

--- a/client/test/features/advanced/presentation/advanced_page_test.dart
+++ b/client/test/features/advanced/presentation/advanced_page_test.dart
@@ -25,6 +25,44 @@ Future<void> _setDesktopSurface(WidgetTester tester) async {
   });
 }
 
+class _AdvancedPageTestHost extends StatefulWidget {
+  const _AdvancedPageTestHost({required this.services});
+
+  final ClientServiceRegistry services;
+
+  @override
+  State<_AdvancedPageTestHost> createState() => _AdvancedPageTestHostState();
+}
+
+class _AdvancedPageTestHostState extends State<_AdvancedPageTestHost> {
+  AdvancedPageTab _requestedTab = AdvancedPageTab.problemReport;
+  int _requestId = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        TextButton(
+          onPressed: () {
+            setState(() {
+              _requestedTab = AdvancedPageTab.updateStatus;
+              _requestId++;
+            });
+          },
+          child: const Text('Open update status'),
+        ),
+        Expanded(
+          child: AdvancedPage(
+            services: widget.services,
+            requestedTab: _requestedTab,
+            tabRequestId: _requestId,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 ClientServiceRegistry _buildServices({
   AppRuntimeErrorStore? appRuntimeErrors,
 }) {
@@ -134,5 +172,32 @@ void main() {
       find.textContaining('unhandled packaging stub issue'),
       findsOneWidget,
     );
+  });
+
+  testWidgets('supports switching to a requested tab',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    final services = _buildServices();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: _AdvancedPageTestHost(services: services),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+        find.widgetWithText(FilledButton, 'Generate preview'), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, 'Check for Updates (Stub)'),
+        findsNothing);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Open update status'));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(OutlinedButton, 'Check for Updates (Stub)'),
+        findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Generate preview'), findsNothing);
   });
 }

--- a/client/test/features/advanced/presentation/advanced_page_test.dart
+++ b/client/test/features/advanced/presentation/advanced_page_test.dart
@@ -9,6 +9,7 @@ import 'package:trojan_pro_client/features/profiles/application/profile_portabil
 import 'package:trojan_pro_client/features/profiles/application/profile_secrets_service.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_serialization.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_store.dart';
+import 'package:trojan_pro_client/features/readiness/application/readiness_service.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_serialization.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_store.dart';
 import 'package:trojan_pro_client/platform/services/app_runtime_error_store.dart';
@@ -50,6 +51,12 @@ ClientServiceRegistry _buildServices({
     packagingStore: packagingStore,
     fileExporter: diagnosticsExporter,
   );
+  final readiness = ReadinessService(
+    profileStore: profileStore,
+    profileSecrets: profileSecrets,
+    secureStorage: secureStorage,
+    controller: controller,
+  );
   final diagnostics = DiagnosticsExportService(
     profileStore: profileStore,
     profilePortability: profilePortability,
@@ -58,6 +65,7 @@ ClientServiceRegistry _buildServices({
     controller: controller,
     secureStorage: secureStorage,
     fileExporter: diagnosticsExporter,
+    readiness: readiness,
     appRuntimeErrors: runtimeErrors,
   );
 
@@ -72,6 +80,7 @@ ClientServiceRegistry _buildServices({
     packagingExport: packagingExport,
     settingsStore: settingsStore,
     controller: controller,
+    readiness: readiness,
     diagnostics: diagnostics,
     appRuntimeErrors: runtimeErrors,
   );

--- a/client/test/features/controller/application/adapter_backed_client_controller_test.dart
+++ b/client/test/features/controller/application/adapter_backed_client_controller_test.dart
@@ -93,10 +93,19 @@ ControllerRuntimeSession _session({
   int? pid,
   int? lastExitCode,
   String? lastError,
+  ControllerRuntimePhase? phase,
+  bool stopRequested = false,
+  DateTime? stopRequestedAt,
 }) {
   return ControllerRuntimeSession(
     isRunning: isRunning,
     updatedAt: DateTime.now(),
+    phase: phase ??
+        (isRunning
+            ? ControllerRuntimePhase.sessionReady
+            : ControllerRuntimePhase.stopped),
+    stopRequested: stopRequested,
+    stopRequestedAt: stopRequestedAt,
     pid: pid,
     lastExitCode: lastExitCode,
     lastError: lastError,
@@ -154,11 +163,54 @@ void main() {
     );
 
     expect(controller.status.phase, ClientConnectionPhase.connected);
-    expect(controller.status.message, contains('Runtime session is active'));
+    expect(controller.status.message, contains('Runtime session is ready'));
     expect(
       controller.recentEvents.first.title,
-      anyOf(equals('Runtime session active'), equals('Connect requested')),
+      anyOf(equals('Runtime session ready'), equals('Connect requested')),
     );
+  });
+
+  test('keeps connecting status while runtime is alive but not session-ready',
+      () async {
+    final adapter = _ControllableShellControllerAdapter(
+      runtimeConfig: const ControllerRuntimeConfig(
+        mode: 'external-runtime-boundary',
+        endpointHint: 'local-controller://test',
+        enableVerboseTelemetry: true,
+      ),
+      commandAccepted: true,
+      commandSummary: 'Launch requested.',
+      commandDetails: const <String, Object?>{},
+      initialSession: _session(isRunning: false),
+    );
+    final secrets = ProfileSecretsService(secureStorage: MemorySecureStorage());
+    await secrets.saveTrojanPassword(
+        profileId: 'profile-demo', password: 'secret');
+
+    final controller = AdapterBackedClientController(
+      adapter: adapter,
+      profileSecrets: secrets,
+      sessionPollInterval: const Duration(milliseconds: 20),
+    );
+    addTearDown(controller.dispose);
+
+    await controller.connect(_demoProfile());
+    expect(controller.status.phase, ClientConnectionPhase.connecting);
+
+    adapter.setSession(
+      _session(
+        isRunning: true,
+        pid: 4321,
+        phase: ControllerRuntimePhase.alive,
+      ),
+    );
+    await _waitFor(
+      () => controller.status.message.contains('Waiting for session-ready'),
+      description: 'connecting status reflects alive-but-not-ready runtime',
+    );
+
+    expect(controller.status.phase, ClientConnectionPhase.connecting);
+    expect(controller.status.message, contains('Waiting for session-ready'));
   });
 
   test(
@@ -282,12 +334,30 @@ void main() {
     expect(controller.status.activeProfileId, 'profile-demo');
 
     await disconnectFuture;
+    adapter.setSession(
+      _session(
+        isRunning: true,
+        pid: 4321,
+        phase: ControllerRuntimePhase.alive,
+        stopRequested: true,
+        stopRequestedAt: _fixedTime,
+      ),
+    );
+    await _waitFor(
+      () => controller.status.message.contains('Waiting for the runtime process to exit cleanly'),
+      description: 'disconnecting status reflects stop-requested runtime',
+    );
+
     expect(
       controller.status.phase,
       anyOf(
         equals(ClientConnectionPhase.disconnecting),
         equals(ClientConnectionPhase.disconnected),
       ),
+    );
+    expect(
+      controller.status.message,
+      contains('Waiting for the runtime process to exit cleanly'),
     );
   });
 

--- a/client/test/features/controller/application/real_shell_controller_adapter_test.dart
+++ b/client/test/features/controller/application/real_shell_controller_adapter_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:trojan_pro_client/features/controller/application/real_shell_controller_adapter.dart';
 import 'package:trojan_pro_client/features/controller/domain/controller_command.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
 
 ControllerCommand _connectCommand({required String configPath}) {
   return ControllerCommand(
@@ -66,6 +67,49 @@ while True:
   return script;
 }
 
+Future<File> _writeModeAwareFakeTrojanScript(
+  Directory tempDir,
+  String modeFilePath,
+) async {
+  final script = File(
+    '${tempDir.path}${Platform.pathSeparator}fake-trojan-mode-aware.py',
+  );
+  await script.writeAsString('''#!/usr/bin/env python3
+import pathlib
+import signal
+import sys
+import time
+
+mode_path = pathlib.Path(r"$modeFilePath")
+mode = mode_path.read_text().strip() if mode_path.exists() else "run"
+
+config_path = None
+args = sys.argv[1:]
+for index, value in enumerate(args):
+    if value == '-c' and index + 1 < len(args):
+        config_path = args[index + 1]
+
+print(f"fake trojan mode={mode} config={config_path}", flush=True)
+print("fake trojan mode-aware stderr", file=sys.stderr, flush=True)
+
+if mode == "fail":
+    time.sleep(0.3)
+    sys.exit(17)
+
+def stop(signum, frame):
+    print("fake trojan mode-aware shutdown", flush=True)
+    sys.exit(0)
+
+signal.signal(signal.SIGTERM, stop)
+signal.signal(signal.SIGINT, stop)
+
+while True:
+    time.sleep(1)
+''', flush: true);
+  await Process.run('chmod', <String>['+x', script.path]);
+  return script;
+}
+
 Future<void> _waitFor(
   bool Function() condition, {
   Duration timeout = const Duration(seconds: 3),
@@ -116,6 +160,7 @@ void main() {
     );
     expect(await File(configPath).exists(), isFalse);
     expect(adapter.session.lastError, isNotNull);
+    expect(adapter.session.phase, ControllerRuntimePhase.failed);
   });
 
   test('launches fake runtime, captures logs, and cleans config on disconnect',
@@ -143,6 +188,13 @@ void main() {
     expect(connectResult.details['pid'], isNotNull);
     expect(await File(configPath).exists(), isTrue);
     expect(adapter.session.isRunning, isTrue);
+    expect(
+      adapter.session.phase,
+      anyOf(
+        ControllerRuntimePhase.alive,
+        ControllerRuntimePhase.sessionReady,
+      ),
+    );
 
     await _waitFor(
       () => adapter.session.stdoutTail
@@ -157,6 +209,8 @@ void main() {
 
     final disconnectResult = await adapter.execute(_disconnectCommand());
     expect(disconnectResult.accepted, isTrue);
+    expect(adapter.session.stopRequested, isTrue);
+    expect(adapter.session.stopRequestedAt, isNotNull);
 
     await _waitFor(
       () => !adapter.session.isRunning,
@@ -167,6 +221,73 @@ void main() {
       description: 'runtime config cleanup',
     );
 
+    expect(adapter.session.activeConfigPath, isNull);
+    expect(adapter.session.phase, ControllerRuntimePhase.stopped);
+  });
+
+  test('abnormal exit cleanup keeps adapter retry-safe for next launch',
+      () async {
+    final tempDir =
+        await Directory.systemTemp.createTemp('real-shell-adapter-retry-test');
+    addTearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    final modeFile =
+        File('${tempDir.path}${Platform.pathSeparator}fake-trojan.mode');
+    await modeFile.writeAsString('fail', flush: true);
+
+    final fakeTrojan = await _writeModeAwareFakeTrojanScript(
+      tempDir,
+      modeFile.path,
+    );
+    final configPath =
+        '${tempDir.path}${Platform.pathSeparator}runtime-retry-config.json';
+
+    final adapter = RealShellControllerAdapter(
+      binaryPathHint: fakeTrojan.path,
+      transportEndpointHint: 'local-controller://test',
+    );
+
+    final firstConnect =
+        await adapter.execute(_connectCommand(configPath: configPath));
+    expect(firstConnect.accepted, isTrue);
+
+    await _waitFor(
+      () => !adapter.session.isRunning,
+      description: 'runtime exits after forced failure mode',
+    );
+    await _waitFor(
+      () => !File(configPath).existsSync(),
+      description: 'failed runtime launch config cleanup',
+    );
+
+    expect(adapter.session.phase, ControllerRuntimePhase.failed);
+    expect(adapter.session.lastExitCode, 17);
+    expect(adapter.session.activeConfigPath, isNull);
+
+    await modeFile.writeAsString('run', flush: true);
+
+    final secondConnect =
+        await adapter.execute(_connectCommand(configPath: configPath));
+    expect(secondConnect.accepted, isTrue);
+    expect(adapter.session.isRunning, isTrue);
+
+    final disconnectResult = await adapter.execute(_disconnectCommand());
+    expect(disconnectResult.accepted, isTrue);
+
+    await _waitFor(
+      () => !adapter.session.isRunning,
+      description: 'runtime exits after retry disconnect',
+    );
+    await _waitFor(
+      () => !File(configPath).existsSync(),
+      description: 'retry runtime config cleanup',
+    );
+
+    expect(adapter.session.phase, ControllerRuntimePhase.stopped);
     expect(adapter.session.activeConfigPath, isNull);
   });
 }

--- a/client/test/features/controller/application/shell_controller_adapter_selector_test.dart
+++ b/client/test/features/controller/application/shell_controller_adapter_selector_test.dart
@@ -1,0 +1,153 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/application/fake_shell_controller_adapter.dart';
+import 'package:trojan_pro_client/features/controller/application/real_shell_controller_adapter.dart';
+import 'package:trojan_pro_client/features/controller/application/shell_controller_adapter_selector.dart';
+import 'package:trojan_pro_client/features/controller/application/trojan_binary_locator.dart';
+
+void main() {
+  test('auto mode promotes to real adapter when binary is resolvable', () async {
+    final tempDir = await Directory.systemTemp.createTemp('selector-real-test');
+    addTearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    final trojanBinary =
+        File('${tempDir.path}${Platform.pathSeparator}trojan-real');
+    await trojanBinary.writeAsString('#!/bin/sh\nexit 0\n', flush: true);
+
+    final selector = ShellControllerAdapterSelector(
+      environment: const <String, String>{},
+      binaryLocator: TrojanBinaryLocator(overrideBinaryPath: trojanBinary.path),
+      isSupportedDesktop: true,
+    );
+
+    final selection = selector.selectForCurrentPlatform();
+
+    expect(selection.isRealRuntimePath, isTrue);
+    expect(selection.adapter, isA<RealShellControllerAdapter>());
+    expect(selection.adapter.runtimeConfig.mode, 'real-runtime-boundary');
+    expect(selection.adapter.telemetry.backendKind, 'real-shell-controller');
+  });
+
+  test('auto mode falls back to stub when binary is missing', () {
+    final selector = ShellControllerAdapterSelector(
+      environment: const <String, String>{},
+      binaryLocator:
+          const TrojanBinaryLocator(overrideBinaryPath: '/nonexistent/trojan'),
+      isSupportedDesktop: true,
+    );
+
+    final selection = selector.selectForCurrentPlatform();
+
+    expect(selection.isRealRuntimePath, isFalse);
+    expect(selection.adapter, isA<FakeShellControllerAdapter>());
+    expect(
+      selection.adapter.runtimeConfig.mode,
+      'stubbed-local-boundary-fallback',
+    );
+    expect(
+      selection.selectionReason,
+      contains('no launchable trojan binary was found'),
+    );
+  });
+
+  test('explicit stub mode keeps stub even when binary exists', () async {
+    final tempDir = await Directory.systemTemp.createTemp('selector-stub-test');
+    addTearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    final trojanBinary =
+        File('${tempDir.path}${Platform.pathSeparator}trojan-stub');
+    await trojanBinary.writeAsString('#!/bin/sh\nexit 0\n', flush: true);
+
+    final selector = ShellControllerAdapterSelector(
+      environment: <String, String>{
+        'TROJAN_CLIENT_BACKEND_MODE': 'stub',
+      },
+      binaryLocator: TrojanBinaryLocator(overrideBinaryPath: trojanBinary.path),
+      isSupportedDesktop: true,
+    );
+
+    final selection = selector.selectForCurrentPlatform();
+
+    expect(selection.isRealRuntimePath, isFalse);
+    expect(selection.adapter, isA<FakeShellControllerAdapter>());
+    expect(
+      selection.adapter.runtimeConfig.mode,
+      'stubbed-local-boundary-explicit',
+    );
+  });
+
+  test('explicit real mode degrades to fallback stub when binary is missing', () {
+    final selector = ShellControllerAdapterSelector(
+      environment: <String, String>{
+        'TROJAN_CLIENT_BACKEND_MODE': 'real',
+      },
+      binaryLocator:
+          const TrojanBinaryLocator(overrideBinaryPath: '/nonexistent/trojan'),
+      isSupportedDesktop: true,
+    );
+
+    final selection = selector.selectForCurrentPlatform();
+
+    expect(selection.isRealRuntimePath, isFalse);
+    expect(selection.adapter, isA<FakeShellControllerAdapter>());
+    expect(
+      selection.adapter.runtimeConfig.mode,
+      'stubbed-local-boundary-fallback',
+    );
+  });
+
+  test('non-desktop target keeps non-desktop stub mode', () {
+    final selector = ShellControllerAdapterSelector(
+      environment: const <String, String>{},
+      binaryLocator:
+          const TrojanBinaryLocator(overrideBinaryPath: '/any/path/trojan'),
+      isSupportedDesktop: false,
+    );
+
+    final selection = selector.selectForCurrentPlatform();
+
+    expect(selection.isRealRuntimePath, isFalse);
+    expect(selection.adapter, isA<FakeShellControllerAdapter>());
+    expect(
+      selection.adapter.runtimeConfig.mode,
+      'stubbed-local-boundary-non-desktop',
+    );
+  });
+
+  test('legacy real-adapter flag still promotes when binary is available',
+      () async {
+    final tempDir =
+        await Directory.systemTemp.createTemp('selector-legacy-real-test');
+    addTearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    final trojanBinary =
+        File('${tempDir.path}${Platform.pathSeparator}trojan-legacy');
+    await trojanBinary.writeAsString('#!/bin/sh\nexit 0\n', flush: true);
+
+    final selector = ShellControllerAdapterSelector(
+      environment: <String, String>{
+        'TROJAN_CLIENT_ENABLE_REAL_ADAPTER': '1',
+      },
+      binaryLocator: TrojanBinaryLocator(overrideBinaryPath: trojanBinary.path),
+      isSupportedDesktop: true,
+    );
+
+    final selection = selector.selectForCurrentPlatform();
+
+    expect(selection.isRealRuntimePath, isTrue);
+    expect(selection.adapter, isA<RealShellControllerAdapter>());
+  });
+}

--- a/client/test/features/controller/domain/controller_runtime_session_test.dart
+++ b/client/test/features/controller/domain/controller_runtime_session_test.dart
@@ -42,7 +42,7 @@ void main() {
     final session = ControllerRuntimeSession(
       isRunning: true,
       updatedAt: DateTime.now().subtract(const Duration(seconds: 20)),
-      phase: ControllerRuntimePhase.stopping,
+      phase: ControllerRuntimePhase.alive,
       stopRequested: true,
       stopRequestedAt: DateTime.now().subtract(const Duration(seconds: 10)),
       expectedLocalSocksPort: 10808,
@@ -50,5 +50,33 @@ void main() {
 
     expect(session.truth, ControllerRuntimeSessionTruth.stopping);
     expect(session.truthNote, contains('stop request'));
+    expect(session.needsAttention, isTrue);
+    expect(session.recoveryGuidance, contains('exit confirmation'));
+  });
+
+  test('does not mark live session as needing attention', () {
+    final session = ControllerRuntimeSession(
+      isRunning: true,
+      updatedAt: DateTime.now().subtract(const Duration(seconds: 3)),
+      phase: ControllerRuntimePhase.sessionReady,
+      expectedLocalSocksPort: 10808,
+    );
+
+    expect(session.truth, ControllerRuntimeSessionTruth.live);
+    expect(session.needsAttention, isFalse);
+    expect(session.recoveryGuidance, contains('No recovery action'));
+  });
+
+  test('gives recovery guidance for residual snapshot state', () {
+    final session = ControllerRuntimeSession(
+      isRunning: false,
+      updatedAt: DateTime.now().subtract(const Duration(minutes: 1)),
+      phase: ControllerRuntimePhase.sessionReady,
+      expectedLocalSocksPort: 10808,
+    );
+
+    expect(session.truth, ControllerRuntimeSessionTruth.residual);
+    expect(session.needsAttention, isTrue);
+    expect(session.recoveryGuidance, contains('retry from Profiles'));
   });
 }

--- a/client/test/features/controller/domain/controller_runtime_session_test.dart
+++ b/client/test/features/controller/domain/controller_runtime_session_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
+
+void main() {
+  test('marks recently refreshed running session as live', () {
+    final session = ControllerRuntimeSession(
+      isRunning: true,
+      updatedAt: DateTime.now().subtract(const Duration(seconds: 5)),
+      phase: ControllerRuntimePhase.sessionReady,
+      expectedLocalSocksPort: 10808,
+    );
+
+    expect(session.truth, ControllerRuntimeSessionTruth.live);
+    expect(session.truth.label, 'Live');
+  });
+
+  test('marks older running session as stale', () {
+    final session = ControllerRuntimeSession(
+      isRunning: true,
+      updatedAt: DateTime.now().subtract(const Duration(minutes: 5)),
+      phase: ControllerRuntimePhase.sessionReady,
+      expectedLocalSocksPort: 10808,
+    );
+
+    expect(session.truth, ControllerRuntimeSessionTruth.stale);
+    expect(session.truthNote, contains('stale'));
+  });
+
+  test('marks non-running non-stopped session as residual snapshot', () {
+    final session = ControllerRuntimeSession(
+      isRunning: false,
+      updatedAt: DateTime.now().subtract(const Duration(minutes: 1)),
+      phase: ControllerRuntimePhase.sessionReady,
+      expectedLocalSocksPort: 10808,
+    );
+
+    expect(session.truth, ControllerRuntimeSessionTruth.residual);
+    expect(session.truth.label, 'Residual snapshot');
+  });
+
+  test('marks stop-requested session as stopping', () {
+    final session = ControllerRuntimeSession(
+      isRunning: true,
+      updatedAt: DateTime.now().subtract(const Duration(seconds: 20)),
+      phase: ControllerRuntimePhase.stopping,
+      stopRequested: true,
+      stopRequestedAt: DateTime.now().subtract(const Duration(seconds: 10)),
+      expectedLocalSocksPort: 10808,
+    );
+
+    expect(session.truth, ControllerRuntimeSessionTruth.stopping);
+    expect(session.truthNote, contains('stop request'));
+  });
+}

--- a/client/test/features/controller/domain/runtime_action_feedback_test.dart
+++ b/client/test/features/controller/domain/runtime_action_feedback_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_command_result.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_action_feedback.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_posture.dart';
+
+void main() {
+  test('connect feedback mentions shell validation on stub posture', () {
+    final feedback = buildRuntimeActionFeedback(
+      action: RuntimeActionKind.connect,
+      result: ControllerCommandResult(
+        commandId: 'connect-1',
+        accepted: true,
+        completedAt: DateTime.now(),
+        summary: 'Connection flow completed in fake controller boundary.',
+      ),
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.connected,
+        message: 'Connected via fake controller boundary',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: false,
+        updatedAt: DateTime.now(),
+        phase: ControllerRuntimePhase.sessionReady,
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'stubbed-local-boundary',
+        backendKind: 'fake-shell-controller',
+      ),
+    );
+
+    expect(feedback, contains('Shell validation is ready'));
+  });
+
+  test('disconnect feedback asks for exit confirmation while stop is pending', () {
+    final feedback = buildRuntimeActionFeedback(
+      action: RuntimeActionKind.disconnect,
+      result: ControllerCommandResult(
+        commandId: 'disconnect-1',
+        accepted: true,
+        completedAt: DateTime.now(),
+        summary: 'Requested trojan client shutdown for pid=4242.',
+      ),
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.disconnecting,
+        message: 'Stop requested.',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: DateTime.now(),
+        phase: ControllerRuntimePhase.alive,
+        stopRequested: true,
+        stopRequestedAt: DateTime.now(),
+        pid: 4242,
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+    );
+
+    expect(feedback, contains('Wait for exit confirmation'));
+  });
+}

--- a/client/test/features/controller/domain/runtime_action_matrix_test.dart
+++ b/client/test/features/controller/domain/runtime_action_matrix_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_action_matrix.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_posture.dart';
+
+void main() {
+  test('stale connected runtime prefers troubleshooting without withholding manual fallback', () {
+    final matrix = RuntimeActionMatrix.resolve(
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.connected,
+        message: 'Runtime session is ready.',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: DateTime.now().subtract(const Duration(minutes: 3)),
+        phase: ControllerRuntimePhase.sessionReady,
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+      troubleshootingAvailable: true,
+    );
+
+    expect(matrix.primaryActionContract,
+        RuntimePrimaryActionContract.preferTroubleshooting);
+    expect(matrix.secondaryStateChangeContract,
+        RuntimeSecondaryStateChangeContract.allowFallback);
+    expect(matrix.evidenceCaptureContract,
+        RuntimeEvidenceCaptureContract.optional);
+    expect(matrix.retryContract, RuntimeRetryContract.blockShortcut);
+    expect(matrix.nextStepContract,
+        RuntimeNextStepContract.openTroubleshooting);
+    expect(matrix.preferredOperatorAction,
+        RuntimePreferredOperatorAction.openTroubleshooting);
+    expect(matrix.preferredEvidenceAction, RuntimePreferredEvidenceAction.none);
+    expect(matrix.preferTroubleshootingPrimary, isTrue);
+    expect(matrix.withholdSecondaryStateChangingActions, isFalse);
+    expect(matrix.preferSnapshotFirst, isFalse);
+    expect(matrix.blockRetryShortcut, isTrue);
+    expect(matrix.showExitConfirmationWarning, isFalse);
+  });
+
+  test('stop-pending runtime prefers snapshot-first and withholds secondary state changes', () {
+    final matrix = RuntimeActionMatrix.resolve(
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.disconnecting,
+        message: 'Disconnecting current session...',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: DateTime.now().subtract(const Duration(seconds: 8)),
+        phase: ControllerRuntimePhase.alive,
+        stopRequested: true,
+        stopRequestedAt: DateTime.now().subtract(const Duration(seconds: 4)),
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+      troubleshootingAvailable: true,
+    );
+
+    expect(matrix.primaryActionContract,
+        RuntimePrimaryActionContract.preferTroubleshooting);
+    expect(matrix.secondaryStateChangeContract,
+        RuntimeSecondaryStateChangeContract.withholdFallback);
+    expect(matrix.evidenceCaptureContract,
+        RuntimeEvidenceCaptureContract.preferBeforeMutation);
+    expect(matrix.retryContract, RuntimeRetryContract.blockShortcut);
+    expect(matrix.nextStepContract,
+        RuntimeNextStepContract.captureSupportEvidence);
+    expect(matrix.preferredOperatorAction,
+        RuntimePreferredOperatorAction.openTroubleshooting);
+    expect(matrix.preferTroubleshootingPrimary, isTrue);
+    expect(matrix.withholdSecondaryStateChangingActions, isTrue);
+    expect(matrix.preferSnapshotFirst, isTrue);
+    expect(matrix.blockRetryShortcut, isTrue);
+    expect(matrix.showExitConfirmationWarning, isTrue);
+  });
+
+  test('stub residual state does not create operator gating by itself', () {
+    final matrix = RuntimeActionMatrix.resolve(
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.connected,
+        message: 'Connected via fake controller boundary',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: false,
+        updatedAt: DateTime.now(),
+        phase: ControllerRuntimePhase.sessionReady,
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'stubbed-local-boundary',
+        backendKind: 'fake-shell-controller',
+      ),
+      troubleshootingAvailable: true,
+    );
+
+    expect(matrix.primaryActionContract,
+        RuntimePrimaryActionContract.keepCurrentPrimary);
+    expect(matrix.secondaryStateChangeContract,
+        RuntimeSecondaryStateChangeContract.allowFallback);
+    expect(matrix.evidenceCaptureContract,
+        RuntimeEvidenceCaptureContract.optional);
+    expect(matrix.retryContract, RuntimeRetryContract.allowShortcut);
+    expect(matrix.nextStepContract, RuntimeNextStepContract.none);
+    expect(matrix.preferredOperatorAction, RuntimePreferredOperatorAction.none);
+    expect(matrix.preferredEvidenceAction, RuntimePreferredEvidenceAction.none);
+    expect(matrix.preferTroubleshootingPrimary, isFalse);
+    expect(matrix.withholdSecondaryStateChangingActions, isFalse);
+    expect(matrix.preferSnapshotFirst, isFalse);
+    expect(matrix.blockRetryShortcut, isFalse);
+    expect(matrix.showExitConfirmationWarning, isFalse);
+  });
+}

--- a/client/test/features/controller/domain/runtime_action_safety_test.dart
+++ b/client/test/features/controller/domain/runtime_action_safety_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_action_safety.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_posture.dart';
+
+void main() {
+  test('disconnecting stop-pending runtime blocks retry until exit confirmation', () {
+    final safety = RuntimeActionSafety.resolve(
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.disconnecting,
+        message: 'Disconnecting current session...',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: DateTime.now().subtract(const Duration(seconds: 8)),
+        phase: ControllerRuntimePhase.alive,
+        stopRequested: true,
+        stopRequestedAt: DateTime.now().subtract(const Duration(seconds: 4)),
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+    );
+
+    expect(safety.state, RuntimeActionSafetyState.waitForExitConfirmation);
+    expect(safety.blocksRetry, isTrue);
+    expect(safety.recommendsSnapshotFirst, isTrue);
+  });
+
+  test('stale connected runtime requires revalidation before state changes', () {
+    final safety = RuntimeActionSafety.resolve(
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.connected,
+        message: 'Runtime session is ready.',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: DateTime.now().subtract(const Duration(minutes: 3)),
+        phase: ControllerRuntimePhase.sessionReady,
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+    );
+
+    expect(safety.state, RuntimeActionSafetyState.revalidateFirst);
+    expect(safety.blocksRetry, isTrue);
+    expect(safety.recommendsSnapshotFirst, isFalse);
+  });
+}

--- a/client/test/features/controller/domain/runtime_operator_advice_test.dart
+++ b/client/test/features/controller/domain/runtime_operator_advice_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_operator_advice.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_posture.dart';
+
+void main() {
+  test('connected stale runtime recommends revalidation', () {
+    final advice = RuntimeOperatorAdvice.resolve(
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.connected,
+        message: 'Runtime session is ready.',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: DateTime.now().subtract(const Duration(minutes: 3)),
+        phase: ControllerRuntimePhase.sessionReady,
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+      troubleshootingAvailable: true,
+    );
+
+    expect(advice.kind, RuntimeOperatorAdviceKind.revalidateInTroubleshooting);
+    expect(advice.headline, 'Connection state needs revalidation');
+    expect(advice.primaryEnabled, isTrue);
+  });
+
+  test('disconnecting stop-pending runtime recommends waiting for exit confirmation', () {
+    final advice = RuntimeOperatorAdvice.resolve(
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.disconnecting,
+        message: 'Disconnecting current session...',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: DateTime.now().subtract(const Duration(seconds: 8)),
+        phase: ControllerRuntimePhase.alive,
+        stopRequested: true,
+        stopRequestedAt: DateTime.now().subtract(const Duration(seconds: 4)),
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+      troubleshootingAvailable: true,
+    );
+
+    expect(advice.kind, RuntimeOperatorAdviceKind.waitForExitConfirmation);
+    expect(advice.headline, 'Exit confirmation pending');
+    expect(advice.message, contains('fully closed yet'));
+  });
+
+  test('stub residual state does not create actionable advice by itself', () {
+    final advice = RuntimeOperatorAdvice.resolve(
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.connected,
+        message: 'Connected via fake controller boundary',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: false,
+        updatedAt: DateTime.now(),
+        phase: ControllerRuntimePhase.sessionReady,
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'stubbed-local-boundary',
+        backendKind: 'fake-shell-controller',
+      ),
+      troubleshootingAvailable: true,
+    );
+
+    expect(advice.kind, RuntimeOperatorAdviceKind.none);
+    expect(advice.actionableSessionTruth, isFalse);
+  });
+}

--- a/client/test/features/controller/domain/runtime_posture_test.dart
+++ b/client/test/features/controller/domain/runtime_posture_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_posture.dart';
+
+void main() {
+  test('describes runtime-true posture', () {
+    final posture = describeRuntimePosture(
+      runtimeMode: 'real-runtime-boundary',
+      backendKind: 'real-shell-controller',
+    );
+
+    expect(posture.kind, RuntimePostureKind.runtimeTrue);
+    expect(posture.isRuntimeTrue, isTrue);
+    expect(posture.postureLabel, 'Runtime-true');
+    expect(posture.executionPathLabel, 'Real runtime path');
+  });
+
+  test('describes fallback stub posture', () {
+    final posture = describeRuntimePosture(
+      runtimeMode: 'stubbed-local-boundary-fallback',
+      backendKind: 'fake-shell-controller-fallback',
+    );
+
+    expect(posture.kind, RuntimePostureKind.stubFallback);
+    expect(posture.isStubOnly, isTrue);
+    expect(posture.postureLabel, 'Stub-only (fallback)');
+    expect(
+      posture.truthNote,
+      contains('fell back to a stub boundary'),
+    );
+  });
+
+  test('describes non-desktop stub posture', () {
+    final posture = describeRuntimePosture(
+      runtimeMode: 'stubbed-local-boundary-non-desktop',
+      backendKind: 'fake-shell-controller-non-desktop',
+    );
+
+    expect(posture.kind, RuntimePostureKind.stubNonDesktop);
+    expect(posture.postureLabel, 'Stub-only (non-desktop)');
+    expect(posture.executionPathLabel, 'Stub mode (non-desktop target)');
+  });
+
+  test('keeps unknown posture explicit', () {
+    final posture = describeRuntimePosture(
+      runtimeMode: 'mystery-runtime-mode',
+      backendKind: 'mystery-backend',
+    );
+
+    expect(posture.kind, RuntimePostureKind.unknown);
+    expect(posture.postureLabel, 'Unknown posture');
+    expect(posture.truthNote, contains('not recognized'));
+  });
+}

--- a/client/test/features/controller/domain/runtime_posture_test.dart
+++ b/client/test/features/controller/domain/runtime_posture_test.dart
@@ -11,6 +11,7 @@ void main() {
     expect(posture.kind, RuntimePostureKind.runtimeTrue);
     expect(posture.isRuntimeTrue, isTrue);
     expect(posture.postureLabel, 'Runtime-true');
+    expect(posture.evidenceGradeLabel, 'Evidence-grade');
     expect(posture.executionPathLabel, 'Real runtime path');
   });
 
@@ -23,6 +24,7 @@ void main() {
     expect(posture.kind, RuntimePostureKind.stubFallback);
     expect(posture.isStubOnly, isTrue);
     expect(posture.postureLabel, 'Stub-only (fallback)');
+    expect(posture.evidenceGradeLabel, 'Shell-grade only');
     expect(
       posture.truthNote,
       contains('fell back to a stub boundary'),

--- a/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_action_safety.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_operator_advice.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_posture.dart';
+import 'package:trojan_pro_client/features/dashboard/application/connection_lifecycle_view_model.dart';
+import 'package:trojan_pro_client/features/dashboard/presentation/dashboard_guide_policy.dart';
+import 'package:trojan_pro_client/features/profiles/domain/client_profile.dart';
+
+ClientProfile _profile({
+  String id = 'sample-hk-1',
+  String name = 'Sample • Hong Kong',
+  bool hasStoredPassword = true,
+}) {
+  return ClientProfile(
+    id: id,
+    name: name,
+    serverHost: 'hk.example.com',
+    serverPort: 443,
+    sni: 'hk.example.com',
+    localSocksPort: 10808,
+    verifyTls: true,
+    hasStoredPassword: hasStoredPassword,
+    updatedAt: DateTime.parse('2026-03-29T00:00:00.000Z'),
+  );
+}
+
+void main() {
+  test('stale connected runtime produces revalidation guide', () {
+    final profile = _profile();
+    final status = ClientConnectionStatus(
+      phase: ClientConnectionPhase.connected,
+      message: 'Runtime session is ready.',
+      updatedAt: DateTime.now(),
+      activeProfileId: profile.id,
+    );
+    final session = ControllerRuntimeSession(
+      isRunning: true,
+      updatedAt: DateTime.now().subtract(const Duration(minutes: 3)),
+      phase: ControllerRuntimePhase.sessionReady,
+    );
+    final posture = describeRuntimePosture(
+      runtimeMode: 'real-runtime-boundary',
+      backendKind: 'real-shell-controller',
+    );
+    final advice = RuntimeOperatorAdvice.resolve(
+      status: status,
+      session: session,
+      posture: posture,
+      troubleshootingAvailable: true,
+    );
+
+    final guide = DashboardGuidePolicy.resolve(
+      lifecycle: ConnectionLifecycleViewModel.fromStatus(
+        status: status,
+        selectedProfile: profile,
+      ),
+      selectedProfile: profile,
+      activeProfile: profile,
+      status: status,
+      posture: posture,
+      runtimeSession: session,
+      operatorAdvice: advice,
+      readiness: null,
+    );
+
+    expect(guide.title, 'Connection state needs revalidation');
+    expect(guide.primaryAction, DashboardGuideAction.openAdvanced);
+    expect(guide.secondaryAction, DashboardGuideAction.disconnectNow);
+    expect(guide.operatorTitle, 'Recommended right now');
+    expect(guide.operatorBody, contains('Open Troubleshooting first'));
+    expect(guide.actionSafety.state, RuntimeActionSafetyState.revalidateFirst);
+    expect(guide.actionSafety.blocksRetry, isTrue);
+    expect(guide.secondaryAction, DashboardGuideAction.disconnectNow);
+  });
+
+  test('idle missing-password state still routes to profiles', () {
+    final profile = _profile(hasStoredPassword: false);
+    final status = ClientConnectionStatus.disconnected();
+    final posture = describeRuntimePosture(
+      runtimeMode: 'stubbed-local-boundary',
+      backendKind: 'fake-shell-controller',
+    );
+
+    final guide = DashboardGuidePolicy.resolve(
+      lifecycle: ConnectionLifecycleViewModel.fromStatus(
+        status: status,
+        selectedProfile: profile,
+      ),
+      selectedProfile: profile,
+      activeProfile: null,
+      status: status,
+      posture: posture,
+      runtimeSession: ControllerRuntimeSession(
+        isRunning: false,
+        updatedAt: DateTime.now(),
+        phase: ControllerRuntimePhase.stopped,
+      ),
+      operatorAdvice: RuntimeOperatorAdvice.none,
+      readiness: null,
+    );
+
+    expect(guide.title, 'Save the password before testing');
+    expect(guide.primaryAction, DashboardGuideAction.openProfiles);
+  });
+
+  test('error runtime with residual evidence prefers troubleshooting over retry shortcut', () {
+    final profile = _profile();
+    final status = ClientConnectionStatus(
+      phase: ClientConnectionPhase.error,
+      message: 'Runtime session exited with code 7.',
+      updatedAt: DateTime.now(),
+      activeProfileId: profile.id,
+    );
+    final session = ControllerRuntimeSession(
+      isRunning: false,
+      updatedAt: DateTime.now(),
+      phase: ControllerRuntimePhase.failed,
+      lastExitCode: 7,
+    );
+    final posture = describeRuntimePosture(
+      runtimeMode: 'real-runtime-boundary',
+      backendKind: 'real-shell-controller',
+    );
+    final advice = RuntimeOperatorAdvice.resolve(
+      status: status,
+      session: session,
+      posture: posture,
+      troubleshootingAvailable: true,
+    );
+
+    final guide = DashboardGuidePolicy.resolve(
+      lifecycle: ConnectionLifecycleViewModel.fromStatus(
+        status: status,
+        selectedProfile: profile,
+      ),
+      selectedProfile: profile,
+      activeProfile: profile,
+      status: status,
+      posture: posture,
+      runtimeSession: session,
+      operatorAdvice: advice,
+      readiness: null,
+    );
+
+    expect(guide.primaryAction, DashboardGuideAction.openAdvanced);
+    expect(guide.primaryLabel, 'Open Troubleshooting');
+    expect(guide.secondaryAction, isNull);
+    expect(
+      guide.operatorTitle,
+      'Recommended right now: capture a support snapshot first',
+    );
+    expect(guide.operatorBody, contains('preserve the current runtime evidence'));
+    expect(guide.actionSafety.state,
+        RuntimeActionSafetyState.captureSnapshotFirst);
+  });
+
+  test('disconnecting stop-pending runtime uses exit confirmation headline', () {
+    final profile = _profile();
+    final status = ClientConnectionStatus(
+      phase: ClientConnectionPhase.disconnecting,
+      message: 'Disconnecting current session...',
+      updatedAt: DateTime.now(),
+      activeProfileId: profile.id,
+    );
+    final session = ControllerRuntimeSession(
+      isRunning: true,
+      updatedAt: DateTime.now().subtract(const Duration(seconds: 10)),
+      phase: ControllerRuntimePhase.alive,
+      stopRequested: true,
+      stopRequestedAt: DateTime.now().subtract(const Duration(seconds: 5)),
+    );
+    final posture = describeRuntimePosture(
+      runtimeMode: 'real-runtime-boundary',
+      backendKind: 'real-shell-controller',
+    );
+    final advice = RuntimeOperatorAdvice.resolve(
+      status: status,
+      session: session,
+      posture: posture,
+      troubleshootingAvailable: true,
+    );
+
+    final guide = DashboardGuidePolicy.resolve(
+      lifecycle: ConnectionLifecycleViewModel.fromStatus(
+        status: status,
+        selectedProfile: profile,
+      ),
+      selectedProfile: profile,
+      activeProfile: profile,
+      status: status,
+      posture: posture,
+      runtimeSession: session,
+      operatorAdvice: advice,
+      readiness: null,
+    );
+
+    expect(guide.title, 'Exit confirmation pending');
+    expect(guide.body, contains('fully closed yet'));
+    expect(guide.primaryAction, DashboardGuideAction.openAdvanced);
+    expect(
+      guide.operatorTitle,
+      'Recommended right now: capture a support snapshot first',
+    );
+    expect(guide.operatorBody, contains('capture the current support evidence'));
+    expect(guide.actionSafety.state,
+        RuntimeActionSafetyState.waitForExitConfirmation);
+    expect(guide.actionSafety.recommendsSnapshotFirst, isTrue);
+  });
+}

--- a/client/test/features/dashboard/presentation/dashboard_page_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_page_test.dart
@@ -304,6 +304,8 @@ void main() {
     await _showDashboard(tester, services: services);
 
     expect(find.text('Connection Home'), findsOneWidget);
+    expect(find.text('Runtime Posture'), findsOneWidget);
+    expect(find.text('Stub-only'), findsWidgets);
     expect(find.text('Open Troubleshooting'), findsWidgets);
     expect(find.text('Open Profiles'), findsWidgets);
     expect(find.text('Problem Report'), findsWidgets);

--- a/client/test/features/dashboard/presentation/dashboard_page_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_page_test.dart
@@ -213,6 +213,7 @@ void main() {
 
     expect(find.text('Save the password before testing'), findsWidgets);
     expect(find.text('Open Profiles'), findsWidgets);
+    expect(find.text('Readiness Provenance'), findsOneWidget);
   });
 
   testWidgets('shows connection home CTAs when profile is ready',

--- a/client/test/features/dashboard/presentation/dashboard_page_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_page_test.dart
@@ -308,7 +308,9 @@ void main() {
 
     expect(find.text('Connection Home'), findsOneWidget);
     expect(find.text('Runtime Posture'), findsOneWidget);
+    expect(find.text('Evidence Grade'), findsOneWidget);
     expect(find.text('Stub-only'), findsWidgets);
+    expect(find.text('Shell-grade only'), findsWidgets);
     expect(find.text('Open Troubleshooting'), findsWidgets);
     expect(find.text('Open Profiles'), findsWidgets);
     expect(find.text('Problem Report'), findsWidgets);

--- a/client/test/features/dashboard/presentation/dashboard_page_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_page_test.dart
@@ -61,6 +61,9 @@ class _TestLifecycleController extends ClientControllerApi {
   ControllerRuntimeSession get session => ControllerRuntimeSession(
         isRunning: _status.phase == ClientConnectionPhase.connected,
         updatedAt: DateTime.now(),
+        phase: _status.phase == ClientConnectionPhase.connected
+            ? ControllerRuntimePhase.sessionReady
+            : ControllerRuntimePhase.stopped,
       );
 
   @override

--- a/client/test/features/dashboard/presentation/dashboard_page_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_page_test.dart
@@ -292,6 +292,42 @@ void main() {
     expect(find.widgetWithText(FilledButton, 'Open Profiles'), findsWidgets);
   });
 
+  testWidgets(
+      'dashboard readiness refreshes when selected profile changes in place',
+      (WidgetTester tester) async {
+    final services = _buildServices();
+    final profile = services.profileStore.selectedProfile!;
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: profile.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      profile.copyWith(
+        hasStoredPassword: true,
+        serverHost: '',
+      ),
+    );
+
+    await _showDashboard(tester, services: services);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Connect blocked'), findsWidgets);
+    expect(find.widgetWithText(FilledButton, 'Connect now'), findsNothing);
+
+    final refreshed = services.profileStore.selectedProfile!.copyWith(
+      serverHost: 'hk-edge.example.com',
+      hasStoredPassword: true,
+      updatedAt: DateTime.now().add(const Duration(seconds: 1)),
+    );
+    services.profileStore.upsertProfile(refreshed);
+
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Connect blocked'), findsNothing);
+    expect(find.widgetWithText(FilledButton, 'Connect now'), findsOneWidget);
+  });
+
   testWidgets('dashboard distinguishes selected and active profile',
       (WidgetTester tester) async {
     final services = _buildServices();
@@ -331,7 +367,8 @@ void main() {
       profileId: first.id,
       password: 'secret-first',
     );
-    services.profileStore.upsertProfile(first.copyWith(hasStoredPassword: true));
+    services.profileStore
+        .upsertProfile(first.copyWith(hasStoredPassword: true));
     services.profileStore.selectProfile(second.id);
     controller.statusForTest = ClientConnectionStatus(
       phase: ClientConnectionPhase.error,
@@ -390,7 +427,8 @@ void main() {
     );
   });
 
-  testWidgets('shows recent desktop activation when duplicate launch focuses window',
+  testWidgets(
+      'shows recent desktop activation when duplicate launch focuses window',
       (WidgetTester tester) async {
     final services = _buildServices();
     await services.desktopLifecycle.recordExternalActivation(
@@ -448,7 +486,8 @@ void main() {
       },
     );
 
-    await tester.tap(find.widgetWithText(OutlinedButton, 'Review desktop behavior'));
+    await tester
+        .tap(find.widgetWithText(OutlinedButton, 'Review desktop behavior'));
     await tester.pump();
 
     expect(openedSettings, isTrue);

--- a/client/test/features/dashboard/presentation/dashboard_page_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_page_test.dart
@@ -269,6 +269,29 @@ void main() {
     expect(services.controller.status.phase, ClientConnectionPhase.connected);
   });
 
+  testWidgets('dashboard gates connect when readiness is blocked',
+      (WidgetTester tester) async {
+    final services = _buildServices();
+    final profile = services.profileStore.selectedProfile!;
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: profile.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      profile.copyWith(
+        hasStoredPassword: true,
+        serverHost: '',
+      ),
+    );
+
+    await _showDashboard(tester, services: services);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Connect blocked'), findsWidgets);
+    expect(find.widgetWithText(FilledButton, 'Connect now'), findsNothing);
+    expect(find.widgetWithText(FilledButton, 'Open Profiles'), findsWidgets);
+  });
+
   testWidgets('dashboard distinguishes selected and active profile',
       (WidgetTester tester) async {
     final services = _buildServices();
@@ -304,6 +327,11 @@ void main() {
     final services = _buildServices(controller: controller);
     final first = services.profileStore.selectedProfile!;
     final second = services.profileStore.profiles[1];
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: first.id,
+      password: 'secret-first',
+    );
+    services.profileStore.upsertProfile(first.copyWith(hasStoredPassword: true));
     services.profileStore.selectProfile(second.id);
     controller.statusForTest = ClientConnectionStatus(
       phase: ClientConnectionPhase.error,

--- a/client/test/features/dashboard/presentation/dashboard_page_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_page_test.dart
@@ -12,6 +12,7 @@ import 'package:trojan_pro_client/features/controller/domain/controller_telemetr
 import 'package:trojan_pro_client/features/controller/domain/last_runtime_failure_summary.dart';
 import 'package:trojan_pro_client/features/dashboard/presentation/dashboard_page.dart';
 import 'package:trojan_pro_client/features/diagnostics/application/diagnostics_export_service.dart';
+import 'package:trojan_pro_client/features/readiness/application/readiness_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_store.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_portability_service.dart';
@@ -168,6 +169,13 @@ ClientServiceRegistry _buildServices({ClientControllerApi? controller}) {
     packagingStore: packagingStore,
     fileExporter: diagnosticsExporter,
   );
+  final readiness = ReadinessService(
+    profileStore: profileStore,
+    profileSecrets: profileSecrets,
+    secureStorage: secureStorage,
+    controller: resolvedController,
+  );
+
   final diagnostics = DiagnosticsExportService(
     profileStore: profileStore,
     profilePortability: profilePortability,
@@ -176,6 +184,7 @@ ClientServiceRegistry _buildServices({ClientControllerApi? controller}) {
     controller: resolvedController,
     secureStorage: secureStorage,
     fileExporter: diagnosticsExporter,
+    readiness: readiness,
   );
 
   return ClientServiceRegistry(
@@ -189,6 +198,7 @@ ClientServiceRegistry _buildServices({ClientControllerApi? controller}) {
     packagingExport: packagingExport,
     settingsStore: settingsStore,
     controller: resolvedController,
+    readiness: readiness,
     diagnostics: diagnostics,
   );
 }

--- a/client/test/features/dashboard/presentation/dashboard_page_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_page_test.dart
@@ -282,7 +282,10 @@ void main() {
 
     expect(find.textContaining('Live check'), findsOneWidget);
     expect(find.text('Connect blocked'), findsNothing);
-    expect(find.widgetWithText(FilledButton, 'Connect now'), findsOneWidget);
+    expect(
+      find.widgetWithText(FilledButton, 'Connect now (stub path)'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('shows connection home CTAs when profile is ready',
@@ -325,7 +328,8 @@ void main() {
 
     await _showDashboard(tester, services: services);
 
-    final connectFinder = find.widgetWithText(FilledButton, 'Connect now');
+    final connectFinder =
+        find.widgetWithText(FilledButton, 'Connect now (stub path)');
     expect(connectFinder, findsOneWidget);
     await tester.ensureVisible(connectFinder);
     await tester.pump();
@@ -360,7 +364,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Connect blocked'), findsWidgets);
-    expect(find.widgetWithText(FilledButton, 'Connect now'), findsNothing);
+    expect(
+      find.widgetWithText(FilledButton, 'Connect now (stub path)'),
+      findsNothing,
+    );
     expect(find.widgetWithText(FilledButton, 'Open Profiles'), findsWidgets);
   });
 
@@ -384,7 +391,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Connect blocked'), findsWidgets);
-    expect(find.widgetWithText(FilledButton, 'Connect now'), findsNothing);
+    expect(
+      find.widgetWithText(FilledButton, 'Connect now (stub path)'),
+      findsNothing,
+    );
 
     final refreshed = services.profileStore.selectedProfile!.copyWith(
       serverHost: 'hk-edge.example.com',
@@ -397,7 +407,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Connect blocked'), findsNothing);
-    expect(find.widgetWithText(FilledButton, 'Connect now'), findsOneWidget);
+    expect(
+      find.widgetWithText(FilledButton, 'Connect now (stub path)'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('dashboard distinguishes selected and active profile',
@@ -451,7 +464,8 @@ void main() {
 
     await _showDashboard(tester, services: services);
 
-    final retryFinder = find.widgetWithText(FilledButton, 'Retry now');
+    final retryFinder =
+        find.widgetWithText(FilledButton, 'Retry now (stub path)');
     expect(retryFinder, findsOneWidget);
     await tester.ensureVisible(retryFinder);
     await tester.pump();

--- a/client/test/features/dashboard/presentation/dashboard_page_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_page_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:trojan_pro_client/features/controller/application/client_controller_api.dart';
@@ -13,6 +15,7 @@ import 'package:trojan_pro_client/features/controller/domain/last_runtime_failur
 import 'package:trojan_pro_client/features/dashboard/presentation/dashboard_page.dart';
 import 'package:trojan_pro_client/features/diagnostics/application/diagnostics_export_service.dart';
 import 'package:trojan_pro_client/features/readiness/application/readiness_service.dart';
+import 'package:trojan_pro_client/features/readiness/domain/readiness_report.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_store.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_portability_service.dart';
@@ -22,10 +25,32 @@ import 'package:trojan_pro_client/features/profiles/application/profile_store.da
 import 'package:trojan_pro_client/features/profiles/domain/client_profile.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_serialization.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_store.dart';
+import 'package:trojan_pro_client/platform/services/local_state_store.dart';
 import 'package:trojan_pro_client/platform/services/memory_diagnostics_file_exporter.dart';
 import 'package:trojan_pro_client/platform/services/memory_local_state_store.dart';
 import 'package:trojan_pro_client/platform/services/service_registry.dart';
 import 'package:trojan_pro_client/platform/secure_storage/memory_secure_storage.dart';
+
+class _DelayedReadLocalStateStore implements LocalStateStore {
+  static const Duration _readDelay = Duration(milliseconds: 200);
+
+  final MemoryLocalStateStore _delegate = MemoryLocalStateStore();
+
+  @override
+  String get backendName => _delegate.backendName;
+
+  @override
+  Future<void> delete(String key) => _delegate.delete(key);
+
+  @override
+  Future<String?> read(String key) async {
+    await Future<void>.delayed(_readDelay);
+    return _delegate.read(key);
+  }
+
+  @override
+  Future<void> write(String key, String value) => _delegate.write(key, value);
+}
 
 class _TestLifecycleController extends ClientControllerApi {
   ClientConnectionStatus _status = ClientConnectionStatus.disconnected();
@@ -147,8 +172,11 @@ Future<void> _pumpUntilPhase(
   }
 }
 
-ClientServiceRegistry _buildServices({ClientControllerApi? controller}) {
-  final localState = MemoryLocalStateStore();
+ClientServiceRegistry _buildServices({
+  ClientControllerApi? controller,
+  LocalStateStore? localStateOverride,
+}) {
+  final localState = localStateOverride ?? MemoryLocalStateStore();
   final secureStorage = MemorySecureStorage();
   final diagnosticsExporter = MemoryDiagnosticsFileExporter();
   final profileStore = ProfileStore.withSampleProfiles(
@@ -174,6 +202,7 @@ ClientServiceRegistry _buildServices({ClientControllerApi? controller}) {
     profileSecrets: profileSecrets,
     secureStorage: secureStorage,
     controller: resolvedController,
+    localStateStore: localState,
   );
 
   final diagnostics = DiagnosticsExportService(
@@ -214,6 +243,46 @@ void main() {
     expect(find.text('Save the password before testing'), findsWidgets);
     expect(find.text('Open Profiles'), findsWidgets);
     expect(find.text('Readiness Provenance'), findsOneWidget);
+  });
+
+  testWidgets('late cached snapshot does not overwrite live readiness',
+      (WidgetTester tester) async {
+    final localState = _DelayedReadLocalStateStore();
+    final services = _buildServices(localStateOverride: localState);
+    final profile = services.profileStore.selectedProfile!;
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: profile.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      profile.copyWith(hasStoredPassword: true),
+    );
+    await localState.write(
+      'client.readiness.last-known.${profile.id}',
+      jsonEncode(
+        ReadinessReport.fromChecks(
+          const <ReadinessCheck>[
+            ReadinessCheck(
+              domain: ReadinessDomain.config,
+              level: ReadinessLevel.blocked,
+              summary: 'stale invalid config snapshot',
+              detail: 'stale snapshot should not override live readiness',
+              action: ReadinessAction.openProfiles,
+              actionLabel: 'Open Profiles',
+            ),
+          ],
+          generatedAt: DateTime.now().subtract(const Duration(minutes: 10)),
+        ).toJson(),
+      ),
+    );
+
+    await _showDashboard(tester, services: services);
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Live check'), findsOneWidget);
+    expect(find.text('Connect blocked'), findsNothing);
+    expect(find.widgetWithText(FilledButton, 'Connect now'), findsOneWidget);
   });
 
   testWidgets('shows connection home CTAs when profile is ready',

--- a/client/test/features/dashboard/presentation/dashboard_page_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_page_test.dart
@@ -55,12 +55,18 @@ class _DelayedReadLocalStateStore implements LocalStateStore {
 class _TestLifecycleController extends ClientControllerApi {
   ClientConnectionStatus _status = ClientConnectionStatus.disconnected();
   String? lastConnectedProfileId;
+  ControllerRuntimeSession? _sessionOverride;
 
   @override
   ClientConnectionStatus get status => _status;
 
   set statusForTest(ClientConnectionStatus value) {
     _status = value;
+    notifyListeners();
+  }
+
+  set sessionForTest(ControllerRuntimeSession value) {
+    _sessionOverride = value;
     notifyListeners();
   }
 
@@ -84,7 +90,8 @@ class _TestLifecycleController extends ClientControllerApi {
       );
 
   @override
-  ControllerRuntimeSession get session => ControllerRuntimeSession(
+  ControllerRuntimeSession get session => _sessionOverride ??
+      ControllerRuntimeSession(
         isRunning: _status.phase == ClientConnectionPhase.connected,
         updatedAt: DateTime.now(),
         phase: _status.phase == ClientConnectionPhase.connected
@@ -135,6 +142,23 @@ class _TestLifecycleController extends ClientControllerApi {
   }
 }
 
+class _RuntimeTrueLifecycleController extends _TestLifecycleController {
+  @override
+  ControllerTelemetrySnapshot get telemetry => ControllerTelemetrySnapshot(
+        backendKind: 'real-shell-controller',
+        backendVersion: 'test-runtime-true',
+        capabilities: const <String>['connect', 'disconnect', 'logs'],
+        lastUpdatedAt: DateTime.parse('2026-03-13T00:00:00.000Z'),
+      );
+
+  @override
+  ControllerRuntimeConfig get runtimeConfig => const ControllerRuntimeConfig(
+        mode: 'real-runtime-boundary',
+        endpointHint: 'unix:/tmp/trojan-runtime.sock',
+        enableVerboseTelemetry: true,
+      );
+}
+
 Future<void> _setDesktopSurface(WidgetTester tester) async {
   await tester.binding.setSurfaceSize(const Size(1600, 1400));
   addTearDown(() async {
@@ -145,6 +169,7 @@ Future<void> _setDesktopSurface(WidgetTester tester) async {
 Future<void> _showDashboard(
   WidgetTester tester, {
   required ClientServiceRegistry services,
+  VoidCallback? onOpenAdvanced,
   VoidCallback? onOpenSettings,
 }) async {
   await _setDesktopSurface(tester);
@@ -153,6 +178,7 @@ Future<void> _showDashboard(
       home: Scaffold(
         body: DashboardPage(
           services: services,
+          onOpenAdvanced: onOpenAdvanced,
           onOpenSettings: onOpenSettings,
         ),
       ),
@@ -316,6 +342,20 @@ void main() {
     expect(find.text('Problem Report'), findsWidgets);
   });
 
+  testWidgets('runtime session summary surfaces truth and recovery guidance',
+      (WidgetTester tester) async {
+    final services = _buildServices();
+
+    await _showDashboard(tester, services: services);
+    await tester.tap(find.text('Advanced runtime session'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Session Truth:'), findsOneWidget);
+    expect(find.text('Runtime Truth'), findsOneWidget);
+    expect(find.text('Snapshot Age'), findsOneWidget);
+    expect(find.textContaining('leftover session state'), findsOneWidget);
+  });
+
   testWidgets('connect now CTA triggers a connection attempt',
       (WidgetTester tester) async {
     final services = _buildServices();
@@ -345,6 +385,7 @@ void main() {
     );
 
     expect(services.controller.status.phase, ClientConnectionPhase.connected);
+    expect(find.textContaining('Shell validation is ready'), findsOneWidget);
   });
 
   testWidgets('dashboard gates connect when readiness is blocked',
@@ -463,6 +504,11 @@ void main() {
       updatedAt: DateTime.now(),
       activeProfileId: first.id,
     );
+    controller.sessionForTest = ControllerRuntimeSession(
+      isRunning: false,
+      updatedAt: DateTime.now(),
+      phase: ControllerRuntimePhase.stopped,
+    );
 
     await _showDashboard(tester, services: services);
 
@@ -478,6 +524,52 @@ void main() {
     expect(controller.lastConnectedProfileId, first.id);
     expect(controller.status.activeProfileId, first.id);
     expect(controller.status.phase, ClientConnectionPhase.connected);
+  });
+
+  testWidgets('error with residual session steers user to troubleshooting before retry',
+      (WidgetTester tester) async {
+    final controller = _RuntimeTrueLifecycleController();
+    final services = _buildServices(controller: controller);
+    final profile = services.profileStore.selectedProfile!;
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: profile.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      profile.copyWith(hasStoredPassword: true),
+    );
+    controller.statusForTest = ClientConnectionStatus(
+      phase: ClientConnectionPhase.error,
+      message: 'Runtime session exited with code 7.',
+      updatedAt: DateTime.now(),
+      activeProfileId: profile.id,
+    );
+    controller.sessionForTest = ControllerRuntimeSession(
+      isRunning: false,
+      updatedAt: DateTime.now(),
+      phase: ControllerRuntimePhase.failed,
+      lastExitCode: 7,
+    );
+
+    var openedAdvanced = false;
+    await _showDashboard(
+      tester,
+      services: services,
+      onOpenAdvanced: () {
+        openedAdvanced = true;
+      },
+    );
+
+    final troubleshootingFinder = find.text('Open Troubleshooting');
+    expect(troubleshootingFinder, findsWidgets);
+    expect(find.text('Capture snapshot before retry'), findsOneWidget);
+    expect(find.textContaining('Preserve the current runtime evidence'),
+        findsOneWidget);
+
+    await tester.tap(troubleshootingFinder.first);
+    await tester.pump();
+
+    expect(openedAdvanced, isTrue);
   });
 
   testWidgets('disconnect now CTA tears down an active connection',
@@ -513,6 +605,90 @@ void main() {
       services.controller.status.phase,
       ClientConnectionPhase.disconnected,
     );
+  });
+
+  testWidgets('connected stale runtime steers user to troubleshooting first',
+      (WidgetTester tester) async {
+    final controller = _TestLifecycleController();
+    final services = _buildServices(controller: controller);
+    final profile = services.profileStore.selectedProfile!;
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: profile.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      profile.copyWith(hasStoredPassword: true),
+    );
+    controller.statusForTest = ClientConnectionStatus(
+      phase: ClientConnectionPhase.connected,
+      message: 'Runtime session is ready.',
+      updatedAt: DateTime.now(),
+      activeProfileId: profile.id,
+    );
+    controller.sessionForTest = ControllerRuntimeSession(
+      isRunning: true,
+      updatedAt: DateTime.now().subtract(const Duration(minutes: 3)),
+      phase: ControllerRuntimePhase.sessionReady,
+      expectedLocalSocksPort: 10808,
+    );
+
+    await _showDashboard(tester, services: services);
+
+    expect(find.text('Connection state needs revalidation'), findsOneWidget);
+    expect(find.text('Open Troubleshooting'), findsWidgets);
+    expect(find.widgetWithText(OutlinedButton, 'Disconnect now'), findsOneWidget);
+    expect(find.textContaining('disconnect and reconnect'), findsOneWidget);
+    expect(find.text('Action safety'), findsOneWidget);
+    expect(find.text('Revalidate before changing state'), findsOneWidget);
+    expect(find.textContaining('Open Troubleshooting first'), findsWidgets);
+    expect(find.text('Recommended right now'), findsOneWidget);
+    expect(find.textContaining('Open Troubleshooting first'), findsWidgets);
+    expect(find.widgetWithText(OutlinedButton, 'Disconnect now'), findsOneWidget);
+    expect(
+      find.textContaining('Secondary state-changing actions are temporarily withheld'),
+      findsNothing,
+    );
+  });
+
+  testWidgets('disconnecting session tells operator to wait for exit confirmation',
+      (WidgetTester tester) async {
+    final controller = _TestLifecycleController();
+    final services = _buildServices(controller: controller);
+    final profile = services.profileStore.selectedProfile!;
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: profile.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      profile.copyWith(hasStoredPassword: true),
+    );
+    controller.statusForTest = ClientConnectionStatus(
+      phase: ClientConnectionPhase.disconnecting,
+      message: 'Disconnecting current session...',
+      updatedAt: DateTime.now(),
+      activeProfileId: profile.id,
+    );
+    controller.sessionForTest = ControllerRuntimeSession(
+      isRunning: true,
+      updatedAt: DateTime.now().subtract(const Duration(seconds: 10)),
+      phase: ControllerRuntimePhase.alive,
+      stopRequested: true,
+      stopRequestedAt: DateTime.now().subtract(const Duration(seconds: 5)),
+      expectedLocalSocksPort: 10808,
+    );
+
+    await _showDashboard(tester, services: services);
+
+    expect(find.textContaining('exit confirmation'), findsWidgets);
+    expect(find.text('Open Troubleshooting'), findsWidgets);
+    expect(find.text('Action safety'), findsOneWidget);
+    expect(find.text('Wait for exit confirmation'), findsWidgets);
+    expect(
+      find.text('Recommended right now: capture a support snapshot first'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('capture the current support evidence'),
+        findsOneWidget);
   });
 
   testWidgets(

--- a/client/test/features/diagnostics/application/diagnostics_export_service_test.dart
+++ b/client/test/features/diagnostics/application/diagnostics_export_service_test.dart
@@ -5,8 +5,10 @@ import 'package:trojan_pro_client/features/controller/application/fake_client_co
 import 'package:trojan_pro_client/features/diagnostics/application/diagnostics_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_store.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_portability_service.dart';
+import 'package:trojan_pro_client/features/profiles/application/profile_secrets_service.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_serialization.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_store.dart';
+import 'package:trojan_pro_client/features/readiness/application/readiness_service.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_serialization.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_store.dart';
 import 'package:trojan_pro_client/platform/secure_storage/memory_secure_storage.dart';
@@ -37,9 +39,16 @@ void main() {
       error: StateError('background task exploded'),
       stackTrace: StackTrace.current,
     );
-    await secureStorage.writeSecret(
-      'profile.sample-hk-1.trojanPassword',
-      'super-secret-password',
+    await ProfileSecretsService(secureStorage: secureStorage).saveTrojanPassword(
+      profileId: 'sample-hk-1',
+      password: 'super-secret-password',
+    );
+
+    final readiness = ReadinessService(
+      profileStore: profileStore,
+      profileSecrets: ProfileSecretsService(secureStorage: secureStorage),
+      secureStorage: secureStorage,
+      controller: controller,
     );
 
     final diagnostics = DiagnosticsExportService(
@@ -50,6 +59,7 @@ void main() {
       controller: controller,
       secureStorage: secureStorage,
       fileExporter: diagnosticsExporter,
+      readiness: readiness,
       appRuntimeErrors: appRuntimeErrors,
     );
 
@@ -75,21 +85,31 @@ void main() {
     final diagnosticsExporter = MemoryDiagnosticsFileExporter();
     final secureStorage = MemorySecureStorage();
 
+    final profileStore = ProfileStore.withSampleProfiles(
+      localStateStore: localState,
+      serialization: ProfileSerialization(),
+      saveDebounceDuration: Duration.zero,
+    );
+    final controller = FakeClientController();
+    final readiness = ReadinessService(
+      profileStore: profileStore,
+      profileSecrets: ProfileSecretsService(secureStorage: secureStorage),
+      secureStorage: secureStorage,
+      controller: controller,
+    );
+
     final diagnostics = DiagnosticsExportService(
-      profileStore: ProfileStore.withSampleProfiles(
-        localStateStore: localState,
-        serialization: ProfileSerialization(),
-        saveDebounceDuration: Duration.zero,
-      ),
+      profileStore: profileStore,
       profilePortability: ProfilePortabilityService(),
       settingsStore: SettingsStore(
         localStateStore: localState,
         serialization: SettingsSerialization(),
       ),
       packagingStore: PackagingStore(),
-      controller: FakeClientController(),
+      controller: controller,
       secureStorage: secureStorage,
       fileExporter: diagnosticsExporter,
+      readiness: readiness,
       appRuntimeErrors: AppRuntimeErrorStore(localStateStore: localState),
     );
 

--- a/client/test/features/diagnostics/application/diagnostics_export_service_test.dart
+++ b/client/test/features/diagnostics/application/diagnostics_export_service_test.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:trojan_pro_client/features/controller/application/fake_client_controller.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_config.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_telemetry_snapshot.dart';
 import 'package:trojan_pro_client/features/diagnostics/application/diagnostics_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_store.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_portability_service.dart';
@@ -15,6 +17,23 @@ import 'package:trojan_pro_client/platform/secure_storage/memory_secure_storage.
 import 'package:trojan_pro_client/platform/services/app_runtime_error_store.dart';
 import 'package:trojan_pro_client/platform/services/memory_diagnostics_file_exporter.dart';
 import 'package:trojan_pro_client/platform/services/memory_local_state_store.dart';
+
+class _RuntimeTrueController extends FakeClientController {
+  @override
+  ControllerRuntimeConfig get runtimeConfig => const ControllerRuntimeConfig(
+        mode: 'real-runtime-boundary',
+        endpointHint: 'unix:/tmp/trojan-runtime.sock',
+        enableVerboseTelemetry: false,
+      );
+
+  @override
+  ControllerTelemetrySnapshot get telemetry => ControllerTelemetrySnapshot(
+        backendKind: 'real-shell-controller',
+        backendVersion: 'test-runtime-true',
+        capabilities: const <String>['spawn', 'logs'],
+        lastUpdatedAt: DateTime.parse('2026-03-24T12:00:00.000Z'),
+      );
+}
 
 void main() {
   test('buildPreviewBundle includes app runtime summary and profiles bundle',
@@ -39,7 +58,8 @@ void main() {
       error: StateError('background task exploded'),
       stackTrace: StackTrace.current,
     );
-    await ProfileSecretsService(secureStorage: secureStorage).saveTrojanPassword(
+    await ProfileSecretsService(secureStorage: secureStorage)
+        .saveTrojanPassword(
       profileId: 'sample-hk-1',
       password: 'super-secret-password',
     );
@@ -66,6 +86,8 @@ void main() {
     final preview = await diagnostics.buildPreviewBundle();
     final payload = jsonDecode(preview) as Map<String, dynamic>;
 
+    expect(payload['bundleKind'], 'support-bundle');
+
     final appRuntime = payload['appRuntime'] as Map<String, dynamic>;
     final lastUnhandledError =
         appRuntime['lastUnhandledError'] as Map<String, dynamic>;
@@ -78,6 +100,93 @@ void main() {
     expect(profiles, hasLength(profileStore.profiles.length));
 
     expect(preview, isNot(contains('super-secret-password')));
+  });
+
+  test('runtime-proof artifact export requires evidence-grade posture',
+      () async {
+    final localState = MemoryLocalStateStore();
+    final diagnosticsExporter = MemoryDiagnosticsFileExporter();
+    final secureStorage = MemorySecureStorage();
+
+    final profileStore = ProfileStore.withSampleProfiles(
+      localStateStore: localState,
+      serialization: ProfileSerialization(),
+      saveDebounceDuration: Duration.zero,
+    );
+    final controller = FakeClientController();
+    final readiness = ReadinessService(
+      profileStore: profileStore,
+      profileSecrets: ProfileSecretsService(secureStorage: secureStorage),
+      secureStorage: secureStorage,
+      controller: controller,
+    );
+
+    final diagnostics = DiagnosticsExportService(
+      profileStore: profileStore,
+      profilePortability: ProfilePortabilityService(),
+      settingsStore: SettingsStore(
+        localStateStore: localState,
+        serialization: SettingsSerialization(),
+      ),
+      packagingStore: PackagingStore(),
+      controller: controller,
+      secureStorage: secureStorage,
+      fileExporter: diagnosticsExporter,
+      readiness: readiness,
+      appRuntimeErrors: AppRuntimeErrorStore(localStateStore: localState),
+    );
+
+    await expectLater(
+      diagnostics.buildRuntimeProofArtifact(),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test(
+      'runtime-proof artifact export uses promoted file name on evidence-grade path',
+      () async {
+    final localState = MemoryLocalStateStore();
+    final diagnosticsExporter = MemoryDiagnosticsFileExporter();
+    final secureStorage = MemorySecureStorage();
+
+    final profileStore = ProfileStore.withSampleProfiles(
+      localStateStore: localState,
+      serialization: ProfileSerialization(),
+      saveDebounceDuration: Duration.zero,
+    );
+    final controller = _RuntimeTrueController();
+    final readiness = ReadinessService(
+      profileStore: profileStore,
+      profileSecrets: ProfileSecretsService(secureStorage: secureStorage),
+      secureStorage: secureStorage,
+      controller: controller,
+    );
+
+    final diagnostics = DiagnosticsExportService(
+      profileStore: profileStore,
+      profilePortability: ProfilePortabilityService(),
+      settingsStore: SettingsStore(
+        localStateStore: localState,
+        serialization: SettingsSerialization(),
+      ),
+      packagingStore: PackagingStore(),
+      controller: controller,
+      secureStorage: secureStorage,
+      fileExporter: diagnosticsExporter,
+      readiness: readiness,
+      appRuntimeErrors: AppRuntimeErrorStore(localStateStore: localState),
+    );
+
+    final result = await diagnostics.exportRuntimeProofArtifact();
+    final payload = jsonDecode(result.contents) as Map<String, dynamic>;
+
+    expect(payload['bundleKind'], 'runtime-proof-artifact');
+    expect(result.target,
+        startsWith('memory://diagnostics/trojan-pro-runtime-proof-'));
+    expect(
+      diagnosticsExporter.exports.keys.single,
+      startsWith('trojan-pro-runtime-proof-'),
+    );
   });
 
   test('exportPreviewBundle delegates to support bundle export path', () async {
@@ -115,7 +224,8 @@ void main() {
 
     final result = await diagnostics.exportPreviewBundle();
 
-    expect(result.target, startsWith('memory://diagnostics/trojan-pro-support-'));
+    expect(
+        result.target, startsWith('memory://diagnostics/trojan-pro-support-'));
     expect(diagnosticsExporter.exports.keys.single,
         startsWith('trojan-pro-support-'));
     expect(result.contents, contains('"controller"'));

--- a/client/test/features/diagnostics/application/diagnostics_export_service_test.dart
+++ b/client/test/features/diagnostics/application/diagnostics_export_service_test.dart
@@ -93,10 +93,15 @@ void main() {
         controllerPayload['runtimePosture'] as Map<String, dynamic>;
     final operatorGuidance =
         runtimePosture['operatorGuidance'] as Map<String, dynamic>;
+    final runtimeSession =
+        controllerPayload['runtimeSession'] as Map<String, dynamic>;
 
     expect(operatorGuidance['heading'],
         'How to use support bundles on this posture');
     expect((operatorGuidance['checklist'] as List<dynamic>).isNotEmpty, isTrue);
+    expect(runtimeSession['truth'], 'Residual snapshot');
+    expect(runtimeSession['needsAttention'], isTrue);
+    expect(runtimeSession['recoveryGuidance'], contains('retry from Profiles'));
 
     final appRuntime = payload['appRuntime'] as Map<String, dynamic>;
     final lastUnhandledError =

--- a/client/test/features/diagnostics/application/diagnostics_export_service_test.dart
+++ b/client/test/features/diagnostics/application/diagnostics_export_service_test.dart
@@ -88,6 +88,16 @@ void main() {
 
     expect(payload['bundleKind'], 'support-bundle');
 
+    final controllerPayload = payload['controller'] as Map<String, dynamic>;
+    final runtimePosture =
+        controllerPayload['runtimePosture'] as Map<String, dynamic>;
+    final operatorGuidance =
+        runtimePosture['operatorGuidance'] as Map<String, dynamic>;
+
+    expect(operatorGuidance['heading'],
+        'How to use support bundles on this posture');
+    expect((operatorGuidance['checklist'] as List<dynamic>).isNotEmpty, isTrue);
+
     final appRuntime = payload['appRuntime'] as Map<String, dynamic>;
     final lastUnhandledError =
         appRuntime['lastUnhandledError'] as Map<String, dynamic>;
@@ -179,8 +189,14 @@ void main() {
 
     final result = await diagnostics.exportRuntimeProofArtifact();
     final payload = jsonDecode(result.contents) as Map<String, dynamic>;
+    final controllerPayload = payload['controller'] as Map<String, dynamic>;
+    final runtimePosture =
+        controllerPayload['runtimePosture'] as Map<String, dynamic>;
+    final operatorGuidance =
+        runtimePosture['operatorGuidance'] as Map<String, dynamic>;
 
     expect(payload['bundleKind'], 'runtime-proof-artifact');
+    expect(operatorGuidance['heading'], 'How to use runtime-proof artifacts');
     expect(result.target,
         startsWith('memory://diagnostics/trojan-pro-runtime-proof-'));
     expect(

--- a/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
+++ b/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:trojan_pro_client/features/controller/application/client_controller_api.dart';
 import 'package:trojan_pro_client/features/controller/application/fake_client_controller.dart';
 import 'package:trojan_pro_client/features/controller/domain/controller_runtime_config.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
 import 'package:trojan_pro_client/features/controller/domain/controller_telemetry_snapshot.dart';
 import 'package:trojan_pro_client/features/diagnostics/application/diagnostics_export_service.dart';
 import 'package:trojan_pro_client/features/diagnostics/presentation/diagnostics_page.dart';
@@ -43,6 +44,15 @@ class _RuntimeTrueController extends FakeClientController {
         capabilities: const <String>['spawn', 'logs'],
         lastUpdatedAt: DateTime.parse('2026-03-24T12:00:00.000Z'),
       );
+
+  @override
+  ControllerRuntimeSession get session => ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: DateTime.now().subtract(const Duration(seconds: 8)),
+        phase: ControllerRuntimePhase.sessionReady,
+        pid: 4242,
+        configProvenance: 'managed-runtime://sample-hk-1',
+      );
 }
 
 class _FailingDiagnosticsFileExporter implements DiagnosticsFileExporter {
@@ -56,6 +66,18 @@ class _FailingDiagnosticsFileExporter implements DiagnosticsFileExporter {
   }) async {
     throw StateError('permission denied for diagnostics export');
   }
+}
+
+class _StoppingController extends FakeClientController {
+  @override
+  ControllerRuntimeSession get session => ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: DateTime.now().subtract(const Duration(seconds: 12)),
+        phase: ControllerRuntimePhase.alive,
+        stopRequested: true,
+        stopRequestedAt: DateTime.now().subtract(const Duration(seconds: 6)),
+        pid: 4242,
+      );
 }
 
 ClientServiceRegistry _buildServices({
@@ -138,6 +160,10 @@ void main() {
     );
     expect(find.text('Runtime-proof artifact available'), findsOneWidget);
     expect(find.text('How to use runtime-proof artifacts'), findsOneWidget);
+    expect(find.text('Runtime truth & recovery'), findsOneWidget);
+    expect(find.text('Current runtime truth: Live'), findsOneWidget);
+    expect(find.text('Needs attention: No'), findsOneWidget);
+    expect(find.textContaining('runtime-true evidence'), findsOneWidget);
 
     await tester
         .tap(find.widgetWithText(FilledButton, 'Generate support preview'));
@@ -177,6 +203,10 @@ void main() {
       find.text('How to use support bundles on this posture'),
       findsOneWidget,
     );
+    expect(find.text('Runtime truth & recovery'), findsOneWidget);
+    expect(find.text('Current runtime truth: Residual snapshot'), findsOneWidget);
+    expect(find.text('Needs attention: Yes'), findsOneWidget);
+    expect(find.textContaining('support context rather than proof'), findsOneWidget);
     expect(
       find.widgetWithText(OutlinedButton, 'Export runtime-proof artifact'),
       findsNothing,
@@ -239,6 +269,10 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
+    expect(find.text('Last captured export snapshot'), findsOneWidget);
+    expect(find.textContaining('support preview captured Residual snapshot'),
+        findsOneWidget);
+
     await tester
         .tap(find.widgetWithText(OutlinedButton, 'Export support bundle'));
     await tester.pump();
@@ -248,6 +282,41 @@ void main() {
       find.textContaining('Last export target (support bundle):'),
       findsOneWidget,
     );
+    expect(find.textContaining('support bundle captured Residual snapshot'),
+        findsOneWidget);
+  });
+
+  testWidgets('stopping runtime shows exit confirmation warning',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    final services = _buildServices(controllerOverride: _StoppingController());
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DiagnosticsPage(services: services),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Runtime truth & recovery'), findsOneWidget);
+    expect(find.text('Current runtime truth: Stopping'), findsOneWidget);
+    expect(find.text('Action safety'), findsOneWidget);
+    expect(find.text('Wait for exit confirmation'), findsWidgets);
+    expect(find.text('Exit confirmation pending'), findsOneWidget);
+    expect(find.textContaining('Do not treat this runtime as fully closed yet'),
+        findsWidgets);
+    expect(find.text('Recommended right now: capture a support snapshot first'),
+        findsOneWidget);
+    expect(find.textContaining('Generate a support preview or export a support bundle'),
+        findsOneWidget);
+    expect(
+      find.textContaining('This preserves the stop-pending evidence while it is still current.'),
+      findsOneWidget,
+    );
+    expect(find.text('Preferred evidence action: Generate support preview'),
+        findsOneWidget);
   });
 
   testWidgets('shows categorized export error guidance when export fails',

--- a/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
+++ b/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/application/client_controller_api.dart';
 import 'package:trojan_pro_client/features/controller/application/fake_client_controller.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_config.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_telemetry_snapshot.dart';
 import 'package:trojan_pro_client/features/diagnostics/application/diagnostics_export_service.dart';
 import 'package:trojan_pro_client/features/diagnostics/presentation/diagnostics_page.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_export_service.dart';
@@ -25,6 +28,23 @@ Future<void> _setDesktopSurface(WidgetTester tester) async {
   });
 }
 
+class _RuntimeTrueController extends FakeClientController {
+  @override
+  ControllerRuntimeConfig get runtimeConfig => const ControllerRuntimeConfig(
+        mode: 'real-runtime-boundary',
+        endpointHint: 'unix:/tmp/trojan-runtime.sock',
+        enableVerboseTelemetry: false,
+      );
+
+  @override
+  ControllerTelemetrySnapshot get telemetry => ControllerTelemetrySnapshot(
+        backendKind: 'real-shell-controller',
+        backendVersion: 'test-runtime-true',
+        capabilities: const <String>['spawn', 'logs'],
+        lastUpdatedAt: DateTime.parse('2026-03-24T12:00:00.000Z'),
+      );
+}
+
 class _FailingDiagnosticsFileExporter implements DiagnosticsFileExporter {
   @override
   String get backendName => 'failing-test-exporter';
@@ -38,7 +58,10 @@ class _FailingDiagnosticsFileExporter implements DiagnosticsFileExporter {
   }
 }
 
-ClientServiceRegistry _buildServices({DiagnosticsFileExporter? exporter}) {
+ClientServiceRegistry _buildServices({
+  DiagnosticsFileExporter? exporter,
+  ClientControllerApi? controllerOverride,
+}) {
   final localState = MemoryLocalStateStore();
   final secureStorage = MemorySecureStorage();
   final diagnosticsExporter = exporter ?? MemoryDiagnosticsFileExporter();
@@ -54,7 +77,7 @@ ClientServiceRegistry _buildServices({DiagnosticsFileExporter? exporter}) {
     localStateStore: localState,
     serialization: SettingsSerialization(),
   );
-  final controller = FakeClientController();
+  final controller = controllerOverride ?? FakeClientController();
 
   final packagingExport = PackagingExportService(
     packagingStore: packagingStore,
@@ -94,6 +117,38 @@ ClientServiceRegistry _buildServices({DiagnosticsFileExporter? exporter}) {
 }
 
 void main() {
+  testWidgets('shows runtime-proof export path on evidence-grade posture',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    final services =
+        _buildServices(controllerOverride: _RuntimeTrueController());
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DiagnosticsPage(services: services),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(
+      find.text('Current evidence grade: Evidence-grade'),
+      findsOneWidget,
+    );
+    expect(find.text('Runtime-proof artifact available'), findsOneWidget);
+
+    await tester
+        .tap(find.widgetWithText(FilledButton, 'Generate support preview'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(
+      find.widgetWithText(OutlinedButton, 'Export runtime-proof artifact'),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('shows support bundle summary before export',
       (WidgetTester tester) async {
     await _setDesktopSurface(tester);
@@ -116,6 +171,10 @@ void main() {
     expect(
       find.text('Runtime-proof artifact unavailable on current posture'),
       findsOneWidget,
+    );
+    expect(
+      find.widgetWithText(OutlinedButton, 'Export runtime-proof artifact'),
+      findsNothing,
     );
     expect(find.text('Includes'), findsOneWidget);
     expect(find.text('Does not include'), findsOneWidget);
@@ -180,7 +239,10 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
-    expect(find.textContaining('Last export target:'), findsOneWidget);
+    expect(
+      find.textContaining('Last export target (support bundle):'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('shows categorized export error guidance when export fails',

--- a/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
+++ b/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
@@ -9,6 +9,7 @@ import 'package:trojan_pro_client/features/profiles/application/profile_portabil
 import 'package:trojan_pro_client/features/profiles/application/profile_secrets_service.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_serialization.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_store.dart';
+import 'package:trojan_pro_client/features/readiness/application/readiness_service.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_serialization.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_store.dart';
 import 'package:trojan_pro_client/platform/services/diagnostics_file_exporter.dart';
@@ -59,6 +60,12 @@ ClientServiceRegistry _buildServices({DiagnosticsFileExporter? exporter}) {
     packagingStore: packagingStore,
     fileExporter: diagnosticsExporter,
   );
+  final readiness = ReadinessService(
+    profileStore: profileStore,
+    profileSecrets: profileSecrets,
+    secureStorage: secureStorage,
+    controller: controller,
+  );
   final diagnostics = DiagnosticsExportService(
     profileStore: profileStore,
     profilePortability: profilePortability,
@@ -67,6 +74,7 @@ ClientServiceRegistry _buildServices({DiagnosticsFileExporter? exporter}) {
     controller: controller,
     secureStorage: secureStorage,
     fileExporter: diagnosticsExporter,
+    readiness: readiness,
   );
 
   return ClientServiceRegistry(
@@ -80,6 +88,7 @@ ClientServiceRegistry _buildServices({DiagnosticsFileExporter? exporter}) {
     packagingExport: packagingExport,
     settingsStore: settingsStore,
     controller: controller,
+    readiness: readiness,
     diagnostics: diagnostics,
   );
 }

--- a/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
+++ b/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
@@ -137,6 +137,7 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Runtime-proof artifact available'), findsOneWidget);
+    expect(find.text('How to use runtime-proof artifacts'), findsOneWidget);
 
     await tester
         .tap(find.widgetWithText(FilledButton, 'Generate support preview'));
@@ -170,6 +171,10 @@ void main() {
     );
     expect(
       find.text('Runtime-proof artifact unavailable on current posture'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('How to use support bundles on this posture'),
       findsOneWidget,
     );
     expect(

--- a/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
+++ b/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
@@ -109,6 +109,10 @@ void main() {
     await tester.pump();
 
     expect(find.text('Before you export a support bundle'), findsOneWidget);
+    expect(
+      find.text('Current evidence grade: Shell-grade only'),
+      findsOneWidget,
+    );
     expect(find.text('Includes'), findsOneWidget);
     expect(find.text('Does not include'), findsOneWidget);
     expect(find.textContaining('raw Trojan password'), findsOneWidget);
@@ -142,6 +146,9 @@ void main() {
     );
     expect(exportButtonAfter.onPressed, isNotNull);
     expect(find.text('Preview excerpt'), findsOneWidget);
+    final preview = await services.diagnostics.buildPreviewBundle();
+    expect(preview, contains('"runtimePosture"'));
+    expect(preview, contains('"evidenceGrade": "Shell-grade only"'));
   });
 
   testWidgets('shows export success state after bundle write',
@@ -198,7 +205,8 @@ void main() {
       find.text('Detail: Bad state: permission denied for diagnostics export'),
       findsOneWidget,
     );
-    expect(find.text('The support bundle could not be written'), findsOneWidget);
+    expect(
+        find.text('The support bundle could not be written'), findsOneWidget);
     expect(find.textContaining('Check the export target path'), findsOneWidget);
   });
 }

--- a/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
+++ b/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
@@ -113,6 +113,10 @@ void main() {
       find.text('Current evidence grade: Shell-grade only'),
       findsOneWidget,
     );
+    expect(
+      find.text('Runtime-proof artifact unavailable on current posture'),
+      findsOneWidget,
+    );
     expect(find.text('Includes'), findsOneWidget);
     expect(find.text('Does not include'), findsOneWidget);
     expect(find.textContaining('raw Trojan password'), findsOneWidget);
@@ -133,16 +137,17 @@ void main() {
     await tester.pump();
 
     final exportButtonBefore = tester.widget<OutlinedButton>(
-      find.widgetWithText(OutlinedButton, 'Export bundle'),
+      find.widgetWithText(OutlinedButton, 'Export support bundle'),
     );
     expect(exportButtonBefore.onPressed, isNull);
 
-    await tester.tap(find.widgetWithText(FilledButton, 'Generate preview'));
+    await tester
+        .tap(find.widgetWithText(FilledButton, 'Generate support preview'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
     final exportButtonAfter = tester.widget<OutlinedButton>(
-      find.widgetWithText(OutlinedButton, 'Export bundle'),
+      find.widgetWithText(OutlinedButton, 'Export support bundle'),
     );
     expect(exportButtonAfter.onPressed, isNotNull);
     expect(find.text('Preview excerpt'), findsOneWidget);
@@ -165,11 +170,13 @@ void main() {
     );
     await tester.pump();
 
-    await tester.tap(find.widgetWithText(FilledButton, 'Generate preview'));
+    await tester
+        .tap(find.widgetWithText(FilledButton, 'Generate support preview'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
-    await tester.tap(find.widgetWithText(OutlinedButton, 'Export bundle'));
+    await tester
+        .tap(find.widgetWithText(OutlinedButton, 'Export support bundle'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
@@ -191,11 +198,13 @@ void main() {
     );
     await tester.pump();
 
-    await tester.tap(find.widgetWithText(FilledButton, 'Generate preview'));
+    await tester
+        .tap(find.widgetWithText(FilledButton, 'Generate support preview'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
-    await tester.tap(find.widgetWithText(OutlinedButton, 'Export bundle'));
+    await tester
+        .tap(find.widgetWithText(OutlinedButton, 'Export support bundle'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 

--- a/client/test/features/diagnostics/presentation/diagnostics_support_policy_test.dart
+++ b/client/test/features/diagnostics/presentation/diagnostics_support_policy_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_operator_advice.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_posture.dart';
+import 'package:trojan_pro_client/features/diagnostics/presentation/diagnostics_support_policy.dart';
+
+void main() {
+  test('stopping runtime surfaces exit confirmation warning', () {
+    final runtimeSession = ControllerRuntimeSession(
+      isRunning: true,
+      updatedAt: DateTime.now().subtract(const Duration(seconds: 12)),
+      phase: ControllerRuntimePhase.alive,
+      stopRequested: true,
+      stopRequestedAt: DateTime.now().subtract(const Duration(seconds: 6)),
+    );
+    final posture = describeRuntimePosture(
+      runtimeMode: 'real-runtime-boundary',
+      backendKind: 'real-shell-controller',
+    );
+    final advice = RuntimeOperatorAdvice.resolve(
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.disconnecting,
+        message: 'Disconnecting current session...',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: runtimeSession,
+      posture: posture,
+      troubleshootingAvailable: true,
+    );
+
+    final policy = DiagnosticsSupportPolicy.resolve(
+      runtimeSession: runtimeSession,
+      runtimePosture: posture,
+      operatorAdvice: advice,
+      exportedRuntimeSession: null,
+      exportedBundleKindLabel: null,
+    );
+
+    expect(policy.showExitConfirmationWarning, isTrue);
+    expect(policy.exitConfirmationTitle, 'Exit confirmation pending');
+    expect(policy.exitConfirmationBody, contains('fully closed yet'));
+    expect(policy.primaryOperatorTitle,
+        'Recommended right now: capture a support snapshot first');
+    expect(policy.primaryOperatorBody, contains('support preview'));
+    expect(policy.preferredEvidenceActionLabel, 'Generate support preview');
+  });
+
+  test('export snapshot detail reuses shared operator semantics', () {
+    final runtimeSession = ControllerRuntimeSession(
+      isRunning: false,
+      updatedAt: DateTime.now(),
+      phase: ControllerRuntimePhase.stopped,
+    );
+    final exportedSession = ControllerRuntimeSession(
+      isRunning: true,
+      updatedAt: DateTime.now().subtract(const Duration(minutes: 3)),
+      phase: ControllerRuntimePhase.sessionReady,
+    );
+    final posture = describeRuntimePosture(
+      runtimeMode: 'real-runtime-boundary',
+      backendKind: 'real-shell-controller',
+    );
+
+    final policy = DiagnosticsSupportPolicy.resolve(
+      runtimeSession: runtimeSession,
+      runtimePosture: posture,
+      operatorAdvice: RuntimeOperatorAdvice.none,
+      exportedRuntimeSession: exportedSession,
+      exportedBundleKindLabel: 'support bundle',
+    );
+
+    expect(policy.exportSnapshotLabel, 'support bundle captured Stale');
+    expect(policy.exportSnapshotDetail, contains('revalidate'));
+  });
+}

--- a/client/test/features/packaging/presentation/packaging_page_test.dart
+++ b/client/test/features/packaging/presentation/packaging_page_test.dart
@@ -9,6 +9,7 @@ import 'package:trojan_pro_client/features/profiles/application/profile_portabil
 import 'package:trojan_pro_client/features/profiles/application/profile_secrets_service.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_serialization.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_store.dart';
+import 'package:trojan_pro_client/features/readiness/application/readiness_service.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_serialization.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_store.dart';
 import 'package:trojan_pro_client/platform/services/memory_diagnostics_file_exporter.dart';
@@ -46,6 +47,12 @@ ClientServiceRegistry _buildServices() {
     packagingStore: packagingStore,
     fileExporter: diagnosticsExporter,
   );
+  final readiness = ReadinessService(
+    profileStore: profileStore,
+    profileSecrets: profileSecrets,
+    secureStorage: secureStorage,
+    controller: controller,
+  );
   final diagnostics = DiagnosticsExportService(
     profileStore: profileStore,
     profilePortability: profilePortability,
@@ -54,6 +61,7 @@ ClientServiceRegistry _buildServices() {
     controller: controller,
     secureStorage: secureStorage,
     fileExporter: diagnosticsExporter,
+    readiness: readiness,
   );
 
   return ClientServiceRegistry(
@@ -67,6 +75,7 @@ ClientServiceRegistry _buildServices() {
     packagingExport: packagingExport,
     settingsStore: settingsStore,
     controller: controller,
+    readiness: readiness,
     diagnostics: diagnostics,
     desktopLifecycle: NoopDesktopLifecycleService(),
   );

--- a/client/test/features/packaging/presentation/packaging_page_test.dart
+++ b/client/test/features/packaging/presentation/packaging_page_test.dart
@@ -25,6 +25,13 @@ Future<void> _setDesktopSurface(WidgetTester tester) async {
   });
 }
 
+Future<void> _setCompactSurface(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(430, 1400));
+  addTearDown(() async {
+    await tester.binding.setSurfaceSize(null);
+  });
+}
+
 ClientServiceRegistry _buildServices() {
   final localState = MemoryLocalStateStore();
   final secureStorage = MemorySecureStorage();
@@ -82,6 +89,33 @@ ClientServiceRegistry _buildServices() {
 }
 
 void main() {
+  testWidgets('packaging page stays usable on compact width',
+      (WidgetTester tester) async {
+    await _setCompactSurface(tester);
+    final services = _buildServices();
+    services.packagingStore.startExport();
+    services.packagingStore.completeExport(
+      manifestTarget: '/tmp/manifest.json',
+      metadataTarget: '/tmp/update.json',
+      rollbackPlanTarget: '/tmp/rollback.json',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PackagingPage(services: services),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Update Status'), findsOneWidget);
+    expect(find.text('Export History'), findsOneWidget);
+    expect(find.textContaining('manifest=/tmp/manifest.json'), findsOneWidget);
+    expect(find.textContaining('Readiness: scaffolded'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('shows update skeleton contract and stub action',
       (WidgetTester tester) async {
     await _setDesktopSurface(tester);

--- a/client/test/features/profiles/presentation/profile_connection_action_policy_test.dart
+++ b/client/test/features/profiles/presentation/profile_connection_action_policy_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_action_safety.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_posture.dart';
+import 'package:trojan_pro_client/features/profiles/presentation/profile_connection_action_policy.dart';
+import 'package:trojan_pro_client/features/readiness/domain/readiness_report.dart';
+
+void main() {
+  test('stale connected session routes to troubleshooting when available', () {
+    final policy = ProfileConnectionActionPolicy.resolve(
+      hasStoredPassword: true,
+      active: true,
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.connected,
+        message: 'Runtime session is ready.',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      runtimePosture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+      runtimeSession: ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: DateTime.now().subtract(const Duration(minutes: 3)),
+        phase: ControllerRuntimePhase.sessionReady,
+      ),
+      readinessReport: null,
+      hasConnectedElsewhere: false,
+      onOpenAdvancedAvailable: true,
+    );
+
+    expect(policy.buttonLabel, 'Revalidate in Troubleshooting');
+    expect(policy.buttonEnabled, isTrue);
+    expect(policy.primaryAction,
+        ProfileConnectionPrimaryAction.openTroubleshooting);
+  });
+
+  test('disconnecting session surfaces recovery guidance instead of idle hint', () {
+    final policy = ProfileConnectionActionPolicy.resolve(
+      hasStoredPassword: true,
+      active: true,
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.disconnecting,
+        message: 'Disconnecting current session...',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      runtimePosture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+      runtimeSession: ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: DateTime.now().subtract(const Duration(seconds: 10)),
+        phase: ControllerRuntimePhase.alive,
+        stopRequested: true,
+        stopRequestedAt: DateTime.now().subtract(const Duration(seconds: 5)),
+      ),
+      readinessReport: null,
+      hasConnectedElsewhere: false,
+      onOpenAdvancedAvailable: true,
+    );
+
+    expect(policy.buttonLabel, 'Open Troubleshooting');
+    expect(policy.buttonEnabled, isTrue);
+    expect(policy.statusHint, contains('exit confirmation'));
+    expect(policy.primaryAction,
+        ProfileConnectionPrimaryAction.openTroubleshooting);
+    expect(policy.actionSafety.state,
+        RuntimeActionSafetyState.waitForExitConfirmation);
+    expect(policy.actionSafety.recommendsSnapshotFirst, isTrue);
+  });
+
+  test('readiness blocked connect returns blocked policy', () {
+    final policy = ProfileConnectionActionPolicy.resolve(
+      hasStoredPassword: true,
+      active: false,
+      status: ClientConnectionStatus.disconnected(),
+      runtimePosture: describeRuntimePosture(
+        runtimeMode: 'stubbed-local-boundary',
+        backendKind: 'fake-shell-controller',
+      ),
+      runtimeSession: ControllerRuntimeSession(
+        isRunning: false,
+        updatedAt: DateTime.now(),
+        phase: ControllerRuntimePhase.stopped,
+      ),
+      readinessReport: ReadinessReport.fromChecks(
+        const <ReadinessCheck>[
+          ReadinessCheck(
+            domain: ReadinessDomain.config,
+            level: ReadinessLevel.blocked,
+            summary: 'server host missing',
+            detail: 'server host missing',
+            action: ReadinessAction.openProfiles,
+            actionLabel: 'Open Profiles',
+          ),
+        ],
+        generatedAt: DateTime.now(),
+      ),
+      hasConnectedElsewhere: false,
+      onOpenAdvancedAvailable: false,
+    );
+
+    expect(policy.buttonLabel, 'Connect Blocked');
+    expect(policy.buttonEnabled, isFalse);
+    expect(policy.statusHint, contains('Readiness blocked'));
+  });
+}

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -31,6 +31,13 @@ Future<void> _setDesktopSurface(WidgetTester tester) async {
   });
 }
 
+Future<void> _setCompactSurface(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(430, 1600));
+  addTearDown(() async {
+    await tester.binding.setSurfaceSize(null);
+  });
+}
+
 class _DelayedReadLocalStateStore implements LocalStateStore {
   static const Duration _readDelay = Duration(milliseconds: 200);
 
@@ -144,6 +151,35 @@ void main() {
           'Controller status: Save the Trojan password before trying this profile.'),
       findsOneWidget,
     );
+  });
+
+  testWidgets('profiles page stays usable on compact width',
+      (WidgetTester tester) async {
+    await _setCompactSurface(tester);
+    final services = _buildServices();
+    final selected = services.profileStore.selectedProfile!;
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: selected.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      selected.copyWith(hasStoredPassword: true),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ProfilesPage(services: services)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Profiles'), findsOneWidget);
+    expect(find.text(selected.name), findsWidgets);
+    expect(find.text('Server'), findsOneWidget);
+    expect(find.text('${selected.serverHost}:${selected.serverPort}'),
+        findsWidgets);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('late cached snapshot does not overwrite live profile readiness',

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -177,6 +177,8 @@ void main() {
     expect(find.text('Profiles'), findsOneWidget);
     expect(find.text(selected.name), findsWidgets);
     expect(find.text('Server'), findsOneWidget);
+    expect(find.text('Runtime Posture'), findsOneWidget);
+    expect(find.text('Stub-only'), findsWidgets);
     expect(find.text('${selected.serverHost}:${selected.serverPort}'),
         findsWidgets);
     expect(tester.takeException(), isNull);

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -178,7 +178,9 @@ void main() {
     expect(find.text(selected.name), findsWidgets);
     expect(find.text('Server'), findsOneWidget);
     expect(find.text('Runtime Posture'), findsOneWidget);
+    expect(find.text('Evidence Grade'), findsOneWidget);
     expect(find.text('Stub-only'), findsWidgets);
+    expect(find.text('Shell-grade only'), findsWidgets);
     expect(find.text('${selected.serverHost}:${selected.serverPort}'),
         findsWidgets);
     expect(tester.takeException(), isNull);

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:trojan_pro_client/features/controller/application/fake_client_controller.dart';
+import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
 import 'package:trojan_pro_client/features/diagnostics/application/diagnostics_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_store.dart';
@@ -144,5 +145,36 @@ void main() {
       ),
       findsOneWidget,
     );
+  });
+
+  testWidgets('blocks connect action when readiness is blocked',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    final services = _buildServices();
+    final selected = services.profileStore.selectedProfile!;
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: selected.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      selected.copyWith(
+        hasStoredPassword: true,
+        serverHost: '',
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ProfilesPage(services: services)),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Connect'));
+    await tester.pump();
+
+    expect(services.controller.status.phase, ClientConnectionPhase.disconnected);
+    expect(find.textContaining('Connect blocked:'), findsOneWidget);
   });
 }

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:trojan_pro_client/features/controller/application/client_controller_api.dart';
@@ -13,8 +15,10 @@ import 'package:trojan_pro_client/features/profiles/application/profile_serializ
 import 'package:trojan_pro_client/features/profiles/application/profile_store.dart';
 import 'package:trojan_pro_client/features/profiles/presentation/profiles_page.dart';
 import 'package:trojan_pro_client/features/readiness/application/readiness_service.dart';
+import 'package:trojan_pro_client/features/readiness/domain/readiness_report.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_serialization.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_store.dart';
+import 'package:trojan_pro_client/platform/services/local_state_store.dart';
 import 'package:trojan_pro_client/platform/services/memory_diagnostics_file_exporter.dart';
 import 'package:trojan_pro_client/platform/services/memory_local_state_store.dart';
 import 'package:trojan_pro_client/platform/services/service_registry.dart';
@@ -25,6 +29,27 @@ Future<void> _setDesktopSurface(WidgetTester tester) async {
   addTearDown(() async {
     await tester.binding.setSurfaceSize(null);
   });
+}
+
+class _DelayedReadLocalStateStore implements LocalStateStore {
+  static const Duration _readDelay = Duration(milliseconds: 200);
+
+  final MemoryLocalStateStore _delegate = MemoryLocalStateStore();
+
+  @override
+  String get backendName => _delegate.backendName;
+
+  @override
+  Future<void> delete(String key) => _delegate.delete(key);
+
+  @override
+  Future<String?> read(String key) async {
+    await Future<void>.delayed(_readDelay);
+    return _delegate.read(key);
+  }
+
+  @override
+  Future<void> write(String key, String value) => _delegate.write(key, value);
 }
 
 class _UnavailableRuntimeController extends FakeClientController {
@@ -38,9 +63,11 @@ class _UnavailableRuntimeController extends FakeClientController {
   }
 }
 
-ClientServiceRegistry _buildServices(
-    {ClientControllerApi? controllerOverride}) {
-  final localState = MemoryLocalStateStore();
+ClientServiceRegistry _buildServices({
+  ClientControllerApi? controllerOverride,
+  LocalStateStore? localStateOverride,
+}) {
+  final localState = localStateOverride ?? MemoryLocalStateStore();
   final secureStorage = MemorySecureStorage();
   final diagnosticsExporter = MemoryDiagnosticsFileExporter();
   final profileStore = ProfileStore.withSampleProfiles(
@@ -66,6 +93,7 @@ ClientServiceRegistry _buildServices(
     profileSecrets: profileSecrets,
     secureStorage: secureStorage,
     controller: controller,
+    localStateStore: localState,
   );
   final diagnostics = DiagnosticsExportService(
     profileStore: profileStore,
@@ -116,6 +144,52 @@ void main() {
           'Controller status: Save the Trojan password before trying this profile.'),
       findsOneWidget,
     );
+  });
+
+  testWidgets('late cached snapshot does not overwrite live profile readiness',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    final localState = _DelayedReadLocalStateStore();
+    final services = _buildServices(localStateOverride: localState);
+    final selected = services.profileStore.selectedProfile!;
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: selected.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      selected.copyWith(hasStoredPassword: true),
+    );
+    await localState.write(
+      'client.readiness.last-known.${selected.id}',
+      jsonEncode(
+        ReadinessReport.fromChecks(
+          const <ReadinessCheck>[
+            ReadinessCheck(
+              domain: ReadinessDomain.config,
+              level: ReadinessLevel.blocked,
+              summary: 'stale invalid config snapshot',
+              detail: 'stale snapshot should not override live readiness',
+              action: ReadinessAction.openProfiles,
+              actionLabel: 'Open Profiles',
+            ),
+          ],
+          generatedAt: DateTime.now().subtract(const Duration(minutes: 10)),
+        ).toJson(),
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ProfilesPage(services: services)),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Readiness: Ready with warnings'), findsOneWidget);
+    expect(find.textContaining('Readiness source: Live check'), findsOneWidget);
+    expect(find.text('Readiness: Blocked'), findsNothing);
   });
 
   testWidgets('disables connect on another profile while one is connected',

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -6,6 +6,7 @@ import 'package:trojan_pro_client/features/controller/application/client_control
 import 'package:trojan_pro_client/features/controller/application/fake_client_controller.dart';
 import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
 import 'package:trojan_pro_client/features/controller/domain/controller_runtime_health.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
 import 'package:trojan_pro_client/features/diagnostics/application/diagnostics_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_store.dart';
@@ -68,6 +69,28 @@ class _UnavailableRuntimeController extends FakeClientController {
       updatedAt: DateTime.parse('2026-03-20T00:00:00.000Z'),
     );
   }
+}
+
+class _StaleConnectedController extends FakeClientController {
+  ClientConnectionStatus statusOverride = ClientConnectionStatus(
+    phase: ClientConnectionPhase.connected,
+    message: 'Runtime session is ready.',
+    updatedAt: DateTime.parse('2026-03-20T00:00:00.000Z'),
+    activeProfileId: 'sample-hk-1',
+  );
+
+  ControllerRuntimeSession sessionOverride = ControllerRuntimeSession(
+    isRunning: true,
+    updatedAt: DateTime.now().subtract(const Duration(minutes: 3)),
+    phase: ControllerRuntimePhase.sessionReady,
+    expectedLocalSocksPort: 10808,
+  );
+
+  @override
+  ClientConnectionStatus get status => statusOverride;
+
+  @override
+  ControllerRuntimeSession get session => sessionOverride;
 }
 
 ClientServiceRegistry _buildServices({
@@ -398,6 +421,137 @@ void main() {
 
     await tester
         .tap(find.widgetWithText(OutlinedButton, 'Open Troubleshooting'));
+    await tester.pump();
+
+    expect(openedAdvanced, isTrue);
+  });
+
+  testWidgets('stale connected profile steers primary CTA to troubleshooting',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    var openedAdvanced = false;
+    final services = _buildServices(
+      controllerOverride: _StaleConnectedController(),
+    );
+    final selected = services.profileStore.selectedProfile!;
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: selected.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      selected.copyWith(hasStoredPassword: true),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ProfilesPage(
+            services: services,
+            onOpenAdvanced: (_) => openedAdvanced = true,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Action safety'), findsOneWidget);
+    expect(find.text('Revalidate before changing state'), findsOneWidget);
+    expect(find.text('Revalidate in Troubleshooting'), findsOneWidget);
+    expect(find.textContaining('Open Troubleshooting to revalidate the runtime'),
+        findsOneWidget);
+    expect(find.textContaining('disconnect and reconnect'), findsOneWidget);
+
+    await tester.tap(find.text('Revalidate in Troubleshooting'));
+    await tester.pump();
+
+    expect(openedAdvanced, isTrue);
+  });
+
+  testWidgets('connect feedback stays truthful on stub posture',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    final services = _buildServices();
+    final selected = services.profileStore.selectedProfile!;
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: selected.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      selected.copyWith(hasStoredPassword: true),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ProfilesPage(services: services)),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Connect (stub path)'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1200));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Shell validation is ready'), findsOneWidget);
+  });
+
+  testWidgets('disconnecting stop-pending profile gates primary action to troubleshooting',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    var openedAdvanced = false;
+    final services = _buildServices(
+      controllerOverride: _StaleConnectedController(),
+    );
+    final selected = services.profileStore.selectedProfile!;
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: selected.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      selected.copyWith(hasStoredPassword: true),
+    );
+
+    final controller = services.controller as _StaleConnectedController;
+    controller.statusOverride = ClientConnectionStatus(
+      phase: ClientConnectionPhase.disconnecting,
+      message: 'Disconnecting current session...',
+      updatedAt: DateTime.now(),
+      activeProfileId: 'sample-hk-1',
+    );
+    controller.sessionOverride = ControllerRuntimeSession(
+      isRunning: true,
+      updatedAt: DateTime.now().subtract(const Duration(seconds: 10)),
+      phase: ControllerRuntimePhase.alive,
+      stopRequested: true,
+      stopRequestedAt: DateTime.now().subtract(const Duration(seconds: 5)),
+      expectedLocalSocksPort: 10808,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ProfilesPage(
+            services: services,
+            onOpenAdvanced: (_) => openedAdvanced = true,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Action safety'), findsOneWidget);
+    expect(find.text('Wait for exit confirmation'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Open Troubleshooting'), findsOneWidget);
+    expect(find.textContaining('Primary state-changing action is temporarily withheld'),
+        findsNothing);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Open Troubleshooting'));
     await tester.pump();
 
     expect(openedAdvanced, isTrue);

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/application/client_controller_api.dart';
 import 'package:trojan_pro_client/features/controller/application/fake_client_controller.dart';
 import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_health.dart';
 import 'package:trojan_pro_client/features/diagnostics/application/diagnostics_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_store.dart';
@@ -25,7 +27,19 @@ Future<void> _setDesktopSurface(WidgetTester tester) async {
   });
 }
 
-ClientServiceRegistry _buildServices() {
+class _UnavailableRuntimeController extends FakeClientController {
+  @override
+  Future<ControllerRuntimeHealth> checkHealth() async {
+    return ControllerRuntimeHealth(
+      level: ControllerRuntimeHealthLevel.unavailable,
+      summary: 'runtime binary missing for this test',
+      updatedAt: DateTime.parse('2026-03-20T00:00:00.000Z'),
+    );
+  }
+}
+
+ClientServiceRegistry _buildServices(
+    {ClientControllerApi? controllerOverride}) {
   final localState = MemoryLocalStateStore();
   final secureStorage = MemorySecureStorage();
   final diagnosticsExporter = MemoryDiagnosticsFileExporter();
@@ -41,7 +55,7 @@ ClientServiceRegistry _buildServices() {
     localStateStore: localState,
     serialization: SettingsSerialization(),
   );
-  final controller = FakeClientController();
+  final controller = controllerOverride ?? FakeClientController();
 
   final packagingExport = PackagingExportService(
     packagingStore: packagingStore,
@@ -175,13 +189,99 @@ void main() {
     expect(find.text('Readiness: Blocked'), findsOneWidget);
     expect(
       find.textContaining('Check server host / server port / local SOCKS port'),
-      findsOneWidget,
+      findsWidgets,
     );
 
-    await tester.tap(find.widgetWithText(FilledButton, 'Connect'));
+    final blockedButton = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'Connect Blocked'),
+    );
+    expect(blockedButton.onPressed, isNull);
+
+    expect(
+        services.controller.status.phase, ClientConnectionPhase.disconnected);
+    expect(find.textContaining('Recommended next step: Open Profiles'),
+        findsOneWidget);
+  });
+
+  testWidgets(
+      'readiness notice refreshes when selected profile changes in place',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    final services = _buildServices();
+    final selected = services.profileStore.selectedProfile!;
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: selected.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      selected.copyWith(
+        hasStoredPassword: true,
+        serverHost: '',
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ProfilesPage(services: services)),
+      ),
+    );
+    await tester.pump();
     await tester.pump();
 
-    expect(services.controller.status.phase, ClientConnectionPhase.disconnected);
-    expect(find.textContaining('Connect blocked:'), findsOneWidget);
+    expect(find.text('Readiness: Blocked'), findsOneWidget);
+
+    final refreshed = services.profileStore.selectedProfile!.copyWith(
+      serverHost: 'hk-edge.example.com',
+      hasStoredPassword: true,
+      updatedAt: DateTime.now().add(const Duration(seconds: 1)),
+    );
+    services.profileStore.upsertProfile(refreshed);
+
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Readiness: Ready with warnings'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Connect'), findsOneWidget);
+  });
+
+  testWidgets('readiness recommendation button can route to troubleshooting',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    final services = _buildServices(
+      controllerOverride: _UnavailableRuntimeController(),
+    );
+    final selected = services.profileStore.selectedProfile!;
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: selected.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      selected.copyWith(hasStoredPassword: true),
+    );
+
+    var openedAdvanced = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ProfilesPage(
+            services: services,
+            onOpenAdvanced: (_) => openedAdvanced = true,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.textContaining('Recommended next step: Open Troubleshooting'),
+        findsOneWidget);
+
+    await tester
+        .tap(find.widgetWithText(OutlinedButton, 'Open Troubleshooting'));
+    await tester.pump();
+
+    expect(openedAdvanced, isTrue);
   });
 }

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -9,6 +9,7 @@ import 'package:trojan_pro_client/features/profiles/application/profile_secrets_
 import 'package:trojan_pro_client/features/profiles/application/profile_serialization.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_store.dart';
 import 'package:trojan_pro_client/features/profiles/presentation/profiles_page.dart';
+import 'package:trojan_pro_client/features/readiness/application/readiness_service.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_serialization.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_store.dart';
 import 'package:trojan_pro_client/platform/services/memory_diagnostics_file_exporter.dart';
@@ -45,6 +46,12 @@ ClientServiceRegistry _buildServices() {
     packagingStore: packagingStore,
     fileExporter: diagnosticsExporter,
   );
+  final readiness = ReadinessService(
+    profileStore: profileStore,
+    profileSecrets: profileSecrets,
+    secureStorage: secureStorage,
+    controller: controller,
+  );
   final diagnostics = DiagnosticsExportService(
     profileStore: profileStore,
     profilePortability: profilePortability,
@@ -53,6 +60,7 @@ ClientServiceRegistry _buildServices() {
     controller: controller,
     secureStorage: secureStorage,
     fileExporter: diagnosticsExporter,
+    readiness: readiness,
   );
 
   return ClientServiceRegistry(
@@ -66,6 +74,7 @@ ClientServiceRegistry _buildServices() {
     packagingExport: packagingExport,
     settingsStore: settingsStore,
     controller: controller,
+    readiness: readiness,
     diagnostics: diagnostics,
   );
 }

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -170,6 +170,13 @@ void main() {
       ),
     );
     await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Readiness: Blocked'), findsOneWidget);
+    expect(
+      find.textContaining('Check server host / server port / local SOCKS port'),
+      findsOneWidget,
+    );
 
     await tester.tap(find.widgetWithText(FilledButton, 'Connect'));
     await tester.pump();

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -187,6 +187,7 @@ void main() {
     await tester.pump();
 
     expect(find.text('Readiness: Blocked'), findsOneWidget);
+    expect(find.textContaining('Readiness source:'), findsOneWidget);
     expect(
       find.textContaining('Check server host / server port / local SOCKS port'),
       findsWidgets,

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -355,7 +355,10 @@ void main() {
     await tester.pump();
 
     expect(find.text('Readiness: Ready with warnings'), findsOneWidget);
-    expect(find.widgetWithText(FilledButton, 'Connect'), findsOneWidget);
+    expect(
+      find.widgetWithText(FilledButton, 'Connect (stub path)'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('readiness recommendation button can route to troubleshooting',

--- a/client/test/features/readiness/application/readiness_service_test.dart
+++ b/client/test/features/readiness/application/readiness_service_test.dart
@@ -142,4 +142,33 @@ void main() {
     expect(report.recommendation, isNotNull);
     expect(report.recommendation!.detail, 'secure storage fallback');
   });
+
+  test('readiness persists and restores last-known snapshot', () async {
+    final localState = MemoryLocalStateStore();
+    final profileStore = ProfileStore.withSampleProfiles(
+      localStateStore: localState,
+      serialization: ProfileSerialization(),
+    );
+    final secureStorage = MemorySecureStorage();
+    final profile = profileStore.selectedProfile!;
+    final profileSecrets = ProfileSecretsService(secureStorage: secureStorage);
+    await profileSecrets.saveTrojanPassword(profileId: profile.id, password: 'pw');
+    profileStore.upsertProfile(profile.copyWith(hasStoredPassword: true));
+
+    final readiness = ReadinessService(
+      profileStore: profileStore,
+      profileSecrets: profileSecrets,
+      secureStorage: secureStorage,
+      controller: FakeClientController(),
+      localStateStore: localState,
+    );
+
+    final built = await readiness.buildReport();
+    final restored = await readiness.readLastKnownReport();
+
+    expect(restored, isNotNull);
+    expect(restored!.overallLevel, built.overallLevel);
+    expect(restored.summary, built.summary);
+    expect(restored.recommendation?.action, built.recommendation?.action);
+  });
 }

--- a/client/test/features/readiness/application/readiness_service_test.dart
+++ b/client/test/features/readiness/application/readiness_service_test.dart
@@ -30,8 +30,9 @@ void main() {
     expect(report.overallLevel, ReadinessLevel.blocked);
     expect(report.headline, 'Connect blocked');
     expect(
-      report.checks.any(
-          (check) => check.domain == ReadinessDomain.profile && check.level == ReadinessLevel.blocked),
+      report.checks.any((check) =>
+          check.domain == ReadinessDomain.profile &&
+          check.level == ReadinessLevel.blocked),
       isTrue,
     );
   });
@@ -56,8 +57,9 @@ void main() {
 
     expect(report.overallLevel, ReadinessLevel.blocked);
     expect(
-      report.checks.any(
-          (check) => check.domain == ReadinessDomain.password && check.level == ReadinessLevel.blocked),
+      report.checks.any((check) =>
+          check.domain == ReadinessDomain.password &&
+          check.level == ReadinessLevel.blocked),
       isTrue,
     );
   });
@@ -72,7 +74,8 @@ void main() {
     final secureStorage = MemorySecureStorage();
     final profile = profileStore.selectedProfile!;
     final profileSecrets = ProfileSecretsService(secureStorage: secureStorage);
-    await profileSecrets.saveTrojanPassword(profileId: profile.id, password: 'pw');
+    await profileSecrets.saveTrojanPassword(
+        profileId: profile.id, password: 'pw');
     profileStore.upsertProfile(profile.copyWith(hasStoredPassword: true));
 
     final readiness = ReadinessService(
@@ -152,7 +155,8 @@ void main() {
     final secureStorage = MemorySecureStorage();
     final profile = profileStore.selectedProfile!;
     final profileSecrets = ProfileSecretsService(secureStorage: secureStorage);
-    await profileSecrets.saveTrojanPassword(profileId: profile.id, password: 'pw');
+    await profileSecrets.saveTrojanPassword(
+        profileId: profile.id, password: 'pw');
     profileStore.upsertProfile(profile.copyWith(hasStoredPassword: true));
 
     final readiness = ReadinessService(
@@ -167,8 +171,11 @@ void main() {
     final restored = await readiness.readLastKnownReport();
 
     expect(restored, isNotNull);
-    expect(restored!.overallLevel, built.overallLevel);
+    expect(built.isCachedSnapshot, isFalse);
+    expect(restored!.isCachedSnapshot, isTrue);
+    expect(restored.overallLevel, built.overallLevel);
     expect(restored.summary, built.summary);
     expect(restored.recommendation?.action, built.recommendation?.action);
+    expect(restored.sourceLabel, 'Cached snapshot');
   });
 }

--- a/client/test/features/readiness/application/readiness_service_test.dart
+++ b/client/test/features/readiness/application/readiness_service_test.dart
@@ -91,5 +91,7 @@ void main() {
           check.level == ReadinessLevel.degraded),
       isTrue,
     );
+    expect(report.recommendation, isNotNull);
+    expect(report.recommendation!.action, ReadinessAction.openTroubleshooting);
   });
 }

--- a/client/test/features/readiness/application/readiness_service_test.dart
+++ b/client/test/features/readiness/application/readiness_service_test.dart
@@ -94,4 +94,52 @@ void main() {
     expect(report.recommendation, isNotNull);
     expect(report.recommendation!.action, ReadinessAction.openTroubleshooting);
   });
+
+  test('recommendation prefers blocked fixes over degraded warnings', () {
+    final report = ReadinessReport.fromChecks(
+      const <ReadinessCheck>[
+        ReadinessCheck(
+          domain: ReadinessDomain.secureStorage,
+          level: ReadinessLevel.degraded,
+          summary: 'secure storage fallback',
+          action: ReadinessAction.openTroubleshooting,
+          actionLabel: 'Open Troubleshooting',
+        ),
+        ReadinessCheck(
+          domain: ReadinessDomain.password,
+          level: ReadinessLevel.blocked,
+          summary: 'password missing',
+          action: ReadinessAction.openProfiles,
+          actionLabel: 'Open Profiles',
+        ),
+      ],
+    );
+
+    expect(report.recommendation, isNotNull);
+    expect(report.recommendation!.action, ReadinessAction.openProfiles);
+  });
+
+  test('recommendation ordering stays stable across degraded domains', () {
+    final report = ReadinessReport.fromChecks(
+      const <ReadinessCheck>[
+        ReadinessCheck(
+          domain: ReadinessDomain.runtimePath,
+          level: ReadinessLevel.degraded,
+          summary: 'stub runtime path',
+          action: ReadinessAction.openTroubleshooting,
+          actionLabel: 'Open Troubleshooting',
+        ),
+        ReadinessCheck(
+          domain: ReadinessDomain.secureStorage,
+          level: ReadinessLevel.degraded,
+          summary: 'secure storage fallback',
+          action: ReadinessAction.openTroubleshooting,
+          actionLabel: 'Open Troubleshooting',
+        ),
+      ],
+    );
+
+    expect(report.recommendation, isNotNull);
+    expect(report.recommendation!.detail, 'secure storage fallback');
+  });
 }

--- a/client/test/features/readiness/application/readiness_service_test.dart
+++ b/client/test/features/readiness/application/readiness_service_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/application/fake_client_controller.dart';
+import 'package:trojan_pro_client/features/readiness/application/readiness_service.dart';
+import 'package:trojan_pro_client/features/readiness/domain/readiness_report.dart';
+import 'package:trojan_pro_client/features/profiles/application/profile_secrets_service.dart';
+import 'package:trojan_pro_client/features/profiles/application/profile_serialization.dart';
+import 'package:trojan_pro_client/features/profiles/application/profile_store.dart';
+import 'package:trojan_pro_client/platform/secure_storage/memory_secure_storage.dart';
+import 'package:trojan_pro_client/platform/services/memory_local_state_store.dart';
+
+void main() {
+  test('readiness blocks when no profile selected', () async {
+    final localState = MemoryLocalStateStore();
+    final profileStore = ProfileStore(
+      initialProfiles: const [],
+      localStateStore: localState,
+      serialization: ProfileSerialization(),
+    );
+    final secureStorage = MemorySecureStorage();
+
+    final readiness = ReadinessService(
+      profileStore: profileStore,
+      profileSecrets: ProfileSecretsService(secureStorage: secureStorage),
+      secureStorage: secureStorage,
+      controller: FakeClientController(),
+    );
+
+    final report = await readiness.buildReport();
+
+    expect(report.overallLevel, ReadinessLevel.blocked);
+    expect(report.headline, 'Connect blocked');
+    expect(
+      report.checks.any(
+          (check) => check.domain == ReadinessDomain.profile && check.level == ReadinessLevel.blocked),
+      isTrue,
+    );
+  });
+
+  test('readiness blocks when password is missing for selected profile',
+      () async {
+    final localState = MemoryLocalStateStore();
+    final profileStore = ProfileStore.withSampleProfiles(
+      localStateStore: localState,
+      serialization: ProfileSerialization(),
+    );
+
+    final secureStorage = MemorySecureStorage();
+    final readiness = ReadinessService(
+      profileStore: profileStore,
+      profileSecrets: ProfileSecretsService(secureStorage: secureStorage),
+      secureStorage: secureStorage,
+      controller: FakeClientController(),
+    );
+
+    final report = await readiness.buildReport();
+
+    expect(report.overallLevel, ReadinessLevel.blocked);
+    expect(
+      report.checks.any(
+          (check) => check.domain == ReadinessDomain.password && check.level == ReadinessLevel.blocked),
+      isTrue,
+    );
+  });
+
+  test('readiness is degraded when secure storage is session-only', () async {
+    final localState = MemoryLocalStateStore();
+    final profileStore = ProfileStore.withSampleProfiles(
+      localStateStore: localState,
+      serialization: ProfileSerialization(),
+    );
+
+    final secureStorage = MemorySecureStorage();
+    final profile = profileStore.selectedProfile!;
+    final profileSecrets = ProfileSecretsService(secureStorage: secureStorage);
+    await profileSecrets.saveTrojanPassword(profileId: profile.id, password: 'pw');
+    profileStore.upsertProfile(profile.copyWith(hasStoredPassword: true));
+
+    final readiness = ReadinessService(
+      profileStore: profileStore,
+      profileSecrets: profileSecrets,
+      secureStorage: secureStorage,
+      controller: FakeClientController(),
+    );
+
+    final report = await readiness.buildReport();
+
+    expect(report.overallLevel, ReadinessLevel.degraded);
+    expect(
+      report.checks.any((check) =>
+          check.domain == ReadinessDomain.secureStorage &&
+          check.level == ReadinessLevel.degraded),
+      isTrue,
+    );
+  });
+}

--- a/client/test/features/settings/presentation/settings_page_test.dart
+++ b/client/test/features/settings/presentation/settings_page_test.dart
@@ -8,6 +8,7 @@ import 'package:trojan_pro_client/features/profiles/application/profile_portabil
 import 'package:trojan_pro_client/features/profiles/application/profile_secrets_service.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_serialization.dart';
 import 'package:trojan_pro_client/features/profiles/application/profile_store.dart';
+import 'package:trojan_pro_client/features/readiness/application/readiness_service.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_serialization.dart';
 import 'package:trojan_pro_client/features/settings/application/settings_store.dart';
 import 'package:trojan_pro_client/features/settings/presentation/settings_page.dart';
@@ -46,6 +47,12 @@ ClientServiceRegistry _buildServices() {
     packagingStore: packagingStore,
     fileExporter: diagnosticsExporter,
   );
+  final readiness = ReadinessService(
+    profileStore: profileStore,
+    profileSecrets: profileSecrets,
+    secureStorage: secureStorage,
+    controller: controller,
+  );
   final diagnostics = DiagnosticsExportService(
     profileStore: profileStore,
     profilePortability: profilePortability,
@@ -54,6 +61,7 @@ ClientServiceRegistry _buildServices() {
     controller: controller,
     secureStorage: secureStorage,
     fileExporter: diagnosticsExporter,
+    readiness: readiness,
   );
 
   return ClientServiceRegistry(
@@ -67,6 +75,7 @@ ClientServiceRegistry _buildServices() {
     packagingExport: packagingExport,
     settingsStore: settingsStore,
     controller: controller,
+    readiness: readiness,
     diagnostics: diagnostics,
     desktopLifecycle: NoopDesktopLifecycleService(),
   );

--- a/client/test/features/settings/presentation/settings_page_test.dart
+++ b/client/test/features/settings/presentation/settings_page_test.dart
@@ -25,6 +25,13 @@ Future<void> _setDesktopSurface(WidgetTester tester) async {
   });
 }
 
+Future<void> _setCompactSurface(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(430, 1400));
+  addTearDown(() async {
+    await tester.binding.setSurfaceSize(null);
+  });
+}
+
 ClientServiceRegistry _buildServices() {
   final localState = MemoryLocalStateStore();
   final secureStorage = MemorySecureStorage();
@@ -82,6 +89,26 @@ ClientServiceRegistry _buildServices() {
 }
 
 void main() {
+  testWidgets('settings page stays usable on compact width',
+      (WidgetTester tester) async {
+    await _setCompactSurface(tester);
+    final services = _buildServices();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SettingsPage(services: services),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Settings'), findsOneWidget);
+    expect(find.text('Diagnostics retention (days)'), findsOneWidget);
+    expect(find.text('Window close behavior'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('shows desktop lifecycle semantics section',
       (WidgetTester tester) async {
     await _setDesktopSurface(tester);
@@ -113,7 +140,8 @@ void main() {
     expect(find.textContaining('External activation:'), findsOneWidget);
   });
 
-  testWidgets('shows external activation summary after focus handoff is recorded',
+  testWidgets(
+      'shows external activation summary after focus handoff is recorded',
       (WidgetTester tester) async {
     await _setDesktopSurface(tester);
     final services = _buildServices();

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,15 @@ This directory only keeps the current, useful project documentation.
 - `v1.3.0-beta-handoff-notes-2026-03-16.md` — current handoff posture and tester-facing caveats for the desktop beta candidate
 - `v1.3.0-staging-release-checklist-2026-03-16.md` — current staging/commit/release checklist for the desktop beta candidate
 - `v1.3.0-linux-runtime-smoke-report-2026-03-16.md` — latest Linux runtime smoke result and blocker note
+- `v1.4.0-product-direction.md` — recommended product direction for the runtime-true desktop client milestone
+- `v1.4.0-backlog.md` — backlog for the runtime-true desktop client milestone
+- `v1.4.0-sprint-1-plan.md` — execution plan for the first real-runtime-path sprint
+- `v1.4.0-sprint-2-plan.md` — execution plan for the readiness doctor sprint
+- `v1.4.0-sprint-3-plan.md` — execution plan for the runtime truth & recovery sprint
+- `v1.4.0-sprint-4-plan.md` — execution plan for the runtime-aware supportability sprint
+- `v1.4.0-sprint-5-plan.md` — execution plan for the release truth & beta validation sprint
+- `v1.4.0-roadmap.md` — milestone sequence for the runtime-true desktop client line
+- `v1.4.0-release-gates.md` — completion and release gates for the v1.4.0 milestone
 - `../CHANGELOG.md` — versioned release history
 
 ## Decisions

--- a/docs/client-runtime-smoke-test.md
+++ b/docs/client-runtime-smoke-test.md
@@ -20,7 +20,10 @@ This test is designed to answer one question only:
 Optional environment variables:
 
 ```bash
-export TROJAN_CLIENT_ENABLE_REAL_ADAPTER=1
+# v1.4.0 first cut: backend mode defaults to auto on desktop.
+# You can still force modes explicitly when validating behavior.
+export TROJAN_CLIENT_BACKEND_MODE=real   # or stub
+export TROJAN_CLIENT_ENABLE_REAL_ADAPTER=1  # legacy compatibility path
 export TROJAN_CLIENT_BINARY=/absolute/path/to/trojan
 export KEEP_SMOKE_ARTIFACTS=1
 ```
@@ -92,7 +95,8 @@ Check Dashboard / Profile details:
 - runtime session block
 
 Expected:
-- runtime mode is `external-runtime-boundary` when env flag is enabled
+- runtime mode is `real-runtime-boundary` when real adapter is selected
+- fallback/degraded cases use explicit `stubbed-local-boundary-*` modes (not silently pretending to be real)
 - health is not permanently `unavailable`
 
 ---
@@ -123,7 +127,7 @@ Expected:
 - process terminates
 - PID clears
 - config file is cleaned up
-- status summary reflects disconnect request/result
+- status summary reflects disconnect request/result truthfully (`stop requested` while pending, `disconnected` after exit)
 
 ---
 
@@ -186,3 +190,11 @@ If the smoke test fails, capture:
 - stdout tail
 - stderr tail
 - exported diagnostics bundle path
+
+---
+
+## Current limitations (Sprint 1)
+
+- In headless environments without `DISPLAY`/`WAYLAND_DISPLAY` and without `xvfb-run`, GUI launch smoke is expected to be reported as **skipped**.
+- `sessionReady` currently depends on local SOCKS port observability; some environments may stay in `alive` longer even when process startup succeeded.
+- The smoke script proves a high-signal local runtime path, but it is not yet a substitute for real staging beta validation on operator-like desktop environments.

--- a/docs/v1.4.0-backlog.md
+++ b/docs/v1.4.0-backlog.md
@@ -1,0 +1,178 @@
+# v1.4.0 Backlog — Runtime-True Desktop Client
+
+## Goal
+
+Make the desktop client trustworthy about **real runtime reality** instead of stopping at polished shell behavior.
+
+This milestone should turn the current desktop beta into a product that can:
+
+- run a real runtime path,
+- tell the truth about readiness / degraded state / simulated state,
+- recover from real execution failures,
+- export support evidence that matches actual runtime behavior,
+- ship with release metadata that does not contradict what the user downloaded.
+
+---
+
+## Scope guardrails
+
+### In scope
+- real shell adapter execution path
+- runtime readiness / doctor surface
+- stronger runtime truthfulness in the UI
+- real execution recovery and stale-session handling
+- runtime-aware support bundle improvements
+- release-truth hygiene directly tied to the shipped client
+
+### Explicitly out of scope
+- mobile-first UX expansion
+- broad public onboarding / marketing layer
+- updater implementation beyond current boundary
+- new protocol families / protocol zoo work
+- major trusted-front/public-edge expansion as the milestone theme
+- code-signing/notarization as the main milestone objective
+
+---
+
+## Epic A — Real Runtime Path
+
+### Objective
+Move from a product shell with adapter seams to a desktop client that can drive a **real runtime execution path** predictably.
+
+### Candidate work
+- [ ] promote real shell adapter from planning seam to default execution path on supported desktop targets
+- [ ] make connect/disconnect drive a real managed process lifecycle
+- [ ] persist and surface runtime process/session identity clearly
+- [ ] distinguish “launch planned”, “launch attempted”, “runtime alive”, and “session healthy”
+- [ ] expose real config render/write path and cleanup path explicitly in diagnostics/support surfaces
+- [ ] keep fake/stub adapter available only as explicit test/degraded mode
+
+### Exit criteria
+- desktop app can drive a real runtime path end-to-end on at least Linux
+- product surfaces clearly indicate when runtime is real vs simulated
+- stopping/cleanup behavior is deterministic enough for repeated beta use
+
+---
+
+## Epic B — Runtime Readiness Doctor
+
+### Objective
+Tell the user whether the app is ready, degraded, or blocked **before** a blind connect attempt.
+
+### Candidate work
+- [ ] binary presence and version check
+- [ ] config destination writeability check
+- [ ] secure storage readiness check
+- [ ] executable/runtime dependency readiness summary where practical
+- [ ] explicit blocked/degraded/ready state model
+- [ ] connect-preflight card / doctor page in product UI
+- [ ] diagnostics export inclusion for doctor summary
+
+### Exit criteria
+- user can explain why connect is blocked or degraded without reading logs
+- support bundle captures readiness evidence consistently
+
+---
+
+## Epic C — Runtime Truthfulness & Recovery
+
+### Objective
+Ensure runtime UI state tracks actual execution truth rather than only app-local state.
+
+### Candidate work
+- [ ] enrich runtime phase model (`planned`, `launching`, `alive`, `session-ready`, `degraded`, `failed`, `stale`)
+- [ ] show backend identity (`real adapter`, `stub adapter`, `degraded backend`) in product surfaces
+- [ ] improve stale-session and residue cleanup when UI and process diverge
+- [ ] add restart/reconnect-safe stop semantics for the real execution path
+- [ ] improve “what changed since last failure” and “why retry might work now” guidance
+- [ ] add targeted regression tests for state divergence and recovery paths
+
+### Exit criteria
+- user is not left guessing whether the runtime is truly running
+- stale or half-dead states are explicit and recoverable
+
+---
+
+## Epic D — Runtime-Aware Supportability
+
+### Objective
+Make support bundles useful for real launch/runtime failures, not just shell-state failures.
+
+### Candidate work
+- [ ] include runtime launch metadata in support bundle where safe
+- [ ] include executable path / version / launch plan evidence
+- [ ] include backend identity and session evidence in Advanced / support views
+- [ ] classify launch failures vs config failures vs environment failures vs connect failures
+- [ ] improve runtime log/session readability for real execution path
+- [ ] add export regression tests for runtime-aware support payloads
+
+### Exit criteria
+- support bundle from a failed real launch contains enough evidence to classify the failure family
+- support surfaces stay honest about what is known vs inferred
+
+---
+
+## Epic E — Release Truth Hygiene
+
+### Objective
+Make release metadata, shipped asset names, and product-visible version/channel tell the same story.
+
+### Candidate work
+- [ ] align client package version naming with release tag/version metadata
+- [ ] align product-visible version string with shipped release metadata
+- [ ] document version/source-of-truth rules for client packaging
+- [ ] prevent future client/core version drift in release validation
+- [ ] extend release checklist with version-truth validation
+
+### Exit criteria
+- release tag, release page, asset names, and product-visible version are no longer inconsistent
+
+---
+
+## Epic F — Runtime-True Beta Validation
+
+### Objective
+Raise confidence with validation that reflects real execution paths.
+
+### Candidate work
+- [ ] add one higher-signal packaged runtime smoke for the real execution path
+- [ ] define which runtime validations are hard blockers vs best-effort signals
+- [ ] document environment-dependent validation gaps explicitly
+- [ ] capture real-runtime beta handoff notes and known limitations template updates
+- [ ] tighten CI/reporting around runtime truth instead of pure artifact presence
+
+### Exit criteria
+- beta release decisions rely on runtime-truth evidence, not only build success
+- CI/release output makes hard blockers vs advisory warnings explicit
+
+---
+
+## Suggested delivery order
+
+1. **Epic A — Real Runtime Path**
+2. **Epic B — Runtime Readiness Doctor**
+3. **Epic C — Runtime Truthfulness & Recovery**
+4. **Epic D — Runtime-Aware Supportability**
+5. **Epic E — Release Truth Hygiene**
+6. **Epic F — Runtime-True Beta Validation**
+
+### Why this order
+
+- without a real runtime path, later truth/recovery/support work stays partially synthetic
+- readiness doctor reduces wasted failure loops before we polish support UX around them
+- release hygiene matters, but it should lock in truth after the product behavior is real enough
+
+---
+
+## Milestone exit verdict
+
+`v1.4.0` should be considered complete only when:
+
+- the desktop client can execute a real runtime path on supported desktop platforms,
+- readiness blockers are visible before connect,
+- runtime state is honest about real vs simulated vs degraded execution,
+- failure recovery paths feel intentional,
+- support bundle includes real runtime evidence,
+- release version truth is no longer visibly inconsistent.
+
+If those are not true, the milestone is not done — even if the app looks polished.

--- a/docs/v1.4.0-product-direction.md
+++ b/docs/v1.4.0-product-direction.md
@@ -1,0 +1,357 @@
+# v1.4.0 Product Direction — Runtime-True Desktop Client
+
+## Goal
+
+Make the desktop client feel less like a polished shell and more like a **trustworthy daily-use control surface for a real Trojan runtime**.
+
+`v1.3.0-beta.3` proved three important things:
+
+1. desktop lifecycle / diagnostics / supportability / packaging can already be productized,
+2. the desktop shell is now credible enough to hand to testers,
+3. the next highest-value gap is no longer tray polish or release plumbing — it is **runtime truthfulness**.
+
+So the recommended `v1.4.0` product direction is:
+
+> **turn the desktop beta into a runtime-true desktop client**
+
+That means the app should not only look like a product; it should tell the truth about what runtime is actually happening, what failed, what can be recovered, and whether the app is using a real or simulated execution path.
+
+---
+
+## Why this is the right next move
+
+Current project memory already points in this direction:
+
+- the client line was launched as **desktop-first / mobile-ready**, with Flutter + local controller boundary as the stable architecture choice,
+- the current client is already a **desktop-first product skeleton** with state, secure storage, diagnostics, packaging, and controller seams,
+- the remaining hard blockers have been identified as **Flutter runtime validation** and the **real shell adapter execution path**.
+
+That makes `v1.4.0` much clearer than a generic “more polish” milestone.
+
+### In blunt terms
+
+`v1.3.0` answered:
+- can this feel like a product?
+- can we package and prerelease it?
+- can a tester understand lifecycle + diagnostics?
+
+`v1.4.0` should answer:
+- can a user **really run** the thing through the desktop client?
+- can they **trust what the UI says** about runtime state?
+- can they **recover** without guesswork when reality diverges from the happy path?
+
+---
+
+## Recommended product thesis
+
+### Product thesis
+
+The Trojan desktop client should become a **safe operator surface** for the stable Trojan/TCP/TLS backend.
+
+### Success feeling
+
+A technically capable user should be able to:
+
+1. add or import a profile,
+2. pass a preflight check,
+3. connect through the **real runtime path**,
+4. see accurate lifecycle / health / failure state,
+5. recover or retry with understandable guidance,
+6. export useful evidence when something breaks,
+7. know whether the app is using a **real backend**, a degraded mode, or a simulated path.
+
+If those things are true, `v1.4.0` has real product value.
+
+---
+
+## Candidate directions considered
+
+## Option A — Public-beta onboarding first
+
+Examples:
+- first-run walkthrough
+- profile import wizard polish
+- friendlier marketing-style UX
+- broader external distribution posture
+
+### Why not now
+
+This would improve the first impression, but it would still sit on top of a runtime path that is not trustworthy enough yet. That is lipstick on a moving transport seam.
+
+---
+
+## Option B — Mobile-first expansion
+
+Examples:
+- Android/iOS UI work
+- mobile onboarding
+- mobile profile flow adaptation
+
+### Why not now
+
+The architecture is mobile-ready by design, but the desktop runtime story is not mature enough to clone into a second product surface yet. This would create two half-products.
+
+---
+
+## Option C — Updater / distribution / signing hardening first
+
+Examples:
+- self-update implementation
+- signing/notarization hardening
+- broader packaging refinement
+
+### Why not now
+
+Important, yes — but distribution quality matters more once the runtime loop itself is trustworthy. Otherwise we would distribute a polished shell whose most important behavior is still partially simulated or opaque.
+
+---
+
+## Option D — **Runtime-true desktop client**
+
+Examples:
+- real shell adapter execution path
+- runtime preflight / readiness doctor
+- real session truthfulness and recovery
+- runtime-aware diagnostics and release confidence
+
+### Recommendation
+
+**Pick this.**
+
+This is the highest-value, most honest continuation of `v1.3.0`.
+
+---
+
+## North star for v1.4.0
+
+> **A user should be able to trust that the desktop client is reporting real runtime reality, not just UI state.**
+
+This means the milestone should optimize for:
+
+- truthfulness,
+- recovery,
+- operator confidence,
+- minimal ambiguity between “real”, “degraded”, and “simulated”.
+
+---
+
+## In scope
+
+### 1. Real shell adapter execution path
+- promote the real shell adapter from planning seam to trustworthy execution path
+- connect / disconnect should drive a real launched process on supported desktop platforms
+- surface runtime process identity, config provenance, and session evidence clearly
+- keep the fake/stub path available only as an explicit fallback or test mode
+
+### 2. Runtime readiness / doctor surface
+- binary presence and version check
+- config writeability / filesystem readiness
+- secure storage readiness summary
+- platform/runtime dependency readiness where practical
+- explicit “why connect is blocked” guidance
+
+### 3. Runtime truthfulness in UI
+- distinguish `real runtime active` vs `simulated adapter` vs `degraded backend`
+- show last launch plan / config destination / process state
+- make runtime session state, failure reason, and recovery action more explicit
+- extend Advanced / Support surfaces to include real execution evidence
+
+### 4. Recovery and operator control
+- restart / reconnect-safe stop behavior on real execution path
+- clearer stale session handling when the actual process and UI state diverge
+- controlled cleanup for runtime residue, temp configs, and partial launches
+- better “what changed since last failure” visibility
+
+### 5. Runtime-aware diagnostics
+- support bundle should include real adapter/backend identity
+- include executable path / version / launch metadata where safe
+- include “real vs simulated” execution evidence in exported support payloads
+- produce more actionable categories for launch failures vs connect failures
+
+### 6. Release trust improvements that serve the product
+- align client artifact version metadata with the release tag
+- ensure product-visible version/channel info matches shipped artifacts
+- add at least one higher-signal real packaged runtime smoke on desktop where practical
+
+---
+
+## Explicitly out of scope
+
+- mobile-first UX expansion
+- public-beta onboarding campaign / wide external rollout work
+- updater implementation beyond the existing boundary and metadata contract
+- protocol family expansion / protocol zoo work
+- trusted-front / public-edge capability expansion as the main milestone theme
+- signing/notarization perfection as the primary goal
+
+---
+
+## Proposed epics
+
+## Epic A — Real Runtime Path
+
+### Objective
+Turn the desktop client into a real launcher/controller instead of a shell wrapped around an adapter seam.
+
+### Likely work
+- promote real adapter launch path
+- harden stop/cleanup semantics
+- surface process/session identity
+- strengthen config render + write + launch + observe chain
+
+### Exit signal
+A packaged desktop client can drive a real runtime path on at least Linux with truthful state reporting.
+
+---
+
+## Epic B — Runtime Readiness Doctor
+
+### Objective
+Catch environment/setup blockers before the user presses Connect into a wall.
+
+### Likely work
+- binary locator + version check
+- writable-path check
+- secure storage readiness check
+- platform capability warnings (tray/runtime deps as advisory)
+- structured “blocked / degraded / ready” model
+
+### Exit signal
+The user can tell *before connecting* whether the app is ready, degraded, or blocked.
+
+---
+
+## Epic C — Runtime Truthfulness & Recovery
+
+### Objective
+Make the UI’s runtime story match real process reality.
+
+### Likely work
+- richer runtime phase model
+- explicit real-vs-simulated backend identity in product surfaces
+- clearer failure categorization
+- better stale-session / residue / retry flow
+- more operator-friendly troubleshooting state
+
+### Exit signal
+Abnormal states no longer leave the user asking “is it actually connected or not?”
+
+---
+
+## Epic D — Runtime-Aware Supportability
+
+### Objective
+Make support bundles useful for real execution failures, not just UI-state failures.
+
+### Likely work
+- include runtime launch metadata in support bundle
+- include backend identity + runtime session evidence
+- include launch/config path hints where safe
+- improve categorization of launch failures, permission failures, and environment failures
+
+### Exit signal
+A support bundle from a failed real-runtime launch is enough to reason about the likely failure class.
+
+---
+
+## Epic E — Release Truth Hygiene
+
+### Objective
+Make shipped product metadata consistent with what users download.
+
+### Likely work
+- align client asset version naming with release tag semantics
+- align product-visible version info with release metadata
+- add a minimal release-truth checklist that prevents version drift
+
+### Exit signal
+The release tag, asset names, and product-visible version/channel no longer disagree.
+
+---
+
+## Suggested delivery order
+
+1. **Epic A — Real Runtime Path**
+2. **Epic B — Runtime Readiness Doctor**
+3. **Epic C — Runtime Truthfulness & Recovery**
+4. **Epic D — Runtime-Aware Supportability**
+5. **Epic E — Release Truth Hygiene**
+
+### Why this order
+
+- if the runtime path is still fuzzy, all later UX layers are half-truths,
+- once real execution exists, readiness + recovery become high-leverage,
+- supportability should evolve around real runtime evidence,
+- release truth hygiene matters, but it should support the product loop rather than replace it.
+
+---
+
+## Risks and mitigations
+
+## Risk 1 — Over-coupling UI to process/runtime internals
+
+### Mitigation
+- keep the adapter boundary intact
+- promote the real adapter, not direct UI-to-process calls
+- keep fake/stub adapters for tests and degraded states
+
+## Risk 2 — False confidence from partial runtime evidence
+
+### Mitigation
+- always label backend identity explicitly
+- do not let “started process” masquerade as “healthy session”
+- separate `launch succeeded`, `session active`, `health acceptable`, and `connect path proven`
+
+## Risk 3 — Environment-dependent failures overwhelm UX
+
+### Mitigation
+- put a readiness doctor in front of the connect flow
+- classify failures as setup / runtime / profile / permission / OS dependency
+- keep support bundle evidence high-signal
+
+## Risk 4 — Release engineering churn steals product focus
+
+### Mitigation
+- keep release-truth hygiene scoped and surgical
+- do not let code-signing / updater / distribution policy become the main story of `v1.4.0`
+
+---
+
+## Definition of done
+
+`v1.4.0` should be considered done only when:
+
+- the desktop client can execute a **real runtime path** on supported desktop targets,
+- the user can tell whether the app is in a real, degraded, or simulated state,
+- readiness blockers are surfaced before a blind connect attempt,
+- runtime failures have recovery paths that feel intentional,
+- support bundles include real runtime evidence,
+- release artifact/product version truth is no longer visibly inconsistent.
+
+If those are not true, the milestone is not done — even if packaging, docs, and desktop chrome are pretty.
+
+---
+
+## Recommended branch/theme name
+
+If you want a milestone branch/theme right away, the clearest naming is:
+
+- `feature/v1.4.0-runtime-true-desktop`
+
+Alternative if you want a slightly more product-facing name:
+
+- `feature/v1.4.0-runtime-confidence`
+
+---
+
+## Blunt recommendation
+
+For `v1.4.0`, do **not** drift back into generic polish.
+
+The correct next move is:
+
+> **make the desktop client trustworthy about real runtime reality**
+
+not:
+
+> “add more UI niceness and hope the backend truth catches up later.”

--- a/docs/v1.4.0-release-gates.md
+++ b/docs/v1.4.0-release-gates.md
@@ -1,0 +1,40 @@
+# v1.4.0 Release Gates
+
+## Purpose
+
+Define what must be true before `v1.4.0` can be promoted from milestone-complete to releasable.
+
+---
+
+## Gate 1 — Product truth
+- [ ] real runtime path exists on supported desktop targets
+- [ ] user can distinguish real / simulated / degraded backend state
+- [ ] readiness blockers are shown before connect
+- [ ] stale-session and retry recovery are understandable
+
+## Gate 2 — Support truth
+- [ ] support bundle contains real runtime evidence
+- [ ] launch/config/environment failures are distinguishable
+- [ ] Advanced/support surfaces do not overclaim certainty
+
+## Gate 3 — Release truth
+- [ ] client asset version metadata matches release tag semantics
+- [ ] product-visible version/channel matches shipped release metadata
+- [ ] release notes / known limitations reflect actual runtime posture
+
+## Gate 4 — Validation truth
+- [ ] build and packaging are green
+- [ ] runtime-aware validation has at least one higher-signal packaged smoke
+- [ ] hard blockers vs advisory validation signals are documented
+- [ ] release can be justified without hidden tribal knowledge
+
+---
+
+## Non-gates
+
+The following are valuable, but should not silently redefine `v1.4.0`:
+- mobile parity
+- updater implementation
+- code-signing perfection
+- broad public onboarding polish
+- protocol expansion beyond current stable backend scope

--- a/docs/v1.4.0-roadmap.md
+++ b/docs/v1.4.0-roadmap.md
@@ -1,0 +1,34 @@
+# v1.4.0 Roadmap
+
+## Milestone theme
+
+**Runtime-True Desktop Client**
+
+## Sequence
+
+### Phase 1 — Real runtime path
+- Sprint 1: Real Runtime Path First Cut
+
+### Phase 2 — Pre-connect truth
+- Sprint 2: Runtime Readiness Doctor
+
+### Phase 3 — Runtime truth & recovery
+- Sprint 3: Runtime Truthfulness & Recovery
+
+### Phase 4 — Runtime-aware supportability
+- Sprint 4: Runtime-Aware Supportability
+
+### Phase 5 — Release truth & validation
+- Sprint 5: Release Truth Hygiene & Beta Validation
+
+## Intended release posture
+
+`v1.4.0` should target:
+- stronger desktop beta confidence than `v1.3.0`
+- runtime-truthful operator UX
+- release/version honesty
+
+It should **not** target:
+- polished public onboarding for a mass audience
+- mobile-first expansion
+- major protocol scope growth

--- a/docs/v1.4.0-sprint-1-plan.md
+++ b/docs/v1.4.0-sprint-1-plan.md
@@ -1,0 +1,128 @@
+# v1.4.0 Sprint 1 Plan — Real Runtime Path First Cut
+
+## Goal
+
+Land the first trustworthy **real runtime execution path** for the desktop client.
+
+This sprint should move the client from “good shell with planning seam” to “desktop app that can actually drive a managed runtime and say what happened truthfully.”
+
+---
+
+## Why this sprint first
+
+The current product shell already covers:
+
+- profile/settings state
+- secure storage abstraction
+- diagnostics/support flow
+- desktop lifecycle/tray semantics
+- packaging and prerelease flow
+
+The next highest-value gap is whether the app can truthfully operate a **real runtime path**.
+
+---
+
+## Scope
+
+### In scope
+- real shell adapter execution path
+- managed process launch / stop first cut
+- launch-plan → config write → process start → session observe chain
+- real backend identity in product surfaces
+- first-pass cleanup guarantees for config/temp residue
+- targeted tests around launch/stop/failure path
+
+### Out of scope
+- readiness doctor UI
+- full support bundle enrichment
+- broader release/version hygiene
+- mobile work
+- updater work
+
+---
+
+## Progress snapshot (first cut)
+
+- Added a dedicated shell-adapter selector (`ShellControllerAdapterSelector`) so promotion logic is explicit and testable instead of hidden in ad-hoc bootstrap flags.
+- Defined and implemented `auto/real/stub` policy (`TROJAN_CLIENT_BACKEND_MODE`), with legacy compatibility for `TROJAN_CLIENT_ENABLE_REAL_ADAPTER`.
+- Desktop default now follows `auto` promotion: prefer real adapter when a launchable Trojan binary is resolvable; otherwise degrade to explicit fallback stub identity.
+- Non-desktop target path is now explicitly labeled as stub-only.
+- Runtime execution-path truth is now surfaced in Dashboard / Advanced / Profiles (real vs fallback vs explicit stub vs non-desktop stub).
+- Added selector regression tests covering auto promotion, forced stub, forced real-without-binary degradation, non-desktop fallback, and legacy env compatibility.
+
+## Progress snapshot (second cut — runtime phase truth)
+
+- Introduced `ControllerRuntimePhase` (`planned/launching/alive/sessionReady/failed/stopped`) in runtime session state.
+- Real adapter now records launch plan + config provenance + expected SOCKS port, and promotes phase to `sessionReady` only after the local port opens.
+- Adapter-backed controller keeps `connecting` until session-ready; while alive-but-not-ready it now emits explicit progress messaging.
+- Runtime session UI now shows phase, provenance, expected port, and launch plan summary.
+- Persisted runtime snapshot now captures phase + provenance + expected port + launch plan summary for recovery truth.
+
+## Progress snapshot (third cut — stop semantics)
+
+- Runtime session state now distinguishes `stop requested` from `process already exited`, including `stopRequestedAt` evidence.
+- Disconnect flow now tells the truth when shutdown is still pending instead of implying teardown already finished.
+- Runtime session UI shows stop-request evidence directly for debugging/support.
+- Persisted runtime snapshot now carries stop-request state so recovery/support evidence matches what really happened.
+
+## Progress snapshot (fourth cut — cleanup/retry + smoke)
+
+- Added a real-adapter regression test for `abnormal exit -> cleanup -> retry -> clean disconnect`, validating retry safety after a failed launch cycle.
+- Refined disconnect-exit semantics so user-requested shutdown resolves to `stopped` even when process exit code is non-zero.
+- Executed `./scripts/run-client-runtime-smoke.sh` end-to-end in this environment:
+  - analyze/test/build: passed
+  - real trojan preflight: passed
+  - desktop GUI smoke: skipped (headless env without DISPLAY/xvfb-run), recorded as environment limitation instead of app failure.
+
+## Work items
+
+### 1. Promote real shell adapter
+- [x] define the exact promotion rule from fake/stub to real adapter
+- [x] make the real adapter the intended path on supported desktop targets
+- [x] keep fallback/stub path explicit for tests and unsupported/degraded cases
+
+### 2. Harden launch chain
+- [x] render real config deterministically
+- [x] write config to managed path
+- [x] launch managed process
+- [x] surface process/session identity
+- [x] ensure stop semantics are explicit and deterministic
+
+### 3. Surface runtime truth in product state
+- [x] expose backend identity in Dashboard / Advanced / support surfaces
+- [x] distinguish planned / launching / alive / session-ready / failed
+- [x] show config/runtime path provenance where safe
+
+### 4. Cleanup and residue handling
+- [x] ensure abnormal exit cleanup is deterministic enough for beta use
+- [x] verify stale runtime residue is handled with the real adapter path
+- [x] add regression coverage for launch failure + cleanup + retry
+
+### 5. Tests / validation
+- [x] extend real shell adapter tests for process lifecycle truthfulness
+- [x] add at least one higher-signal local/package runtime smoke where practical
+- [x] update docs with current real-runtime limitations
+
+---
+
+## Risks
+
+### Risk 1 — real adapter path introduces unstable process semantics
+**Mitigation:** keep adapter boundary strict and expand state model before UI polish.
+
+### Risk 2 — runtime truth becomes more confusing before it becomes clearer
+**Mitigation:** expose backend identity and phase model explicitly instead of hiding uncertainty.
+
+### Risk 3 — cleanup/retry path regresses as soon as real launch exists
+**Mitigation:** treat abnormal-stop cleanup as same-sprint work, not follow-up polish.
+
+---
+
+## Definition of done
+
+Sprint 1 is done only when:
+
+- real shell adapter is a credible execution path,
+- user-visible state can distinguish real runtime phases,
+- stop/cleanup/retry do not leave obvious residue confusion,
+- targeted tests exist for the launch/stop/failure path.

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -49,6 +49,12 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - Readiness report supports `profileOverride`, enabling per-profile gate checks from CTA entry points.
 - Added/updated UI tests to cover blocked-gate behavior in Dashboard and Profiles.
 
+## Progress snapshot (third cut — inline CTA context)
+
+- Profiles page now renders an inline readiness notice beside the local connection workflow instead of relying only on transient snackbar feedback.
+- When a profile is blocked/degraded, the user can see the readiness level and summary **before pressing Connect**.
+- This closes the Sprint 2 definition-of-done gap around “user can tell why connect is blocked before pressing the button” for the profile-level workflow as well.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -55,6 +55,12 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - When a profile is blocked/degraded, the user can see the readiness level and summary **before pressing Connect**.
 - This closes the Sprint 2 definition-of-done gap around “user can tell why connect is blocked before pressing the button” for the profile-level workflow as well.
 
+## Progress snapshot (fourth cut — degraded recommendation routing)
+
+- Readiness recommendation selection now falls back to the highest-signal **degraded** check when no blocked check exists.
+- This means warning-only states (for example secure-storage fallback or stub-runtime posture) now still get a concrete “what to do next” action instead of a passive summary.
+- Dashboard readiness doctor therefore behaves more like a real operator aide: blocked states stop you, degraded states still nudge you toward the right fix path.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -115,6 +115,12 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - Profile detail rows collapse into a stacked label/value form on narrow surfaces, avoiding fixed-width desktop assumptions.
 - Added compact-width widget coverage for both the app shell bottom navigation path and the profiles page itself.
 
+## Progress snapshot (thirteenth cut — settings/advanced compact hardening)
+
+- Settings page now uses page-level scrolling and a compact-friendly diagnostics retention control layout to avoid narrow-surface overflow.
+- App shell compact test flow now explicitly covers `Profiles → Settings → Advanced` navigation and validates no runtime layout exceptions.
+- Fixed Advanced support path overflow by moving Diagnostics page scrolling to the page layer (instead of an inner scroll region inside `SectionCard`).
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -61,6 +61,14 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - This means warning-only states (for example secure-storage fallback or stub-runtime posture) now still get a concrete “what to do next” action instead of a passive summary.
 - Dashboard readiness doctor therefore behaves more like a real operator aide: blocked states stop you, degraded states still nudge you toward the right fix path.
 
+## Progress snapshot (fifth cut — deterministic recommendation priority)
+
+- Recommendation selection no longer depends on incidental check ordering.
+- Added explicit priority policy:
+  - blocked fixes outrank degraded warnings
+  - within the same severity, higher-signal domains (password/profile/config/runtimeBinary/...) win consistently
+- Added regression tests to lock this ordering down, reducing the chance that future extra warnings will make the CTA jump around unpredictably.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -90,6 +90,13 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - Profiles readiness recommendation now lands directly on the `Problem Report` tab, making “Open Troubleshooting” an exact destination instead of a coarse page switch.
 - Added regression coverage for tab-request switching and shell-level troubleshooting landing behavior.
 
+## Progress snapshot (ninth cut — readiness freshness truth)
+
+- Last-known readiness restore now explicitly marks reports as `Cached snapshot`; live checks keep `Live check` provenance.
+- Readiness report exposes freshness metadata (`fresh/aging/stale`) and human-readable age labels.
+- Dashboard and Profiles readiness surfaces now show provenance/freshness and include an explicit hint while live refresh is still running over a cached snapshot.
+- Added/updated regression checks to guard cached-vs-live source semantics.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -40,6 +40,15 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - Diagnostics support bundle now includes serialized readiness evidence (`readiness` block).
 - Added readiness regression tests (`readiness_service_test.dart`) and updated service-registry/diagnostics test wiring to include readiness service.
 
+## Progress snapshot (second cut — hard gate)
+
+- Dashboard `What to do next` now respects blocked readiness in action flow:
+  - blocked state overrides idle connect CTA
+  - `connect/retry` actions re-check readiness and hard-stop when blocked
+- Profiles page connect action now enforces the same readiness hard gate (not only status-label hints), preventing bypass from profile-level action buttons.
+- Readiness report supports `profileOverride`, enabling per-profile gate checks from CTA entry points.
+- Added/updated UI tests to cover blocked-gate behavior in Dashboard and Profiles.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -139,6 +139,12 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - Readiness runtime-path messaging now reuses `RuntimePosture` truth notes, so posture semantics and readiness copy no longer drift apart.
 - This keeps shell-demo actions available while making it much harder to misread stub-only paths as runtime-true execution evidence.
 
+## Progress snapshot (seventeenth cut — evidence-grade mechanism)
+
+- `RuntimePosture` now exposes a second truth axis: `Evidence-grade` vs `Shell-grade only`.
+- Dashboard, Profiles, Advanced, and Problem Report surfaces now all state the current evidence grade alongside runtime posture.
+- Diagnostics preview/export payloads now embed runtime posture + evidence-grade metadata so exported support bundles carry the same truth semantics as the UI.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -127,6 +127,12 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - Export history and per-platform readiness rows now switch to stacked layouts on narrow widths instead of relying on `ListTile.trailing` for long text.
 - Added compact packaging widget coverage with real export-history content so the responsive path is tested, not just visually hoped for.
 
+## Progress snapshot (fifteenth cut — runtime posture truth layer)
+
+- Added a shared `RuntimePosture` interpreter that translates raw runtime modes into stable product language (`Runtime-true`, `Stub-only (fallback)`, `Stub-only (non-desktop)`, etc.).
+- Dashboard, Profiles, and Advanced now surface the same posture/execution-path semantics instead of each page carrying slightly different wording.
+- Added posture domain tests plus UI regression checks so fallback/non-desktop truth stays explicit and doesn’t regress into ambiguous “looks real enough” copy.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -69,6 +69,13 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
   - within the same severity, higher-signal domains (password/profile/config/runtimeBinary/...) win consistently
 - Added regression tests to lock this ordering down, reducing the chance that future extra warnings will make the CTA jump around unpredictably.
 
+## Progress snapshot (sixth cut — last-known readiness snapshot)
+
+- `ReadinessService` now persists last-known readiness verdicts into local state keyed by profile id.
+- Dashboard and Profiles readiness surfaces restore the previous verdict first, then asynchronously refresh the live state.
+- This reduces the “blank/Checking…” cold-open gap and makes the first frame feel more like a product shell instead of a loading placeholder.
+- Added snapshot persistence / restore regression coverage.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -97,6 +97,12 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - Dashboard and Profiles readiness surfaces now show provenance/freshness and include an explicit hint while live refresh is still running over a cached snapshot.
 - Added/updated regression checks to guard cached-vs-live source semantics.
 
+## Progress snapshot (tenth cut — restore/live race hardening)
+
+- Added readiness request-token gating in Dashboard and Profiles so stale async restores cannot overwrite a newer live readiness verdict.
+- Dashboard initial refresh key is now initialized from real inputs to avoid an unnecessary duplicate cycle at first mount.
+- Added regression tests that simulate delayed local-state reads and verify that late cached snapshots no longer clobber live readiness UI.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -133,6 +133,12 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - Dashboard, Profiles, and Advanced now surface the same posture/execution-path semantics instead of each page carrying slightly different wording.
 - Added posture domain tests plus UI regression checks so fallback/non-desktop truth stays explicit and doesn’t regress into ambiguous “looks real enough” copy.
 
+## Progress snapshot (sixteenth cut — posture-aware action wording)
+
+- Dashboard connect/retry guidance and Profiles connect CTA now qualify stub paths directly in the action label (`Connect now (stub path)`, `Retry now (stub path)`, `Connect (non-desktop stub)`, etc.).
+- Readiness runtime-path messaging now reuses `RuntimePosture` truth notes, so posture semantics and readiness copy no longer drift apart.
+- This keeps shell-demo actions available while making it much harder to misread stub-only paths as runtime-true execution evidence.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -109,6 +109,12 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - Dashboard and Profiles now consume the same controller pattern instead of carrying near-duplicate state machines.
 - Kept UI copy and action behavior stable while reducing drift risk for future readiness changes.
 
+## Progress snapshot (twelfth cut — compact multi-platform profiles layout)
+
+- Profiles page now switches between wide split layout and compact stacked layout based on available width.
+- Profile detail rows collapse into a stacked label/value form on narrow surfaces, avoiding fixed-width desktop assumptions.
+- Added compact-width widget coverage for both the app shell bottom navigation path and the profiles page itself.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -145,6 +145,12 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - Dashboard, Profiles, Advanced, and Problem Report surfaces now all state the current evidence grade alongside runtime posture.
 - Diagnostics preview/export payloads now embed runtime posture + evidence-grade metadata so exported support bundles carry the same truth semantics as the UI.
 
+## Progress snapshot (eighteenth cut — support bundle vs runtime-proof artifact)
+
+- Problem Report and Advanced now explicitly distinguish **support bundles** from **runtime-proof artifacts** based on the current evidence grade.
+- On shell-grade-only paths, export CTAs are renamed to support-oriented labels (`Generate support preview`, `Export support bundle`, `Open Support Bundle`) instead of wording that could be mistaken for runtime-proof output.
+- Added UI regression coverage so shell-grade paths keep their “support-only” wording while runtime/evidence semantics remain explicit.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -23,13 +23,30 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 
 ---
 
+## Progress snapshot (first cut)
+
+- Added explicit readiness domain model and structured report payload:
+  - domains: `profile/password/secureStorage/environment/config/runtimePath/runtimeBinary/filesystem`
+  - levels: `ready/degraded/blocked`
+  - recommendation model with actionable next step (`openProfiles/openTroubleshooting/openSettings`)
+- Implemented `ReadinessService`:
+  - validates profile selection + password presence (real secret check)
+  - surfaces secure storage posture and fallback/degraded state
+  - checks environment/config/runtime-path/runtime-binary/filesystem writability
+- Dashboard now includes a dedicated **Readiness doctor** card:
+  - clear `Overall + Headline + Summary`
+  - domain-by-domain checks
+  - recommended action button when blocked/degraded
+- Diagnostics support bundle now includes serialized readiness evidence (`readiness` block).
+- Added readiness regression tests (`readiness_service_test.dart`) and updated service-registry/diagnostics test wiring to include readiness service.
+
 ## Work items
-- [ ] define readiness domains (binary / filesystem / secrets / environment / config)
-- [ ] build readiness check service with structured results
-- [ ] map readiness results to blocked/degraded/ready UX
-- [ ] show why connect is blocked and what next action is recommended
-- [ ] include readiness evidence in diagnostics/support payloads
-- [ ] add tests for readiness result mapping and blocked/degraded UI
+- [x] define readiness domains (binary / filesystem / secrets / environment / config)
+- [x] build readiness check service with structured results
+- [x] map readiness results to blocked/degraded/ready UX
+- [x] show why connect is blocked and what next action is recommended
+- [x] include readiness evidence in diagnostics/support payloads
+- [x] add tests for readiness result mapping and blocked/degraded UI
 
 ---
 

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -103,6 +103,12 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - Dashboard initial refresh key is now initialized from real inputs to avoid an unnecessary duplicate cycle at first mount.
 - Added regression tests that simulate delayed local-state reads and verify that late cached snapshots no longer clobber live readiness UI.
 
+## Progress snapshot (eleventh cut — shared readiness surface controller)
+
+- Extracted the async readiness orchestration (`restore snapshot → live refresh → token gate`) into a shared `ReadinessSurfaceController`.
+- Dashboard and Profiles now consume the same controller pattern instead of carrying near-duplicate state machines.
+- Kept UI copy and action behavior stable while reducing drift risk for future readiness changes.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -1,0 +1,41 @@
+# v1.4.0 Sprint 2 Plan — Runtime Readiness Doctor
+
+## Goal
+
+Add a pre-connect readiness layer so the user knows whether the app is **ready, degraded, or blocked** before they try to connect.
+
+---
+
+## Scope
+
+### In scope
+- binary presence/version checks
+- writable-path/config checks
+- secure storage readiness summary
+- explicit readiness state model
+- UI surface for readiness doctor / preflight summary
+- support bundle inclusion for readiness evidence
+
+### Out of scope
+- full runtime-aware support bundle overhaul
+- release/version alignment
+- mobile UX
+
+---
+
+## Work items
+- [ ] define readiness domains (binary / filesystem / secrets / environment / config)
+- [ ] build readiness check service with structured results
+- [ ] map readiness results to blocked/degraded/ready UX
+- [ ] show why connect is blocked and what next action is recommended
+- [ ] include readiness evidence in diagnostics/support payloads
+- [ ] add tests for readiness result mapping and blocked/degraded UI
+
+---
+
+## Definition of done
+
+Sprint 2 is done only when:
+- user can tell why connect is blocked before pressing the button,
+- readiness state is exportable/supportable,
+- degraded states are explained without reading raw logs.

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -151,6 +151,12 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - On shell-grade-only paths, export CTAs are renamed to support-oriented labels (`Generate support preview`, `Export support bundle`, `Open Support Bundle`) instead of wording that could be mistaken for runtime-proof output.
 - Added UI regression coverage so shell-grade paths keep their “support-only” wording while runtime/evidence semantics remain explicit.
 
+## Progress snapshot (nineteenth cut — runtime-proof artifact promotion flow)
+
+- `DiagnosticsExportService` now supports a promoted `runtime-proof-artifact` export path with dedicated payload kind and filename prefix.
+- Runtime-proof export is explicitly gated behind `Evidence-grade` posture; shell-grade paths fail closed with a clear state error.
+- Diagnostics UI now exposes an extra `Export runtime-proof artifact` action only on evidence-grade paths, while preserving the support-bundle flow for all paths.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -121,6 +121,12 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - App shell compact test flow now explicitly covers `Profiles → Settings → Advanced` navigation and validates no runtime layout exceptions.
 - Fixed Advanced support path overflow by moving Diagnostics page scrolling to the page layer (instead of an inner scroll region inside `SectionCard`).
 
+## Progress snapshot (fourteenth cut — packaging compact mechanism)
+
+- Packaging page no longer assumes fixed 240px desktop metadata tiles; key/value blocks now shrink to fit compact surfaces.
+- Export history and per-platform readiness rows now switch to stacked layouts on narrow widths instead of relying on `ListTile.trailing` for long text.
+- Added compact packaging widget coverage with real export-history content so the responsive path is tested, not just visually hoped for.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -76,6 +76,20 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - This reduces the “blank/Checking…” cold-open gap and makes the first frame feel more like a product shell instead of a loading placeholder.
 - Added snapshot persistence / restore regression coverage.
 
+## Progress snapshot (seventh cut — readiness refresh + truthful CTA)
+
+- Readiness refresh now keys off a deterministic fingerprint of selected profile + runtime + storage inputs, eliminating stale “cached” summaries after in-place edits.
+- Profiles page now reflects blocked readiness directly in the Connect CTA (`Connect Blocked`) and routes recommendation actions to the correct tab when available.
+- Added regression tests to verify readiness refresh on in-place edits and the troubleshooting recommendation route.
+- App shell now wires Profiles recommendation actions to Settings/Advanced navigation so the “fix” button is a real exit, not just a hint.
+
+## Progress snapshot (eighth cut — direct troubleshooting landing)
+
+- Advanced page now supports explicit requested-tab routing (`Problem Report` / `Update Status`) instead of always opening at a generic default.
+- App shell can issue targeted Advanced tab requests and bump a request token so repeated navigations still land correctly.
+- Profiles readiness recommendation now lands directly on the `Problem Report` tab, making “Open Troubleshooting” an exact destination instead of a coarse page switch.
+- Added regression coverage for tab-request switching and shell-level troubleshooting landing behavior.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-2-plan.md
+++ b/docs/v1.4.0-sprint-2-plan.md
@@ -157,6 +157,12 @@ Add a pre-connect readiness layer so the user knows whether the app is **ready, 
 - Runtime-proof export is explicitly gated behind `Evidence-grade` posture; shell-grade paths fail closed with a clear state error.
 - Diagnostics UI now exposes an extra `Export runtime-proof artifact` action only on evidence-grade paths, while preserving the support-bundle flow for all paths.
 
+## Progress snapshot (twentieth cut — proof artifact operator UX)
+
+- Runtime posture now carries operator guidance (`How to use …` heading + checklist) so proof/support semantics are easier to interpret by humans, not just code.
+- Problem Report UI now renders this checklist inline, making it clear how to handle support bundles vs runtime-proof artifacts on the current posture.
+- Diagnostics export payloads now embed the same operator guidance, so exported JSON carries both machine-readable truth and human-usable instructions.
+
 ## Work items
 - [x] define readiness domains (binary / filesystem / secrets / environment / config)
 - [x] build readiness check service with structured results

--- a/docs/v1.4.0-sprint-3-plan.md
+++ b/docs/v1.4.0-sprint-3-plan.md
@@ -21,6 +21,12 @@ Make the UI/runtime story truthful when real execution is running, degraded, sta
 
 ---
 
+## Progress snapshot (first cut — runtime session truth semantics)
+
+- Introduced `ControllerRuntimeSessionTruth` semantics (`Live / Aging / Stale / Residual snapshot / Stopping / Stopped`) derived from session age, running state, phase, and stop requests.
+- Added domain-level coverage to lock in the distinction between live runtime state, stale session records, and residual non-running snapshots.
+- This is the first Sprint 3 building block for richer runtime phase / stale-session recovery UX; UI surfacing can now reuse a stable truth model instead of inventing ad-hoc wording.
+
 ## Work items
 - [ ] enrich runtime phase/state model
 - [ ] surface backend identity and real execution evidence across product surfaces

--- a/docs/v1.4.0-sprint-3-plan.md
+++ b/docs/v1.4.0-sprint-3-plan.md
@@ -1,0 +1,37 @@
+# v1.4.0 Sprint 3 Plan — Runtime Truthfulness & Recovery
+
+## Goal
+
+Make the UI/runtime story truthful when real execution is running, degraded, stale, or failed.
+
+---
+
+## Scope
+
+### In scope
+- richer runtime phase model
+- explicit real-vs-simulated-vs-degraded identity in UI
+- stale-session / divergence recovery
+- retry/restart-safe semantics
+- clearer last-failure deltas and recovery guidance
+
+### Out of scope
+- release hygiene work
+- packaging flow changes unrelated to runtime truth
+
+---
+
+## Work items
+- [ ] enrich runtime phase/state model
+- [ ] surface backend identity and real execution evidence across product surfaces
+- [ ] improve stale-session / divergence recovery behavior
+- [ ] improve retry guidance after real launch/connect failures
+- [ ] add regression tests for divergent runtime/UI states
+
+---
+
+## Definition of done
+
+Sprint 3 is done only when:
+- user-visible runtime state matches actual execution truth closely enough for beta use,
+- stale or half-dead states are recognizable and recoverable.

--- a/docs/v1.4.0-sprint-3-plan.md
+++ b/docs/v1.4.0-sprint-3-plan.md
@@ -27,6 +27,16 @@ Make the UI/runtime story truthful when real execution is running, degraded, sta
 - Added domain-level coverage to lock in the distinction between live runtime state, stale session records, and residual non-running snapshots.
 - This is the first Sprint 3 building block for richer runtime phase / stale-session recovery UX; UI surfacing can now reuse a stable truth model instead of inventing ad-hoc wording.
 
+## Progress snapshot (third cut — runtime truth recovery surfacing)
+
+- Promoted `ControllerRuntimeSessionTruth` from a pure domain concept into product-visible recovery semantics with `needsAttention` and human-readable `recoveryGuidance`.
+- Dashboard runtime session view now states **Session Truth** (`Live / Aging / Stale / Residual snapshot / Stopping`) plus snapshot age, truth note, and a concrete next-step hint instead of raw phase-only telemetry.
+- Advanced support surface now includes a dedicated **Runtime truth & recovery** card so operators can quickly see whether a session is stale/residual and what recovery posture to take before exporting or retrying.
+- Dashboard / Profiles CTAs now respect actionable runtime truth: stale or stopping runtime state can steer the operator toward **Troubleshooting first** instead of blindly presenting normal Disconnect / Retry flows.
+- Action feedback is now truth-aware too: connect / retry / disconnect SnackBars no longer echo raw adapter summaries blindly, and support bundles now include `runtimeSession.truth`, `needsAttention`, and `recoveryGuidance` for downstream diagnosis.
+- Diagnostics / support UI now surfaces the same runtime-truth semantics directly on-page, so operators can see whether the current session is `Live / Stale / Residual` before exporting bundles instead of discovering that only in raw JSON.
+- Added regression coverage for truth/recovery semantics and the new Dashboard/Advanced/Profiles surfacing.
+
 ## Work items
 - [ ] enrich runtime phase/state model
 - [ ] surface backend identity and real execution evidence across product surfaces

--- a/docs/v1.4.0-sprint-4-plan.md
+++ b/docs/v1.4.0-sprint-4-plan.md
@@ -1,0 +1,35 @@
+# v1.4.0 Sprint 4 Plan — Runtime-Aware Supportability
+
+## Goal
+
+Make support and diagnostics flows useful for **real runtime failures**, not just shell-state failures.
+
+---
+
+## Scope
+
+### In scope
+- runtime launch metadata in support bundles
+- executable/config/session evidence in diagnostics
+- clearer launch vs connect vs environment failure categorization
+- Advanced/support UI updates around runtime evidence
+- export regression coverage
+
+### Out of scope
+- release version alignment beyond direct supportability needs
+
+---
+
+## Work items
+- [ ] extend diagnostics export model with runtime evidence
+- [ ] enrich support issue descriptor categories for real runtime failures
+- [ ] expose backend identity / launch metadata in support-facing UI
+- [ ] add regression tests for runtime-aware export contents and messaging
+
+---
+
+## Definition of done
+
+Sprint 4 is done only when:
+- a support bundle from a failed real launch provides actionable evidence,
+- support surfaces distinguish launch, environment, and runtime-session failures clearly.

--- a/docs/v1.4.0-sprint-5-plan.md
+++ b/docs/v1.4.0-sprint-5-plan.md
@@ -1,0 +1,39 @@
+# v1.4.0 Sprint 5 Plan — Release Truth Hygiene & Beta Validation
+
+## Goal
+
+Make release outputs and release decisions tell the truth about the shipped client.
+
+---
+
+## Scope
+
+### In scope
+- client asset version alignment with release tags
+- product-visible version/channel alignment
+- release-truth checklist updates
+- runtime-true beta validation/runbooks
+- hard-blocker vs advisory validation policy cleanup
+
+### Out of scope
+- updater implementation
+- public onboarding/distribution campaign work
+
+---
+
+## Work items
+- [ ] align client package version metadata with release tag flow
+- [ ] align product-visible version info with shipped metadata
+- [ ] extend release checklist with version-truth validation
+- [ ] update beta handoff notes and known-limitations templates for runtime-true client
+- [ ] define runtime validation gates: hard blockers vs best-effort signals
+- [ ] verify one higher-signal packaged runtime smoke path for release candidates
+
+---
+
+## Definition of done
+
+Sprint 5 is done only when:
+- release tag / assets / product-visible version no longer disagree,
+- runtime-aware beta validation is documented and repeatable,
+- release gating no longer relies on ambiguous or misleading signals.

--- a/packaging/linux/release-metadata.env
+++ b/packaging/linux/release-metadata.env
@@ -10,8 +10,8 @@ ICON_NAME="trojan-pro-client"
 ICON_SOURCE="packaging/linux/assets/trojan-pro-client.png"
 
 CHANNEL="stable"
-VERSION_LABEL="1.1.0"
-DEB_VERSION="1.1.0-1"
+VERSION_LABEL="1.4.0-beta.1"
+DEB_VERSION="1.4.0~beta.1-1"
 PACKAGE_ARCH="amd64"
 ARTIFACT_STEM="trojan-pro-client"
 


### PR DESCRIPTION
## Summary

- unify runtime-aware operator semantics for the desktop client by introducing shared `RuntimeActionSafety`, `RuntimeOperatorAdvice`, `RuntimeActionFeedback`, and `RuntimeActionMatrix` domain contracts
- make Dashboard / Diagnostics / Profiles surface the same runtime truth, recovery, action-safety, troubleshooting-first, and evidence-first guidance instead of each page deriving its own ad-hoc rules
- tighten error / stale / stop-pending flows so residual runtime evidence can steer operators toward Troubleshooting and support-preview capture before destructive retry shortcuts
- align client release metadata with the `v1.4.0` beta line (`client/pubspec.yaml` + Linux packaging metadata)

## Scope

- [ ] core
- [x] client
- [x] ci/release
- [x] docs

## Validation

- [x] local validation completed
- [ ] CI passed
- [x] docs updated if needed

Local validation run:

```bash
cd client && flutter test \
  test/features/controller/domain/runtime_action_feedback_test.dart \
  test/features/controller/domain/runtime_action_matrix_test.dart \
  test/features/controller/domain/runtime_action_safety_test.dart \
  test/features/controller/domain/runtime_operator_advice_test.dart \
  test/features/dashboard/presentation/dashboard_guide_policy_test.dart \
  test/features/diagnostics/presentation/diagnostics_support_policy_test.dart \
  test/features/profiles/presentation/profile_connection_action_policy_test.dart \
  test/features/advanced/presentation/advanced_page_test.dart \
  test/features/controller/domain/controller_runtime_session_test.dart \
  test/features/dashboard/presentation/dashboard_page_test.dart \
  test/features/diagnostics/application/diagnostics_export_service_test.dart \
  test/features/diagnostics/presentation/diagnostics_page_test.dart \
  test/features/profiles/presentation/profiles_page_action_gating_test.dart \
  && flutter analyze
```

## Risk

- [ ] low
- [x] medium
- [ ] high

## Release impact

- [ ] no release impact
- [x] affects packaging or release flow
- [x] requires changelog update

## Notes

Reviewer focus areas:

- `RuntimeActionMatrix` / `RuntimeActionSafety` / `RuntimeOperatorAdvice` contract boundaries: make sure shared runtime semantics stay coherent and do not overfit one page
- Dashboard error / residual-session flow: verify the new evidence-first steering only triggers for runtime-true residual/error states and does not regress ordinary retry paths
- Diagnostics preferred evidence action: currently first cut is `Generate support preview`; confirm this is the right initial emphasis before we expand the action graph further
- Version metadata alignment: `client/pubspec.yaml` and `packaging/linux/release-metadata.env` now move with the `v1.4.0-beta.1` line together, which is intended to close the earlier client-package version drift
