### PR TITLE
ci(actions): upgrade release lanes for Node24 readiness

### DIFF
--- a/.github/workflows/client-packaging.yml
+++ b/.github/workflows/client-packaging.yml
@@ -1,5 +1,9 @@
 name: Client Packaging
 
+env:
+  # Prefer Node.js 24 for JavaScript actions ahead of platform default switch
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_call:
     inputs:
@@ -316,7 +320,7 @@ jobs:
           cache: false
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Ensure Android scaffolding exists
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ on:
 
 env:
   BUILD_TYPE: Release
+  # Prefer Node.js 24 for JavaScript actions ahead of platform default switch
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # ============================================
@@ -503,7 +505,7 @@ jobs:
           EOF
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: Trojan-Pro ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- bump `softprops/action-gh-release` from `v2` to `v3`
- bump `android-actions/setup-android` from `v3` to `v4`
- set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` in release/client workflows

## Why
GitHub Actions Node20 deprecation warnings were emitted in release lanes.
This change proactively aligns release workflows with Node24 runtime compatibility.

## Verification
- Triggered workflow: `Build and Release`
- Run: https://github.com/proxy-trojan/trojan-obfuscation/actions/runs/24406128486
- Result: success
- Key lanes validated: Android client packaging + artifact validation

## Notes
- `release` job remains skipped on `workflow_dispatch` by design (tag-push only).
