### PR TITLE
release: promote v1.4.0 stable (non-beta)

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -42,3 +42,30 @@ jobs:
       - name: Run smoke tests
         run: |
           ctest --test-dir build/ci --output-on-failure -j"$(nproc)"
+
+  flutter-client-gate:
+    runs-on: ubuntu-22.04
+    name: Flutter client gate (domain/application)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: false
+
+      - name: Flutter analyze + targeted tests
+        working-directory: client
+        run: |
+          flutter pub get
+          flutter analyze
+          flutter test \
+            test/features/controller/application/adapter_backed_client_controller_test.dart \
+            test/features/controller/application/real_shell_controller_adapter_test.dart \
+            test/features/diagnostics/application/diagnostics_export_service_test.dart \
+            test/features/settings/application/settings_serialization_test.dart \
+            test/features/packaging/application/packaging_store_test.dart \
+            test/features/packaging/presentation/packaging_page_test.dart

--- a/.github/workflows/client-packaging.yml
+++ b/.github/workflows/client-packaging.yml
@@ -113,6 +113,17 @@ jobs:
           flutter pub get
           flutter analyze
 
+      - name: Flutter test gate (domain/application)
+        working-directory: client
+        run: |
+          flutter test \
+            test/features/controller/application/adapter_backed_client_controller_test.dart \
+            test/features/controller/application/real_shell_controller_adapter_test.dart \
+            test/features/diagnostics/application/diagnostics_export_service_test.dart \
+            test/features/settings/application/settings_serialization_test.dart \
+            test/features/packaging/application/packaging_store_test.dart \
+            test/features/packaging/presentation/packaging_page_test.dart
+
       - name: Build Linux bundle
         working-directory: client
         run: flutter build linux --release

--- a/client/lib/features/controller/application/real_shell_controller_adapter.dart
+++ b/client/lib/features/controller/application/real_shell_controller_adapter.dart
@@ -71,6 +71,7 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
           'connect',
           'disconnect',
           'healthCheck',
+          'collectDiagnostics',
           'prepareExport',
         ],
         lastUpdatedAt: DateTime.now(),
@@ -162,16 +163,55 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
       case ControllerCommandKind.disconnect:
         return _disconnect(command);
       case ControllerCommandKind.collectDiagnostics:
+        return _collectDiagnostics(command);
       case ControllerCommandKind.prepareExport:
-        return ControllerCommandResult(
-          commandId: command.id,
-          accepted: false,
-          completedAt: DateTime.now(),
-          summary:
-              'Command kind ${command.kind.name} is not wired in the real shell adapter yet.',
-          error: 'NOT_IMPLEMENTED',
-        );
+        return _prepareExport(command);
     }
+  }
+
+  Future<ControllerCommandResult> _collectDiagnostics(
+    ControllerCommand command,
+  ) async {
+    final bundleKind = command.arguments['bundleKind']?.toString();
+    final health = await checkHealth();
+    final safeToExport = _runtimePhase != ControllerRuntimePhase.failed &&
+        health.level != ControllerRuntimeHealthLevel.unavailable;
+
+    return ControllerCommandResult(
+      commandId: command.id,
+      accepted: true,
+      completedAt: DateTime.now(),
+      summary:
+          'Collected runtime evidence from the real shell adapter for diagnostics.',
+      details: _buildRuntimeEvidenceDetails(
+        bundleKind: bundleKind,
+        health: health,
+        safeToExport: safeToExport,
+      ),
+    );
+  }
+
+  Future<ControllerCommandResult> _prepareExport(
+    ControllerCommand command,
+  ) async {
+    final bundleKind = command.arguments['bundleKind']?.toString();
+    final health = await checkHealth();
+    final safeToExport = _runtimePhase != ControllerRuntimePhase.failed &&
+        health.level != ControllerRuntimeHealthLevel.unavailable;
+
+    return ControllerCommandResult(
+      commandId: command.id,
+      accepted: true,
+      completedAt: DateTime.now(),
+      summary: safeToExport
+          ? 'Runtime evidence is prepared for export from the real shell adapter.'
+          : 'Runtime evidence is prepared with caution because runtime health is unavailable or failed.',
+      details: _buildRuntimeEvidenceDetails(
+        bundleKind: bundleKind,
+        health: health,
+        safeToExport: safeToExport,
+      ),
+    );
   }
 
   Future<ControllerCommandResult> _disconnect(ControllerCommand command) async {
@@ -455,5 +495,40 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
 
   void _markSessionUpdated() {
     _sessionUpdatedAt = DateTime.now();
+  }
+
+  Map<String, Object?> _buildRuntimeEvidenceDetails({
+    required String? bundleKind,
+    required ControllerRuntimeHealth health,
+    required bool safeToExport,
+  }) {
+    return <String, Object?>{
+      if (bundleKind != null) 'bundleKind': bundleKind,
+      'evidenceClass': _runningProcess != null
+          ? 'runtime-live-evidence'
+          : 'runtime-snapshot-evidence',
+      'backendKind': backendKind,
+      'backendVersion': backendVersion,
+      'binaryPathHint': binaryPathHint,
+      'transportEndpointHint': transportEndpointHint,
+      'runtimeMode': runtimeMode,
+      'runtimePhase': _runtimePhase.name,
+      'health': <String, Object?>{
+        'level': health.level.name,
+        'summary': health.summary,
+        'updatedAt': health.updatedAt.toIso8601String(),
+      },
+      'session': session.toJson(),
+      if (_lastLaunchPlan != null) 'launchPlan': _lastLaunchPlan!.toJson(),
+      'logTail': <String, Object?>{
+        'stdoutTail': List<String>.unmodifiable(_stdoutTail),
+        'stderrTail': List<String>.unmodifiable(_stderrTail),
+      },
+      'safeToExport': safeToExport,
+      'includesBinaryPathHint': true,
+      'includesLaunchPlan': _lastLaunchPlan != null,
+      'includesSessionEvidence': true,
+      'includesLogTail': true,
+    };
   }
 }

--- a/client/lib/features/packaging/application/packaging_store.dart
+++ b/client/lib/features/packaging/application/packaging_store.dart
@@ -9,7 +9,7 @@ import '../domain/update_workflow_state.dart';
 import 'packaging_dry_run_service.dart';
 
 class PackagingStore extends ChangeNotifier {
-  PackagingStore({UpdateChannel initialChannel = UpdateChannel.beta})
+  PackagingStore({UpdateChannel initialChannel = UpdateChannel.stable})
       : _state = UpdateWorkflowState.initial.copyWith(
           selectedChannel: initialChannel,
           rolloutPolicySummary: _rolloutPolicySummaryFor(initialChannel),
@@ -24,8 +24,7 @@ class PackagingStore extends ChangeNotifier {
   final List<PackagingExportRecord> _exportHistory = <PackagingExportRecord>[];
 
   // 不使用 const：列表内容在后续版本中可能被动态更新
-  final List<DesktopPackageStatus> _packageStatuses =
-      <DesktopPackageStatus>[
+  final List<DesktopPackageStatus> _packageStatuses = <DesktopPackageStatus>[
     const DesktopPackageStatus(
       platform: DesktopPackagePlatform.windows,
       readiness: DesktopPackageReadiness.scaffolded,
@@ -102,7 +101,7 @@ class PackagingStore extends ChangeNotifier {
     _state = _state.copyWith(
       installerSkeletonReady: true,
       lastCheckSummary:
-          'Packaging skeleton drafted; release truth + packaged smoke gates are now part of the current beta.3 posture.',
+          'Packaging skeleton drafted; release truth + packaged smoke gates are now part of the current stable posture.',
     );
     notifyListeners();
   }

--- a/client/lib/features/packaging/domain/update_workflow_state.dart
+++ b/client/lib/features/packaging/domain/update_workflow_state.dart
@@ -60,8 +60,8 @@ class UpdateWorkflowState {
   }
 
   static const UpdateWorkflowState initial = UpdateWorkflowState(
-    selectedChannel: UpdateChannel.beta,
-    currentVersionLabel: '1.4.0-beta.4',
+    selectedChannel: UpdateChannel.stable,
+    currentVersionLabel: '1.4.0',
     updateChecksEnabled: true,
     lastCheckSummary:
         'No update check has been executed in this shell environment yet.',

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: trojan_pro_client
 description: Desktop-first, mobile-ready client shell for Trojan-Pro.
 publish_to: "none"
-version: 1.4.0-beta.4+1
+version: 1.4.0+1
 
 environment:
   sdk: ^3.3.0

--- a/client/test/features/controller/application/real_shell_controller_adapter_test.dart
+++ b/client/test/features/controller/application/real_shell_controller_adapter_test.dart
@@ -35,6 +35,30 @@ ControllerCommand _disconnectCommand() {
   );
 }
 
+ControllerCommand _collectDiagnosticsCommand({String? bundleKind}) {
+  return ControllerCommand(
+    id: 'collect-diagnostics-1',
+    kind: ControllerCommandKind.collectDiagnostics,
+    issuedAt: DateTime.now(),
+    profileId: 'profile-demo',
+    arguments: <String, Object?>{
+      if (bundleKind != null) 'bundleKind': bundleKind,
+    },
+  );
+}
+
+ControllerCommand _prepareExportCommand({String? bundleKind}) {
+  return ControllerCommand(
+    id: 'prepare-export-1',
+    kind: ControllerCommandKind.prepareExport,
+    issuedAt: DateTime.now(),
+    profileId: 'profile-demo',
+    arguments: <String, Object?>{
+      if (bundleKind != null) 'bundleKind': bundleKind,
+    },
+  );
+}
+
 Future<File> _writeFakeTrojanScript(Directory tempDir) async {
   final script = File(
     '${tempDir.path}${Platform.pathSeparator}fake-trojan.py',
@@ -289,5 +313,64 @@ void main() {
 
     expect(adapter.session.phase, ControllerRuntimePhase.stopped);
     expect(adapter.session.activeConfigPath, isNull);
+  });
+
+  test('collectDiagnostics returns runtime evidence payload', () async {
+    final tempDir =
+        await Directory.systemTemp.createTemp('real-shell-adapter-evidence');
+    addTearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    final adapter = RealShellControllerAdapter(
+      binaryPathHint: '${tempDir.path}${Platform.pathSeparator}missing-trojan',
+      transportEndpointHint: 'local-controller://test',
+    );
+
+    final result = await adapter.execute(
+      _collectDiagnosticsCommand(bundleKind: 'support-bundle'),
+    );
+
+    expect(result.accepted, isTrue);
+    expect(result.error, isNull);
+    expect(result.details['bundleKind'], 'support-bundle');
+    expect(result.details['backendKind'], isNotNull);
+    expect(result.details['runtimeMode'], 'external-runtime-boundary');
+    expect(result.details['runtimePhase'], isNotNull);
+    expect(result.details['session'], isA<Map<String, Object?>>());
+    expect(result.details['health'], isA<Map<String, Object?>>());
+    expect(result.details['safeToExport'], isA<bool>());
+    expect(result.details['includesSessionEvidence'], isTrue);
+    expect(result.details['includesLogTail'], isTrue);
+  });
+
+  test('prepareExport is accepted and carries evidence contract fields',
+      () async {
+    final tempDir =
+        await Directory.systemTemp.createTemp('real-shell-adapter-export');
+    addTearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    final adapter = RealShellControllerAdapter(
+      binaryPathHint: '${tempDir.path}${Platform.pathSeparator}missing-trojan',
+      transportEndpointHint: 'local-controller://test',
+    );
+
+    final result = await adapter.execute(
+      _prepareExportCommand(bundleKind: 'runtime-proof-artifact'),
+    );
+
+    expect(result.accepted, isTrue);
+    expect(result.error, isNull);
+    expect(result.details['bundleKind'], 'runtime-proof-artifact');
+    expect(result.details['evidenceClass'], isNotNull);
+    expect(result.details['safeToExport'], isA<bool>());
+    expect(result.details['includesBinaryPathHint'], isTrue);
+    expect(result.details['includesSessionEvidence'], isTrue);
   });
 }

--- a/client/test/features/packaging/application/packaging_store_test.dart
+++ b/client/test/features/packaging/application/packaging_store_test.dart
@@ -4,21 +4,21 @@ import 'package:trojan_pro_client/features/packaging/domain/desktop_package_stat
 import 'package:trojan_pro_client/features/settings/domain/app_settings.dart';
 
 void main() {
-  test('initial packaging workflow reflects beta.3 release truth defaults', () {
+  test('initial packaging workflow reflects stable release truth defaults', () {
     final store = PackagingStore();
 
-    expect(store.state.selectedChannel, UpdateChannel.beta);
-    expect(store.state.currentVersionLabel, '1.4.0-beta.3');
+    expect(store.state.selectedChannel, UpdateChannel.stable);
+    expect(store.state.currentVersionLabel, '1.4.0');
   });
 
   test('stub update check records status and timestamp', () {
-    final store = PackagingStore(initialChannel: UpdateChannel.beta);
+    final store = PackagingStore(initialChannel: UpdateChannel.stable);
 
     store.runStubUpdateCheck();
 
     expect(store.state.lastUpdateCheckAt, isNotNull);
     expect(store.state.updateCheckStatusLabel, contains('Stub only'));
-    expect(store.state.lastCheckSummary, contains('beta'));
+    expect(store.state.lastCheckSummary, contains('stable'));
     expect(store.state.releaseMetadataContractVersion, 'v0-draft');
   });
 

--- a/client/test/features/packaging/presentation/packaging_page_test.dart
+++ b/client/test/features/packaging/presentation/packaging_page_test.dart
@@ -134,11 +134,12 @@ void main() {
     expect(find.text('Check for Updates (Stub)'), findsOneWidget);
     expect(find.textContaining('Metadata Contract'), findsOneWidget);
     expect(find.textContaining('Contract Version'), findsOneWidget);
-    expect(find.text('1.4.0-beta.3'), findsOneWidget);
-    expect(find.text('beta'), findsWidgets);
+    expect(find.text('1.4.0'), findsOneWidget);
+    expect(find.text('stable'), findsWidgets);
   });
 
-  testWidgets('packaging page reflects packaged smoke and release truth posture',
+  testWidgets(
+      'packaging page reflects packaged smoke and release truth posture',
       (WidgetTester tester) async {
     await _setDesktopSurface(tester);
     final services = _buildServices();
@@ -154,9 +155,13 @@ void main() {
 
     expect(find.textContaining('release truth + packaged smoke gates'),
         findsOneWidget);
-    expect(find.textContaining('Validated locally; packaged smoke gate is in place'),
+    expect(
+        find.textContaining(
+            'Validated locally; packaged smoke gate is in place'),
         findsOneWidget);
-    expect(find.textContaining('packaged smoke gate is wired in CI'), findsNWidgets(2));
-    expect(find.textContaining('before CI/runtime validation exists'), findsNothing);
+    expect(find.textContaining('packaged smoke gate is wired in CI'),
+        findsNWidgets(2));
+    expect(find.textContaining('before CI/runtime validation exists'),
+        findsNothing);
   });
 }

--- a/docs/client-packaging-readiness.md
+++ b/docs/client-packaging-readiness.md
@@ -2,7 +2,7 @@
 
 ## Current answer
 
-Desktop client packaging is now **real**, and the current `v1.4.0-beta.3` lane has **executable CI gates** for release truth and packaged smoke.
+Desktop client packaging is now **real**, and the current `v1.4.0` stable lane has **executable CI gates** for release truth and packaged smoke.
 
 ## Verified status
 
@@ -45,7 +45,7 @@ cd ..
 python3 scripts/validate_client_release_truth.py
 python3 scripts/client_packaged_smoke.py \
   --platform linux \
-  --artifact-root packaging/linux/artifacts/v1.4.0-beta.3 \
+  --artifact-root packaging/linux/artifacts/v1.4.0 \
   --mode smoke \
   --allow-skip
 ```

--- a/docs/client-runtime-smoke-test.md
+++ b/docs/client-runtime-smoke-test.md
@@ -37,7 +37,7 @@ Automation helpers:
 # packaged desktop smoke (artifact-first)
 python3 scripts/client_packaged_smoke.py \
   --platform linux \
-  --artifact-root packaging/linux/artifacts/v1.4.0-beta.3 \
+  --artifact-root packaging/linux/artifacts/v1.4.0 \
   --mode smoke
 ```
 
@@ -176,7 +176,7 @@ Expected:
 
 ## Packaged smoke policy
 
-For `v1.4.0-beta.3`, packaged smoke is intentionally narrower than the full manual runtime checklist above.
+For `v1.4.0`, packaged smoke is intentionally narrower than the full manual runtime checklist above.
 
 Latest runner-backed result:
 - `Client Packaging` run `24404269034` is green on all desktop packaged smoke lanes (macOS/Linux/Windows)

--- a/docs/v1.4.0-release-gates.md
+++ b/docs/v1.4.0-release-gates.md
@@ -22,8 +22,8 @@ Support truth is now materially stronger than the earlier beta line: the main fa
 
 ## Gate 3 — Release truth
 - [x] client asset version metadata matches release tag semantics *(validated by `scripts/validate_client_release_truth.py` across pubspec / packaging metadata / workflow state)*
-- [x] product-visible version/channel matches shipped release metadata *(current candidate truth aligned to `1.4.0-beta.3`)*
-- [x] release notes / known limitations reflect actual runtime posture *(current-state docs updated to `beta.3` posture rather than lingering on `beta.1` / `beta.2` drift)*
+- [x] product-visible version/channel matches shipped release metadata *(current candidate truth aligned to `1.4.0` stable release metadata)*
+- [x] release notes / known limitations reflect actual runtime posture *(current-state docs track the stable `v1.4.0` posture and avoid legacy beta drift)*
 
 ### Current snapshot — 2026-04-14
 Release truth is no longer just a documentation aspiration. The candidate now has an executable release-truth check that fails when pubspec, packaging metadata, and product-visible workflow state drift apart.

--- a/packaging/linux/release-metadata.env
+++ b/packaging/linux/release-metadata.env
@@ -9,9 +9,9 @@ DESKTOP_STARTUP_WM_CLASS="trojan_pro_client"
 ICON_NAME="trojan-pro-client"
 ICON_SOURCE="packaging/linux/assets/trojan-pro-client.png"
 
-CHANNEL="beta"
-VERSION_LABEL="1.4.0-beta.4"
-DEB_VERSION="1.4.0~beta.4-1"
+CHANNEL="stable"
+VERSION_LABEL="1.4.0"
+DEB_VERSION="1.4.0-1"
 PACKAGE_ARCH="amd64"
 ARTIFACT_STEM="trojan-pro-client"
 

--- a/scripts/tests/test_client_packaged_smoke.py
+++ b/scripts/tests/test_client_packaged_smoke.py
@@ -28,7 +28,7 @@ class ClientPackagedSmokeTest(unittest.TestCase):
     def test_resolves_linux_packaged_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            artifact = root / 'trojan-pro-client_1.4.0-beta.3_linux-x64-bundle.tar.gz'
+            artifact = root / 'trojan-pro-client_1.4.0_linux-x64-bundle.tar.gz'
             artifact.write_text('')
 
             self.assertEqual(resolve_packaged_artifact('linux', root), artifact)
@@ -44,7 +44,7 @@ class ClientPackagedSmokeTest(unittest.TestCase):
     def test_resolves_windows_packaged_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            artifact = root / 'trojan-pro-client_1.4.0-beta.3_windows-x64.zip'
+            artifact = root / 'trojan-pro-client_1.4.0_windows-x64.zip'
             artifact.write_text('')
 
             self.assertEqual(resolve_packaged_artifact('windows', root), artifact)
@@ -62,7 +62,7 @@ class ClientPackagedSmokeTest(unittest.TestCase):
     def test_resolves_macos_packaged_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            artifact = root / 'trojan-pro-client_1.4.0-beta.3_macos-app.zip'
+            artifact = root / 'trojan-pro-client_1.4.0_macos-app.zip'
             artifact.write_text('')
 
             self.assertEqual(resolve_packaged_artifact('macos', root), artifact)
@@ -75,7 +75,7 @@ class ClientPackagedSmokeTest(unittest.TestCase):
             binary = bundle_dir / 'trojan_pro_client'
             binary.write_text('')
             binary.chmod(0o755)
-            artifact = root / 'trojan-pro-client_1.4.0-beta.3_linux-x64-bundle.tar.gz'
+            artifact = root / 'trojan-pro-client_1.4.0_linux-x64-bundle.tar.gz'
             with tarfile.open(artifact, 'w:gz') as archive:
                 archive.add(bundle_dir, arcname=bundle_dir.name)
 
@@ -90,7 +90,7 @@ class ClientPackagedSmokeTest(unittest.TestCase):
     def test_extracts_windows_zip_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            artifact = root / 'trojan-pro-client_1.4.0-beta.3_windows-x64.zip'
+            artifact = root / 'trojan-pro-client_1.4.0_windows-x64.zip'
             with zipfile.ZipFile(artifact, 'w') as archive:
                 archive.writestr('Trojan Pro Client.exe', '')
 
@@ -105,7 +105,7 @@ class ClientPackagedSmokeTest(unittest.TestCase):
     def test_extracts_macos_zip_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            artifact = root / 'trojan-pro-client_1.4.0-beta.3_macos-app.zip'
+            artifact = root / 'trojan-pro-client_1.4.0_macos-app.zip'
             with zipfile.ZipFile(artifact, 'w') as archive:
                 info = zipfile.ZipInfo(
                     'Trojan Pro Client.app/Contents/MacOS/Trojan Pro Client',
@@ -130,7 +130,7 @@ class ClientPackagedSmokeTest(unittest.TestCase):
     def test_extracts_macos_zip_symlinks(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            artifact = root / 'trojan-pro-client_1.4.0-beta.3_macos-app.zip'
+            artifact = root / 'trojan-pro-client_1.4.0_macos-app.zip'
             link_path = 'trojan_pro_client.app/Contents/Frameworks/App.framework/Versions/Current'
             with zipfile.ZipFile(artifact, 'w') as archive:
                 app_binary = zipfile.ZipInfo(

--- a/scripts/tests/test_validate_client_release_truth.py
+++ b/scripts/tests/test_validate_client_release_truth.py
@@ -20,19 +20,19 @@ class ReleaseTruthValidationTest(unittest.TestCase):
             metadata = root / 'release-metadata.env'
             workflow_state = root / 'update_workflow_state.dart'
 
-            pubspec.write_text('version: 1.4.0-beta.3+1\n')
-            metadata.write_text('VERSION_LABEL="1.4.0-beta.3"\n')
+            pubspec.write_text('version: 1.4.0+1\n')
+            metadata.write_text('VERSION_LABEL="1.4.0"\n')
             workflow_state.write_text(textwrap.dedent('''
                 static const UpdateWorkflowState initial = UpdateWorkflowState(
-                  currentVersionLabel: '1.4.0-beta.3',
+                  currentVersionLabel: '1.4.0',
                 );
             '''))
 
-            self.assertEqual(parse_pubspec_version_label(pubspec), '1.4.0-beta.3')
-            self.assertEqual(parse_release_metadata_label(metadata), '1.4.0-beta.3')
+            self.assertEqual(parse_pubspec_version_label(pubspec), '1.4.0')
+            self.assertEqual(parse_release_metadata_label(metadata), '1.4.0')
             self.assertEqual(
                 parse_update_workflow_state_label(workflow_state),
-                '1.4.0-beta.3',
+                '1.4.0',
             )
 
     def test_rejects_mismatched_release_truth(self) -> None:
@@ -42,9 +42,9 @@ class ReleaseTruthValidationTest(unittest.TestCase):
             metadata = root / 'release-metadata.env'
             workflow_state = root / 'update_workflow_state.dart'
 
-            pubspec.write_text('version: 1.4.0-beta.3+1\n')
-            metadata.write_text('VERSION_LABEL="1.4.0-beta.2"\n')
-            workflow_state.write_text("currentVersionLabel: '1.4.0-beta.3',\n")
+            pubspec.write_text('version: 1.4.0+1\n')
+            metadata.write_text('VERSION_LABEL="1.3.9"\n')
+            workflow_state.write_text("currentVersionLabel: '1.4.0',\n")
 
             with self.assertRaises(ReleaseTruthMismatch) as ctx:
                 validate_release_truth(


### PR DESCRIPTION
## Summary
- promote client release truth from beta to stable `1.4.0`
- implement real-shell adapter handling for `collectDiagnostics` / `prepareExport`
- add Flutter domain/application test gates in CI workflows
- align packaging/docs/script tests with stable artifact/version semantics

## Changes
- Runtime adapter:
  - `collectDiagnostics` and `prepareExport` now accepted and return runtime evidence payload
  - add evidence details contract for diagnostics/export path
- Release truth:
  - `client/pubspec.yaml` -> `1.4.0+1`
  - `packaging/linux/release-metadata.env` -> `CHANNEL=stable`, `VERSION_LABEL=1.4.0`, `DEB_VERSION=1.4.0-1`
  - `update_workflow_state` and `packaging_store` defaults switched to stable
- CI:
  - add Flutter targeted test gate in `ci-smoke.yml`
  - add Flutter targeted test step in `client-packaging.yml`
- Tests/docs/scripts:
  - update packaging UI/store tests to stable assertions
  - update script unit tests from beta artifact names to stable names
  - refresh docs wording/examples from beta lane to stable lane

## Verification (local)
- `flutter analyze` (client): pass
- `flutter test` targeted suite: pass
- `python3 scripts/validate_client_release_truth.py`: pass
- `python3 -m unittest scripts.tests.test_validate_client_release_truth scripts.tests.test_client_packaged_smoke`: pass
- `python3 scripts/client_packaged_smoke.py --platform linux --artifact-root packaging/linux/artifacts/v1.4.0 --mode smoke --allow-skip`
  - expected skip in headless env: `linux packaged smoke requires DISPLAY/WAYLAND_DISPLAY or xvfb-run`

## Notes
- This PR intentionally keeps `--allow-skip` semantics for headless smoke environments and relies on CI runner display capabilities for non-skip execution.
