### PR TITLE
feat(client): integrate v1.5.0 routing profile kernel into client data/control/diagnostics paths

### DIFF
--- a/client/lib/features/controller/application/adapter_backed_client_controller.dart
+++ b/client/lib/features/controller/application/adapter_backed_client_controller.dart
@@ -6,6 +6,7 @@ import '../../../platform/services/client_filesystem_layout.dart';
 import '../../../platform/services/local_state_store.dart';
 import '../../profiles/application/profile_secrets_service.dart';
 import '../../profiles/domain/client_profile.dart';
+import '../../routing/application/routing_profile_codec.dart';
 import '../domain/client_connection_status.dart';
 import '../domain/client_controller_event.dart';
 import '../domain/controller_command.dart';
@@ -25,11 +26,13 @@ class AdapterBackedClientController extends ClientControllerApi {
     required ProfileSecretsService profileSecrets,
     LocalStateStore? localStateStore,
     ClientFilesystemLayout? filesystemLayout,
+    RoutingProfileCodec? routingCodec,
     Duration sessionPollInterval = const Duration(milliseconds: 600),
   })  : _adapter = adapter,
         _profileSecrets = profileSecrets,
         _localStateStore = localStateStore,
-        _filesystemLayout = filesystemLayout {
+        _filesystemLayout = filesystemLayout,
+        _routingCodec = routingCodec ?? const RoutingProfileCodec() {
     _lastSessionUpdatedAt = _adapter.session.updatedAt;
     _sessionWatcher = Timer.periodic(sessionPollInterval, (_) {
       final session = _adapter.session;
@@ -51,6 +54,7 @@ class AdapterBackedClientController extends ClientControllerApi {
   final ProfileSecretsService _profileSecrets;
   final LocalStateStore? _localStateStore;
   final ClientFilesystemLayout? _filesystemLayout;
+  final RoutingProfileCodec _routingCodec;
   late final Timer _sessionWatcher;
   DateTime? _lastSessionUpdatedAt;
   int _operationCounter = 0;
@@ -242,6 +246,7 @@ class AdapterBackedClientController extends ClientControllerApi {
           'sni': profile.sni,
           'verifyTls': profile.verifyTls,
           'configPath': _configPathFor(profile.id),
+          'routing': _routingCodec.encodeToJsonMap(profile.routing),
         },
         secretArguments: <String, String>{
           'trojanPassword': password,
@@ -467,10 +472,8 @@ class AdapterBackedClientController extends ClientControllerApi {
         'Launch plan accepted. Starting runtime process.',
       ControllerRuntimePhase.alive =>
         'Runtime process is alive. Waiting for session-ready signal.',
-      ControllerRuntimePhase.sessionReady =>
-        commandResult.summary,
-      ControllerRuntimePhase.failed =>
-        commandResult.summary,
+      ControllerRuntimePhase.sessionReady => commandResult.summary,
+      ControllerRuntimePhase.failed => commandResult.summary,
       ControllerRuntimePhase.stopped =>
         'Launch accepted. Waiting for runtime state update.',
     };
@@ -480,7 +483,8 @@ class AdapterBackedClientController extends ClientControllerApi {
     ControllerRuntimeSession runtimeSession,
     ControllerCommandResult commandResult,
   ) {
-    final pidSuffix = runtimeSession.pid == null ? '' : ' (pid=${runtimeSession.pid})';
+    final pidSuffix =
+        runtimeSession.pid == null ? '' : ' (pid=${runtimeSession.pid})';
     if (runtimeSession.stopRequested) {
       return 'Stop requested$pidSuffix. Waiting for the runtime process to exit cleanly.';
     }
@@ -540,8 +544,7 @@ class AdapterBackedClientController extends ClientControllerApi {
             'Runtime launch reported a failure state.',
           ControllerRuntimePhase.stopped =>
             'Launch accepted. Waiting for runtime process to start.',
-          ControllerRuntimePhase.sessionReady =>
-            'Runtime session is ready.',
+          ControllerRuntimePhase.sessionReady => 'Runtime session is ready.',
         };
 
         if (_status.message != progressSummary) {
@@ -1024,7 +1027,8 @@ class _PersistedRuntimeSnapshot {
     final sessionPid = value['sessionPid'];
     final sessionActiveConfigPath = value['sessionActiveConfigPath'];
     final sessionConfigProvenance = value['sessionConfigProvenance'];
-    final sessionExpectedLocalSocksPort = value['sessionExpectedLocalSocksPort'];
+    final sessionExpectedLocalSocksPort =
+        value['sessionExpectedLocalSocksPort'];
     final sessionLaunchPlanSummary = value['sessionLaunchPlanSummary'];
     final sessionLastExitCode = value['sessionLastExitCode'];
     final sessionLastError = value['sessionLastError'];
@@ -1051,7 +1055,8 @@ class _PersistedRuntimeSnapshot {
       statusUpdatedAt: parsedStatusUpdatedAt,
       sessionPhase: sessionPhase is String ? sessionPhase : 'stopped',
       sessionIsRunning: sessionIsRunning,
-      sessionStopRequested: sessionStopRequested is bool ? sessionStopRequested : false,
+      sessionStopRequested:
+          sessionStopRequested is bool ? sessionStopRequested : false,
       sessionStopRequestedAt: sessionStopRequestedAt is String
           ? DateTime.tryParse(sessionStopRequestedAt)
           : null,
@@ -1060,8 +1065,9 @@ class _PersistedRuntimeSnapshot {
           sessionActiveConfigPath is String ? sessionActiveConfigPath : null,
       sessionConfigProvenance:
           sessionConfigProvenance is String ? sessionConfigProvenance : null,
-      sessionExpectedLocalSocksPort:
-          sessionExpectedLocalSocksPort is int ? sessionExpectedLocalSocksPort : null,
+      sessionExpectedLocalSocksPort: sessionExpectedLocalSocksPort is int
+          ? sessionExpectedLocalSocksPort
+          : null,
       sessionLaunchPlanSummary:
           sessionLaunchPlanSummary is String ? sessionLaunchPlanSummary : null,
       sessionLastExitCode:

--- a/client/lib/features/controller/application/real_shell_connect_planner.dart
+++ b/client/lib/features/controller/application/real_shell_connect_planner.dart
@@ -1,4 +1,5 @@
 import '../../profiles/domain/client_profile.dart';
+import '../../routing/application/routing_profile_codec.dart';
 import '../domain/controller_command.dart';
 
 class RealShellConnectPlannerInput {
@@ -14,7 +15,10 @@ class RealShellConnectPlannerInput {
 }
 
 class RealShellConnectPlanner {
-  const RealShellConnectPlanner();
+  RealShellConnectPlanner({RoutingProfileCodec? routingCodec})
+      : _routingCodec = routingCodec ?? const RoutingProfileCodec();
+
+  final RoutingProfileCodec _routingCodec;
 
   RealShellConnectPlannerInput? parse(ControllerCommand command) {
     final profileName = command.arguments['profileName'] as String?;
@@ -46,6 +50,7 @@ class RealShellConnectPlanner {
         localSocksPort: localSocksPort,
         verifyTls: verifyTls ?? true,
         updatedAt: command.issuedAt,
+        routing: _routingCodec.decodeFromObject(command.arguments['routing']),
       ),
       configPath: configPath,
       password: password,

--- a/client/lib/features/controller/application/real_shell_controller_adapter.dart
+++ b/client/lib/features/controller/application/real_shell_controller_adapter.dart
@@ -34,8 +34,8 @@ class RealShellControllerAdapter implements ShellControllerAdapter {
                     : binaryPathHint,
               ),
             ),
-        _connectPlanner = connectPlanner ?? const RealShellConnectPlanner(),
-        _configRenderer = configRenderer ?? const TrojanClientConfigRenderer();
+        _connectPlanner = connectPlanner ?? RealShellConnectPlanner(),
+        _configRenderer = configRenderer ?? TrojanClientConfigRenderer();
 
   final String binaryPathHint;
   final String transportEndpointHint;

--- a/client/lib/features/controller/application/trojan_client_config_renderer.dart
+++ b/client/lib/features/controller/application/trojan_client_config_renderer.dart
@@ -1,9 +1,13 @@
 import 'dart:convert';
 
 import '../../profiles/domain/client_profile.dart';
+import '../../routing/application/routing_profile_codec.dart';
 
 class TrojanClientConfigRenderer {
-  const TrojanClientConfigRenderer();
+  TrojanClientConfigRenderer({RoutingProfileCodec? routingCodec})
+      : _routingCodec = routingCodec ?? const RoutingProfileCodec();
+
+  final RoutingProfileCodec _routingCodec;
 
   String render({
     required ClientProfile profile,
@@ -37,6 +41,7 @@ class TrojanClientConfigRenderer {
         'fast_open': false,
         'fast_open_qlen': 20,
       },
+      'routing': _routingCodec.encodeToJsonMap(profile.routing),
     };
 
     return const JsonEncoder.withIndent('  ').convert(payload);

--- a/client/lib/features/diagnostics/application/diagnostics_export_service.dart
+++ b/client/lib/features/diagnostics/application/diagnostics_export_service.dart
@@ -104,6 +104,13 @@ class DiagnosticsExportService {
               'serverPort': selected.serverPort,
               'sni': selected.sni,
               'hasStoredPassword': selected.hasStoredPassword,
+              'routing': {
+                'mode': selected.routing.mode.name,
+                'defaultAction': selected.routing.defaultAction.name,
+                'globalAction': selected.routing.globalAction.name,
+                'ruleCount': selected.routing.rules.length,
+                'policyGroupCount': selected.routing.policyGroups.length,
+              },
             },
       'readiness': readinessReport.toJson(),
       'controller': {

--- a/client/lib/features/profiles/application/profile_portability_service.dart
+++ b/client/lib/features/profiles/application/profile_portability_service.dart
@@ -1,9 +1,15 @@
 import 'dart:convert';
 
+import '../../routing/application/routing_profile_codec.dart';
 import '../domain/client_profile.dart';
 import 'profile_import_bundle.dart';
 
 class ProfilePortabilityService {
+  ProfilePortabilityService({RoutingProfileCodec? routingCodec})
+      : _routingCodec = routingCodec ?? const RoutingProfileCodec();
+
+  final RoutingProfileCodec _routingCodec;
+
   Map<String, Object?> _profilePayload(ClientProfile profile) {
     return <String, Object?>{
       'id': profile.id,
@@ -15,6 +21,7 @@ class ProfilePortabilityService {
       'verifyTls': profile.verifyTls,
       'notes': profile.notes,
       'updatedAt': profile.updatedAt.toIso8601String(),
+      'routing': _routingCodec.encodeToJsonMap(profile.routing),
     };
   }
 
@@ -28,7 +35,7 @@ class ProfilePortabilityService {
 
   String exportProfile(ClientProfile profile) {
     final payload = <String, Object?>{
-      'version': 1,
+      'version': 2,
       'kind': 'trojan-pro-client-profile',
       'profile': _profilePayload(profile),
       'secrets': _secretsPayload(profile),
@@ -39,7 +46,7 @@ class ProfilePortabilityService {
 
   String exportProfiles(List<ClientProfile> profiles) {
     final payload = <String, Object?>{
-      'version': 1,
+      'version': 2,
       'kind': 'trojan-pro-client-profile-bundle',
       'profiles': profiles
           .map(
@@ -75,6 +82,7 @@ class ProfilePortabilityService {
         updatedAt: DateTime.tryParse((profile['updatedAt'] as String?) ?? '') ??
             DateTime.now(),
         hasStoredPassword: false,
+        routing: _routingCodec.decodeFromObject(profile['routing']),
       ),
       trojanPasswordIncluded:
           (secrets['trojanPasswordIncluded'] as bool?) ?? false,

--- a/client/lib/features/profiles/application/profile_serialization.dart
+++ b/client/lib/features/profiles/application/profile_serialization.dart
@@ -1,26 +1,36 @@
 import 'dart:convert';
 
+import '../../routing/application/routing_profile_codec.dart';
+import '../../routing/domain/routing_models.dart';
+import '../../routing/domain/routing_profile_config.dart';
 import '../domain/client_profile.dart';
 
 class ProfileSerialization {
+  ProfileSerialization({RoutingProfileCodec? routingCodec})
+      : _routingCodec = routingCodec ?? const RoutingProfileCodec();
+
+  final RoutingProfileCodec _routingCodec;
+
   List<ClientProfile> decodeProfileList(String text) {
     final decoded = jsonDecode(text) as Map<String, dynamic>;
     final items = (decoded['profiles'] as List<dynamic>? ?? const <dynamic>[])
-        .cast<Map<String, dynamic>>();
-    return items.map(_fromJson).toList();
+        .whereType<Map>()
+        .map((raw) => Map<String, dynamic>.from(raw));
+    return items.map(_fromJson).toList(growable: false);
   }
 
   String encodeProfileList(List<ClientProfile> profiles) {
     final payload = <String, Object?>{
-      'version': 1,
-      'profiles': profiles.map(_toJson).toList(),
+      'version': 2,
+      'profiles': profiles.map(_toJson).toList(growable: false),
     };
     return const JsonEncoder.withIndent('  ').convert(payload);
   }
 
   ClientProfile _fromJson(Map<String, dynamic> json) {
     return ClientProfile(
-      id: (json['id'] as String?) ?? 'profile-${DateTime.now().microsecondsSinceEpoch}',
+      id: (json['id'] as String?) ??
+          'profile-${DateTime.now().microsecondsSinceEpoch}',
       name: (json['name'] as String?) ?? 'Imported Profile',
       serverHost: (json['serverHost'] as String?) ?? 'example.com',
       serverPort: (json['serverPort'] as num?)?.toInt() ?? 443,
@@ -28,8 +38,10 @@ class ProfileSerialization {
       localSocksPort: (json['localSocksPort'] as num?)?.toInt() ?? 1080,
       verifyTls: (json['verifyTls'] as bool?) ?? true,
       notes: (json['notes'] as String?) ?? '',
-      updatedAt: DateTime.tryParse((json['updatedAt'] as String?) ?? '') ?? DateTime.now(),
+      updatedAt: DateTime.tryParse((json['updatedAt'] as String?) ?? '') ??
+          DateTime.now(),
       hasStoredPassword: (json['hasStoredPassword'] as bool?) ?? false,
+      routing: _routingCodec.decodeFromObject(json['routing']),
     );
   }
 
@@ -45,6 +57,43 @@ class ProfileSerialization {
       'notes': profile.notes,
       'updatedAt': profile.updatedAt.toIso8601String(),
       'hasStoredPassword': profile.hasStoredPassword,
+      'routing': _routingCodec.encodeToJsonMap(
+        _normalizeRouting(profile.routing),
+      ),
     };
+  }
+
+  RoutingProfileConfig _normalizeRouting(RoutingProfileConfig routing) {
+    final validGroupIds = routing.policyGroups.map((group) => group.id).toSet();
+    final normalizedRules = routing.rules.map((rule) {
+      if (!rule.action.usesPolicyGroup) {
+        return rule;
+      }
+      final targetGroupId = rule.action.policyGroupId!.trim();
+      if (validGroupIds.contains(targetGroupId)) {
+        return rule;
+      }
+      return RoutingRule(
+        id: rule.id,
+        name: rule.name,
+        enabled: rule.enabled,
+        priority: rule.priority,
+        match: rule.match,
+        action: RoutingRuleAction.direct(routing.defaultAction),
+      );
+    }).toList(growable: false)
+      ..sort((a, b) {
+        final byPriority = a.priority.compareTo(b.priority);
+        if (byPriority != 0) return byPriority;
+        return a.id.compareTo(b.id);
+      });
+
+    return RoutingProfileConfig(
+      mode: routing.mode,
+      defaultAction: routing.defaultAction,
+      globalAction: routing.globalAction,
+      policyGroups: List<RoutingPolicyGroup>.unmodifiable(routing.policyGroups),
+      rules: List<RoutingRule>.unmodifiable(normalizedRules),
+    );
   }
 }

--- a/client/lib/features/profiles/domain/client_profile.dart
+++ b/client/lib/features/profiles/domain/client_profile.dart
@@ -1,3 +1,5 @@
+import '../../routing/domain/routing_profile_config.dart';
+
 class ClientProfile {
   const ClientProfile({
     required this.id,
@@ -10,6 +12,7 @@ class ClientProfile {
     required this.updatedAt,
     this.notes = '',
     this.hasStoredPassword = false,
+    this.routing = RoutingProfileConfig.defaults,
   });
 
   final String id;
@@ -22,6 +25,7 @@ class ClientProfile {
   final String notes;
   final DateTime updatedAt;
   final bool hasStoredPassword;
+  final RoutingProfileConfig routing;
 
   ClientProfile copyWith({
     String? id,
@@ -34,6 +38,7 @@ class ClientProfile {
     String? notes,
     DateTime? updatedAt,
     bool? hasStoredPassword,
+    RoutingProfileConfig? routing,
   }) {
     return ClientProfile(
       id: id ?? this.id,
@@ -46,6 +51,7 @@ class ClientProfile {
       notes: notes ?? this.notes,
       updatedAt: updatedAt ?? this.updatedAt,
       hasStoredPassword: hasStoredPassword ?? this.hasStoredPassword,
+      routing: routing ?? this.routing,
     );
   }
 
@@ -63,7 +69,8 @@ class ClientProfile {
           verifyTls == other.verifyTls &&
           notes == other.notes &&
           updatedAt == other.updatedAt &&
-          hasStoredPassword == other.hasStoredPassword;
+          hasStoredPassword == other.hasStoredPassword &&
+          routing == other.routing;
 
   @override
   int get hashCode => Object.hash(
@@ -77,5 +84,6 @@ class ClientProfile {
         notes,
         updatedAt,
         hasStoredPassword,
+        routing,
       );
 }

--- a/client/lib/features/routing/application/routing_decision_engine.dart
+++ b/client/lib/features/routing/application/routing_decision_engine.dart
@@ -1,0 +1,266 @@
+import 'dart:io';
+
+import '../domain/routing_models.dart';
+
+class RoutingDecisionEngine {
+  const RoutingDecisionEngine();
+
+  RoutingDecision resolve({
+    required RoutingProfile profile,
+    required RoutingRequestMetadata request,
+  }) {
+    switch (profile.mode) {
+      case RoutingMode.direct:
+        return const RoutingDecision(
+          action: RoutingAction.direct,
+          explain: 'mode=direct -> action=direct',
+        );
+      case RoutingMode.global:
+        return RoutingDecision(
+          action: profile.globalAction,
+          explain: 'mode=global -> action=${profile.globalAction.name}',
+        );
+      case RoutingMode.rule:
+        break;
+    }
+
+    final sortedRules = profile.rules.where((rule) => rule.enabled).toList()
+      ..sort((a, b) {
+        final byPriority = a.priority.compareTo(b.priority);
+        if (byPriority != 0) return byPriority;
+        return a.id.compareTo(b.id);
+      });
+
+    for (final rule in sortedRules) {
+      final matchResult = _matchesRule(rule.match, request);
+      if (!matchResult.matched) {
+        continue;
+      }
+
+      if (rule.action.usesPolicyGroup) {
+        final policyGroupId = rule.action.policyGroupId!.trim();
+        final policyGroup = _findPolicyGroup(profile, policyGroupId);
+        if (policyGroup != null) {
+          return RoutingDecision(
+            action: policyGroup.action,
+            matchedRuleId: rule.id,
+            policyGroupId: policyGroup.id,
+            explain:
+                'mode=rule matchedRule=${rule.id} ${matchResult.explain} -> policyGroup=${policyGroup.id} action=${policyGroup.action.name}',
+          );
+        }
+
+        return RoutingDecision(
+          action: profile.defaultAction,
+          matchedRuleId: rule.id,
+          policyGroupId: policyGroupId,
+          explain:
+              'mode=rule matchedRule=${rule.id} ${matchResult.explain} -> missingPolicyGroup=$policyGroupId fallback=defaultAction:${profile.defaultAction.name}',
+        );
+      }
+
+      final directAction = rule.action.directAction ?? profile.defaultAction;
+      return RoutingDecision(
+        action: directAction,
+        matchedRuleId: rule.id,
+        explain:
+            'mode=rule matchedRule=${rule.id} ${matchResult.explain} -> action=${directAction.name}',
+      );
+    }
+
+    return RoutingDecision(
+      action: profile.defaultAction,
+      explain:
+          'mode=rule no_rule_matched -> defaultAction=${profile.defaultAction.name}',
+    );
+  }
+
+  RoutingPolicyGroup? _findPolicyGroup(
+    RoutingProfile profile,
+    String policyGroupId,
+  ) {
+    for (final policyGroup in profile.policyGroups) {
+      if (policyGroup.id == policyGroupId) {
+        return policyGroup;
+      }
+    }
+    return null;
+  }
+
+  _RoutingRuleMatchResult _matchesRule(
+    RoutingRuleMatch match,
+    RoutingRequestMetadata request,
+  ) {
+    if (!match.hasAnyConstraint) {
+      return const _RoutingRuleMatchResult.noMatch();
+    }
+
+    final explainTokens = <String>[];
+    final normalizedHost = _normalizeHost(request.host);
+
+    final domainExact = _normalizeMaybe(match.domainExact);
+    if (domainExact != null) {
+      if (normalizedHost != domainExact) {
+        return const _RoutingRuleMatchResult.noMatch();
+      }
+      explainTokens.add('domainExact=$domainExact');
+    }
+
+    final domainSuffixRaw = _normalizeMaybe(match.domainSuffix);
+    if (domainSuffixRaw != null) {
+      final domainSuffix = _normalizeSuffix(domainSuffixRaw);
+      final suffixMatch = normalizedHost.endsWith(domainSuffix) ||
+          normalizedHost == domainSuffix.substring(1);
+      if (!suffixMatch) {
+        return const _RoutingRuleMatchResult.noMatch();
+      }
+      explainTokens.add('domainSuffix=$domainSuffixRaw');
+    }
+
+    final domainKeyword = _normalizeMaybe(match.domainKeyword);
+    if (domainKeyword != null) {
+      if (!normalizedHost.contains(domainKeyword)) {
+        return const _RoutingRuleMatchResult.noMatch();
+      }
+      explainTokens.add('domainKeyword=$domainKeyword');
+    }
+
+    final domainRegex = _normalizeMaybe(match.domainRegex);
+    if (domainRegex != null) {
+      RegExp regex;
+      try {
+        regex = RegExp(domainRegex, caseSensitive: false);
+      } on FormatException {
+        return const _RoutingRuleMatchResult.noMatch();
+      }
+      if (!regex.hasMatch(request.host)) {
+        return const _RoutingRuleMatchResult.noMatch();
+      }
+      explainTokens.add('domainRegex=$domainRegex');
+    }
+
+    final ipCidr = _normalizeMaybe(match.ipCidr);
+    if (ipCidr != null) {
+      final requestIp = _normalizeMaybe(request.ip);
+      if (requestIp == null || !_ipInCidr(requestIp, ipCidr)) {
+        return const _RoutingRuleMatchResult.noMatch();
+      }
+      explainTokens.add('ipCidr=$ipCidr');
+    }
+
+    if (match.port != null) {
+      if (request.port != match.port) {
+        return const _RoutingRuleMatchResult.noMatch();
+      }
+      explainTokens.add('port=${match.port}');
+    }
+
+    final expectedProtocol = _normalizeMaybe(match.protocol);
+    if (expectedProtocol != null) {
+      final protocol = _normalizeMaybe(request.protocol) ?? '';
+      if (protocol != expectedProtocol) {
+        return const _RoutingRuleMatchResult.noMatch();
+      }
+      explainTokens.add('protocol=$expectedProtocol');
+    }
+
+    final expectedProcessName = _normalizeMaybe(match.processName);
+    if (expectedProcessName != null) {
+      final processName = _normalizeMaybe(request.processName);
+      if (processName != expectedProcessName) {
+        return const _RoutingRuleMatchResult.noMatch();
+      }
+      explainTokens.add('processName=$expectedProcessName');
+    }
+
+    final expectedProcessPath = _normalizeMaybe(match.processPath);
+    if (expectedProcessPath != null) {
+      final processPath = _normalizeMaybe(request.processPath);
+      if (processPath != expectedProcessPath) {
+        return const _RoutingRuleMatchResult.noMatch();
+      }
+      explainTokens.add('processPath=$expectedProcessPath');
+    }
+
+    return _RoutingRuleMatchResult.match(explainTokens.join(' '));
+  }
+
+  String _normalizeHost(String host) {
+    final value = host.trim().toLowerCase();
+    if (value.endsWith('.')) {
+      return value.substring(0, value.length - 1);
+    }
+    return value;
+  }
+
+  String _normalizeSuffix(String suffix) {
+    final value = suffix.trim().toLowerCase();
+    if (value.startsWith('.')) {
+      return value;
+    }
+    return '.$value';
+  }
+
+  String? _normalizeMaybe(String? value) {
+    if (value == null) return null;
+    final normalized = value.trim().toLowerCase();
+    if (normalized.isEmpty) return null;
+    return normalized;
+  }
+
+  bool _ipInCidr(String ipValue, String cidrValue) {
+    final delimiter = cidrValue.indexOf('/');
+    if (delimiter <= 0 || delimiter == cidrValue.length - 1) {
+      return false;
+    }
+
+    final networkValue = cidrValue.substring(0, delimiter).trim();
+    final prefixValue = cidrValue.substring(delimiter + 1).trim();
+    final prefixBits = int.tryParse(prefixValue);
+    if (prefixBits == null) {
+      return false;
+    }
+
+    final ip = InternetAddress.tryParse(ipValue.trim());
+    final network = InternetAddress.tryParse(networkValue);
+    if (ip == null || network == null) {
+      return false;
+    }
+    if (ip.type != network.type) {
+      return false;
+    }
+
+    final ipBytes = ip.rawAddress;
+    final networkBytes = network.rawAddress;
+    final totalBits = ipBytes.length * 8;
+    if (prefixBits < 0 || prefixBits > totalBits) {
+      return false;
+    }
+
+    var remainingBits = prefixBits;
+    for (var index = 0; index < ipBytes.length; index++) {
+      if (remainingBits <= 0) {
+        break;
+      }
+      final mask =
+          remainingBits >= 8 ? 0xFF : ((0xFF << (8 - remainingBits)) & 0xFF);
+      if ((ipBytes[index] & mask) != (networkBytes[index] & mask)) {
+        return false;
+      }
+      remainingBits -= 8;
+    }
+
+    return true;
+  }
+}
+
+class _RoutingRuleMatchResult {
+  const _RoutingRuleMatchResult.match(this.explain) : matched = true;
+
+  const _RoutingRuleMatchResult.noMatch()
+      : matched = false,
+        explain = '';
+
+  final bool matched;
+  final String explain;
+}

--- a/client/lib/features/routing/application/routing_profile_codec.dart
+++ b/client/lib/features/routing/application/routing_profile_codec.dart
@@ -1,0 +1,203 @@
+import '../domain/routing_models.dart';
+import '../domain/routing_profile_config.dart';
+
+class RoutingProfileCodec {
+  const RoutingProfileCodec();
+
+  RoutingProfileConfig decodeFromObject(Object? value) {
+    if (value is Map<String, dynamic>) {
+      return decodeFromJsonMap(value);
+    }
+    if (value is Map) {
+      return decodeFromJsonMap(Map<String, dynamic>.from(value));
+    }
+    return RoutingProfileConfig.defaults;
+  }
+
+  RoutingProfileConfig decodeFromJsonMap(Map<String, dynamic> json) {
+    final mode = _safeEnum(
+      RoutingMode.values,
+      json['mode'] as String?,
+      RoutingMode.rule,
+    );
+    final defaultAction = _safeEnum(
+      RoutingAction.values,
+      json['defaultAction'] as String?,
+      RoutingAction.proxy,
+    );
+    final globalAction = _safeEnum(
+      RoutingAction.values,
+      json['globalAction'] as String?,
+      RoutingAction.proxy,
+    );
+
+    final policyGroups =
+        (json['policyGroups'] as List<dynamic>? ?? const <dynamic>[])
+            .whereType<Map>()
+            .map((raw) {
+              final map = Map<String, dynamic>.from(raw);
+              final id = (map['id'] as String?)?.trim();
+              if (id == null || id.isEmpty) {
+                return null;
+              }
+              return RoutingPolicyGroup(
+                id: id,
+                name: (map['name'] as String?)?.trim().isNotEmpty == true
+                    ? (map['name'] as String).trim()
+                    : id,
+                action: _safeEnum(
+                  RoutingAction.values,
+                  map['action'] as String?,
+                  RoutingAction.proxy,
+                ),
+              );
+            })
+            .whereType<RoutingPolicyGroup>()
+            .toList(growable: false);
+
+    final rules = (json['rules'] as List<dynamic>? ?? const <dynamic>[])
+        .whereType<Map>()
+        .map((raw) {
+          final map = Map<String, dynamic>.from(raw);
+          final id = (map['id'] as String?)?.trim();
+          if (id == null || id.isEmpty) {
+            return null;
+          }
+
+          final matchMap = _asStringDynamicMap(map['match']);
+          final actionMap = _asStringDynamicMap(map['action']);
+
+          final actionKind = (actionMap['kind'] as String?)?.trim();
+          final action = actionKind == 'policyGroup'
+              ? RoutingRuleAction.policyGroup(
+                  (actionMap['policyGroupId'] as String?)?.trim(),
+                )
+              : RoutingRuleAction.direct(
+                  _safeEnum(
+                    RoutingAction.values,
+                    actionMap['directAction'] as String?,
+                    defaultAction,
+                  ),
+                );
+
+          return RoutingRule(
+            id: id,
+            name: (map['name'] as String?)?.trim().isNotEmpty == true
+                ? (map['name'] as String).trim()
+                : id,
+            enabled: (map['enabled'] as bool?) ?? true,
+            priority: (map['priority'] as num?)?.toInt() ?? 100,
+            match: RoutingRuleMatch(
+              domainExact: (matchMap['domainExact'] as String?)?.trim(),
+              domainSuffix: (matchMap['domainSuffix'] as String?)?.trim(),
+              domainKeyword: (matchMap['domainKeyword'] as String?)?.trim(),
+              domainRegex: (matchMap['domainRegex'] as String?)?.trim(),
+              ipCidr: (matchMap['ipCidr'] as String?)?.trim(),
+              port: (matchMap['port'] as num?)?.toInt(),
+              protocol: (matchMap['protocol'] as String?)?.trim(),
+              processName: (matchMap['processName'] as String?)?.trim(),
+              processPath: (matchMap['processPath'] as String?)?.trim(),
+            ),
+            action: action,
+          );
+        })
+        .whereType<RoutingRule>()
+        .toList(growable: false)
+      ..sort((a, b) {
+        final byPriority = a.priority.compareTo(b.priority);
+        if (byPriority != 0) return byPriority;
+        return a.id.compareTo(b.id);
+      });
+
+    return RoutingProfileConfig(
+      mode: mode,
+      defaultAction: defaultAction,
+      globalAction: globalAction,
+      policyGroups: policyGroups,
+      rules: rules,
+    );
+  }
+
+  Map<String, Object?> encodeToJsonMap(RoutingProfileConfig config) {
+    final sortedPolicyGroups = List<RoutingPolicyGroup>.from(
+      config.policyGroups,
+    )..sort((a, b) => a.id.compareTo(b.id));
+
+    final sortedRules = List<RoutingRule>.from(config.rules)
+      ..sort((a, b) {
+        final byPriority = a.priority.compareTo(b.priority);
+        if (byPriority != 0) return byPriority;
+        return a.id.compareTo(b.id);
+      });
+
+    return <String, Object?>{
+      'mode': config.mode.name,
+      'defaultAction': config.defaultAction.name,
+      'globalAction': config.globalAction.name,
+      'policyGroups': sortedPolicyGroups
+          .map(
+            (group) => <String, Object?>{
+              'id': group.id,
+              'name': group.name,
+              'action': group.action.name,
+            },
+          )
+          .toList(growable: false),
+      'rules': sortedRules
+          .map(
+            (rule) => <String, Object?>{
+              'id': rule.id,
+              'name': rule.name,
+              'enabled': rule.enabled,
+              'priority': rule.priority,
+              'match': <String, Object?>{
+                if ((rule.match.domainExact ?? '').trim().isNotEmpty)
+                  'domainExact': rule.match.domainExact!.trim(),
+                if ((rule.match.domainSuffix ?? '').trim().isNotEmpty)
+                  'domainSuffix': rule.match.domainSuffix!.trim(),
+                if ((rule.match.domainKeyword ?? '').trim().isNotEmpty)
+                  'domainKeyword': rule.match.domainKeyword!.trim(),
+                if ((rule.match.domainRegex ?? '').trim().isNotEmpty)
+                  'domainRegex': rule.match.domainRegex!.trim(),
+                if ((rule.match.ipCidr ?? '').trim().isNotEmpty)
+                  'ipCidr': rule.match.ipCidr!.trim(),
+                if (rule.match.port != null) 'port': rule.match.port,
+                if ((rule.match.protocol ?? '').trim().isNotEmpty)
+                  'protocol': rule.match.protocol!.trim(),
+                if ((rule.match.processName ?? '').trim().isNotEmpty)
+                  'processName': rule.match.processName!.trim(),
+                if ((rule.match.processPath ?? '').trim().isNotEmpty)
+                  'processPath': rule.match.processPath!.trim(),
+              },
+              'action': rule.action.usesPolicyGroup
+                  ? <String, Object?>{
+                      'kind': 'policyGroup',
+                      'policyGroupId': rule.action.policyGroupId!.trim(),
+                    }
+                  : <String, Object?>{
+                      'kind': 'direct',
+                      'directAction':
+                          (rule.action.directAction ?? config.defaultAction)
+                              .name,
+                    },
+            },
+          )
+          .toList(growable: false),
+    };
+  }
+
+  Map<String, dynamic> _asStringDynamicMap(Object? value) {
+    if (value is Map<String, dynamic>) {
+      return value;
+    }
+    if (value is Map) {
+      return Map<String, dynamic>.from(value);
+    }
+    return <String, dynamic>{};
+  }
+
+  T _safeEnum<T extends Enum>(List<T> values, String? name, T fallback) {
+    if (name == null) return fallback;
+    return values.asNameMap()[name] ?? fallback;
+  }
+}

--- a/client/lib/features/routing/domain/routing_models.dart
+++ b/client/lib/features/routing/domain/routing_models.dart
@@ -1,0 +1,208 @@
+enum RoutingMode {
+  rule,
+  global,
+  direct,
+}
+
+enum RoutingAction {
+  proxy,
+  direct,
+  block,
+}
+
+class RoutingPolicyGroup {
+  const RoutingPolicyGroup({
+    required this.id,
+    required this.name,
+    required this.action,
+  });
+
+  final String id;
+  final String name;
+  final RoutingAction action;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RoutingPolicyGroup &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          name == other.name &&
+          action == other.action;
+
+  @override
+  int get hashCode => Object.hash(id, name, action);
+}
+
+class RoutingRuleMatch {
+  const RoutingRuleMatch({
+    this.domainExact,
+    this.domainSuffix,
+    this.domainKeyword,
+    this.domainRegex,
+    this.ipCidr,
+    this.port,
+    this.protocol,
+    this.processName,
+    this.processPath,
+  });
+
+  final String? domainExact;
+  final String? domainSuffix;
+  final String? domainKeyword;
+  final String? domainRegex;
+  final String? ipCidr;
+  final int? port;
+  final String? protocol;
+  final String? processName;
+  final String? processPath;
+
+  bool get hasAnyConstraint =>
+      (domainExact != null && domainExact!.trim().isNotEmpty) ||
+      (domainSuffix != null && domainSuffix!.trim().isNotEmpty) ||
+      (domainKeyword != null && domainKeyword!.trim().isNotEmpty) ||
+      (domainRegex != null && domainRegex!.trim().isNotEmpty) ||
+      (ipCidr != null && ipCidr!.trim().isNotEmpty) ||
+      port != null ||
+      (protocol != null && protocol!.trim().isNotEmpty) ||
+      (processName != null && processName!.trim().isNotEmpty) ||
+      (processPath != null && processPath!.trim().isNotEmpty);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RoutingRuleMatch &&
+          runtimeType == other.runtimeType &&
+          domainExact == other.domainExact &&
+          domainSuffix == other.domainSuffix &&
+          domainKeyword == other.domainKeyword &&
+          domainRegex == other.domainRegex &&
+          ipCidr == other.ipCidr &&
+          port == other.port &&
+          protocol == other.protocol &&
+          processName == other.processName &&
+          processPath == other.processPath;
+
+  @override
+  int get hashCode => Object.hash(
+        domainExact,
+        domainSuffix,
+        domainKeyword,
+        domainRegex,
+        ipCidr,
+        port,
+        protocol,
+        processName,
+        processPath,
+      );
+}
+
+class RoutingRuleAction {
+  const RoutingRuleAction.direct(this.directAction) : policyGroupId = null;
+
+  const RoutingRuleAction.policyGroup(this.policyGroupId) : directAction = null;
+
+  final RoutingAction? directAction;
+  final String? policyGroupId;
+
+  bool get usesPolicyGroup =>
+      policyGroupId != null && policyGroupId!.trim().isNotEmpty;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RoutingRuleAction &&
+          runtimeType == other.runtimeType &&
+          directAction == other.directAction &&
+          policyGroupId == other.policyGroupId;
+
+  @override
+  int get hashCode => Object.hash(directAction, policyGroupId);
+}
+
+class RoutingRule {
+  const RoutingRule({
+    required this.id,
+    required this.name,
+    required this.enabled,
+    required this.priority,
+    required this.match,
+    required this.action,
+  });
+
+  final String id;
+  final String name;
+  final bool enabled;
+  final int priority;
+  final RoutingRuleMatch match;
+  final RoutingRuleAction action;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RoutingRule &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          name == other.name &&
+          enabled == other.enabled &&
+          priority == other.priority &&
+          match == other.match &&
+          action == other.action;
+
+  @override
+  int get hashCode => Object.hash(id, name, enabled, priority, match, action);
+}
+
+class RoutingProfile {
+  const RoutingProfile({
+    required this.id,
+    required this.name,
+    required this.mode,
+    required this.defaultAction,
+    required this.globalAction,
+    required this.policyGroups,
+    required this.rules,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String name;
+  final RoutingMode mode;
+  final RoutingAction defaultAction;
+  final RoutingAction globalAction;
+  final List<RoutingPolicyGroup> policyGroups;
+  final List<RoutingRule> rules;
+  final DateTime updatedAt;
+}
+
+class RoutingRequestMetadata {
+  const RoutingRequestMetadata({
+    required this.host,
+    required this.port,
+    required this.protocol,
+    this.ip,
+    this.processName,
+    this.processPath,
+  });
+
+  final String host;
+  final String? ip;
+  final int port;
+  final String protocol;
+  final String? processName;
+  final String? processPath;
+}
+
+class RoutingDecision {
+  const RoutingDecision({
+    required this.action,
+    required this.explain,
+    this.matchedRuleId,
+    this.policyGroupId,
+  });
+
+  final RoutingAction action;
+  final String explain;
+  final String? matchedRuleId;
+  final String? policyGroupId;
+}

--- a/client/lib/features/routing/domain/routing_profile_config.dart
+++ b/client/lib/features/routing/domain/routing_profile_config.dart
@@ -1,0 +1,54 @@
+import 'routing_models.dart';
+
+class RoutingProfileConfig {
+  const RoutingProfileConfig({
+    required this.mode,
+    required this.defaultAction,
+    required this.globalAction,
+    required this.policyGroups,
+    required this.rules,
+  });
+
+  final RoutingMode mode;
+  final RoutingAction defaultAction;
+  final RoutingAction globalAction;
+  final List<RoutingPolicyGroup> policyGroups;
+  final List<RoutingRule> rules;
+
+  static const RoutingProfileConfig defaults = RoutingProfileConfig(
+    mode: RoutingMode.rule,
+    defaultAction: RoutingAction.proxy,
+    globalAction: RoutingAction.proxy,
+    policyGroups: <RoutingPolicyGroup>[],
+    rules: <RoutingRule>[],
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RoutingProfileConfig &&
+          runtimeType == other.runtimeType &&
+          mode == other.mode &&
+          defaultAction == other.defaultAction &&
+          globalAction == other.globalAction &&
+          _listEquals(policyGroups, other.policyGroups) &&
+          _listEquals(rules, other.rules);
+
+  @override
+  int get hashCode => Object.hash(
+        mode,
+        defaultAction,
+        globalAction,
+        Object.hashAll(policyGroups),
+        Object.hashAll(rules),
+      );
+
+  static bool _listEquals<T>(List<T> a, List<T> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}

--- a/client/test/features/controller/application/adapter_backed_client_controller_test.dart
+++ b/client/test/features/controller/application/adapter_backed_client_controller_test.dart
@@ -145,7 +145,8 @@ void main() {
     );
     final controller = AdapterBackedClientController(
       adapter: adapter,
-      profileSecrets: ProfileSecretsService(secureStorage: MemorySecureStorage()),
+      profileSecrets:
+          ProfileSecretsService(secureStorage: MemorySecureStorage()),
       sessionPollInterval: const Duration(milliseconds: 20),
     );
     addTearDown(controller.dispose);
@@ -166,8 +167,7 @@ void main() {
     );
   });
 
-  test('prepareExport forwards bundle kind through adapter boundary',
-      () async {
+  test('prepareExport forwards bundle kind through adapter boundary', () async {
     final adapter = _ControllableShellControllerAdapter(
       runtimeConfig: const ControllerRuntimeConfig(
         mode: 'external-runtime-boundary',
@@ -181,7 +181,8 @@ void main() {
     );
     final controller = AdapterBackedClientController(
       adapter: adapter,
-      profileSecrets: ProfileSecretsService(secureStorage: MemorySecureStorage()),
+      profileSecrets:
+          ProfileSecretsService(secureStorage: MemorySecureStorage()),
       sessionPollInterval: const Duration(milliseconds: 20),
     );
     addTearDown(controller.dispose);
@@ -229,6 +230,14 @@ void main() {
 
     await controller.connect(_demoProfile());
     expect(controller.status.phase, ClientConnectionPhase.connecting);
+
+    expect(adapter.lastCommand, isNotNull);
+    final routing = adapter.lastCommand!.arguments['routing'];
+    expect(routing, isA<Map<String, Object?>>());
+    final routingMap = routing! as Map<String, Object?>;
+    expect(routingMap['mode'], 'rule');
+    expect(routingMap['defaultAction'], 'proxy');
+    expect(routingMap['globalAction'], 'proxy');
 
     adapter.setSession(_session(isRunning: true, pid: 4321));
     await _waitFor(
@@ -420,7 +429,8 @@ void main() {
       ),
     );
     await _waitFor(
-      () => controller.status.message.contains('Waiting for the runtime process to exit cleanly'),
+      () => controller.status.message
+          .contains('Waiting for the runtime process to exit cleanly'),
       description: 'disconnecting status reflects stop-requested runtime',
     );
 

--- a/client/test/features/controller/application/real_shell_connect_planner_routing_test.dart
+++ b/client/test/features/controller/application/real_shell_connect_planner_routing_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/application/real_shell_connect_planner.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_command.dart';
+
+void main() {
+  final planner = RealShellConnectPlanner();
+
+  test('parse injects default routing when command omits routing payload', () {
+    final command = ControllerCommand(
+      id: 'connect-1',
+      kind: ControllerCommandKind.connect,
+      issuedAt: DateTime.parse('2026-04-15T00:00:00.000Z'),
+      profileId: 'profile-demo',
+      arguments: <String, Object?>{
+        'profileName': 'demo-profile',
+        'serverHost': 'example.com',
+        'serverPort': 443,
+        'localSocksPort': 1080,
+        'sni': 'example.com',
+        'verifyTls': true,
+        'configPath': '/tmp/runtime-config.json',
+      },
+      secretArguments: const <String, String>{
+        'trojanPassword': 'secret',
+      },
+    );
+
+    final input = planner.parse(command);
+    expect(input, isNotNull);
+    expect(input!.profile.routing.mode.name, 'rule');
+    expect(input.profile.routing.defaultAction.name, 'proxy');
+    expect(input.profile.routing.rules, isEmpty);
+  });
+
+  test('parse decodes routing payload from command arguments', () {
+    final command = ControllerCommand(
+      id: 'connect-2',
+      kind: ControllerCommandKind.connect,
+      issuedAt: DateTime.parse('2026-04-15T00:00:00.000Z'),
+      profileId: 'profile-demo',
+      arguments: <String, Object?>{
+        'profileName': 'demo-profile',
+        'serverHost': 'example.com',
+        'serverPort': 443,
+        'localSocksPort': 1080,
+        'sni': 'example.com',
+        'verifyTls': true,
+        'configPath': '/tmp/runtime-config.json',
+        'routing': <String, Object?>{
+          'mode': 'rule',
+          'defaultAction': 'proxy',
+          'globalAction': 'proxy',
+          'policyGroups': <Object?>[
+            <String, Object?>{
+              'id': 'domestic',
+              'name': 'Domestic',
+              'action': 'direct',
+            }
+          ],
+          'rules': <Object?>[
+            <String, Object?>{
+              'id': 'rule-cn',
+              'name': 'CN Direct',
+              'enabled': true,
+              'priority': 10,
+              'match': <String, Object?>{
+                'domainSuffix': '.cn',
+              },
+              'action': <String, Object?>{
+                'kind': 'policyGroup',
+                'policyGroupId': 'domestic',
+              },
+            }
+          ],
+        },
+      },
+      secretArguments: const <String, String>{
+        'trojanPassword': 'secret',
+      },
+    );
+
+    final input = planner.parse(command);
+    expect(input, isNotNull);
+    expect(input!.profile.routing.policyGroups, hasLength(1));
+    expect(input.profile.routing.policyGroups.first.id, 'domestic');
+    expect(input.profile.routing.rules, hasLength(1));
+    expect(input.profile.routing.rules.first.id, 'rule-cn');
+    expect(input.profile.routing.rules.first.action.policyGroupId, 'domestic');
+  });
+}

--- a/client/test/features/controller/application/trojan_client_config_renderer_test.dart
+++ b/client/test/features/controller/application/trojan_client_config_renderer_test.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/application/trojan_client_config_renderer.dart';
+import 'package:trojan_pro_client/features/profiles/domain/client_profile.dart';
+import 'package:trojan_pro_client/features/routing/domain/routing_models.dart';
+import 'package:trojan_pro_client/features/routing/domain/routing_profile_config.dart';
+
+ClientProfile _profile({RoutingProfileConfig? routing}) {
+  return ClientProfile(
+    id: 'profile-1',
+    name: 'Profile One',
+    serverHost: 'example.com',
+    serverPort: 443,
+    sni: 'example.com',
+    localSocksPort: 1080,
+    verifyTls: true,
+    updatedAt: DateTime.parse('2026-04-15T00:00:00.000Z'),
+    routing: routing ?? RoutingProfileConfig.defaults,
+  );
+}
+
+void main() {
+  final renderer = TrojanClientConfigRenderer();
+
+  test('render includes routing payload with safe defaults', () {
+    final raw = renderer.render(
+      profile: _profile(),
+      password: 'super-secret',
+    );
+
+    final decoded = jsonDecode(raw) as Map<String, dynamic>;
+    final routing = decoded['routing'] as Map<String, dynamic>?;
+
+    expect(routing, isNotNull);
+    expect(routing!['mode'], 'rule');
+    expect(routing['defaultAction'], 'proxy');
+    expect(routing['globalAction'], 'proxy');
+    expect(routing['policyGroups'], isEmpty);
+    expect(routing['rules'], isEmpty);
+  });
+
+  test('render routing payload is deterministic and priority-sorted', () {
+    const routing = RoutingProfileConfig(
+      mode: RoutingMode.rule,
+      defaultAction: RoutingAction.proxy,
+      globalAction: RoutingAction.proxy,
+      policyGroups: <RoutingPolicyGroup>[
+        RoutingPolicyGroup(
+          id: 'domestic',
+          name: 'Domestic',
+          action: RoutingAction.direct,
+        ),
+      ],
+      rules: <RoutingRule>[
+        RoutingRule(
+          id: 'rule-late',
+          name: 'late',
+          enabled: true,
+          priority: 100,
+          match: RoutingRuleMatch(domainSuffix: '.com'),
+          action: RoutingRuleAction.direct(RoutingAction.proxy),
+        ),
+        RoutingRule(
+          id: 'rule-early',
+          name: 'early',
+          enabled: true,
+          priority: 10,
+          match: RoutingRuleMatch(domainSuffix: '.cn'),
+          action: RoutingRuleAction.policyGroup('domestic'),
+        ),
+      ],
+    );
+
+    final raw = renderer.render(
+      profile: _profile(routing: routing),
+      password: 'super-secret',
+    );
+
+    final decoded = jsonDecode(raw) as Map<String, dynamic>;
+    final routingPayload = decoded['routing'] as Map<String, dynamic>;
+    final rules = routingPayload['rules'] as List<dynamic>;
+
+    expect(rules, hasLength(2));
+    expect((rules[0] as Map<String, dynamic>)['id'], 'rule-early');
+    expect((rules[1] as Map<String, dynamic>)['id'], 'rule-late');
+  });
+}

--- a/client/test/features/diagnostics/application/diagnostics_export_service_test.dart
+++ b/client/test/features/diagnostics/application/diagnostics_export_service_test.dart
@@ -39,7 +39,8 @@ class _RuntimeTrueController extends FakeClientController {
 
 class _ControllerWithFailureSummary extends FakeClientController {
   @override
-  LastRuntimeFailureSummary? get lastRuntimeFailure => LastRuntimeFailureSummary(
+  LastRuntimeFailureSummary? get lastRuntimeFailure =>
+      LastRuntimeFailureSummary(
         profileId: 'sample-hk-1',
         phase: 'runtime',
         family: FailureFamily.connect,
@@ -101,6 +102,14 @@ void main() {
     final payload = jsonDecode(preview) as Map<String, dynamic>;
 
     expect(payload['bundleKind'], 'support-bundle');
+
+    final selectedProfile = payload['selectedProfile'] as Map<String, dynamic>;
+    final selectedRouting = selectedProfile['routing'] as Map<String, dynamic>;
+    expect(selectedRouting['mode'], 'rule');
+    expect(selectedRouting['defaultAction'], 'proxy');
+    expect(selectedRouting['globalAction'], 'proxy');
+    expect(selectedRouting['ruleCount'], 0);
+    expect(selectedRouting['policyGroupCount'], 0);
 
     final controllerPayload = payload['controller'] as Map<String, dynamic>;
     final runtimePosture =

--- a/client/test/features/profiles/application/profile_portability_routing_test.dart
+++ b/client/test/features/profiles/application/profile_portability_routing_test.dart
@@ -1,0 +1,113 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/profiles/application/profile_portability_service.dart';
+import 'package:trojan_pro_client/features/profiles/domain/client_profile.dart';
+import 'package:trojan_pro_client/features/routing/domain/routing_models.dart';
+import 'package:trojan_pro_client/features/routing/domain/routing_profile_config.dart';
+
+ClientProfile _profileWithRouting() {
+  return ClientProfile(
+    id: 'profile-routing',
+    name: 'Routing Profile',
+    serverHost: 'example.com',
+    serverPort: 443,
+    sni: 'example.com',
+    localSocksPort: 1080,
+    verifyTls: true,
+    updatedAt: DateTime.parse('2026-04-15T00:00:00.000Z'),
+    routing: const RoutingProfileConfig(
+      mode: RoutingMode.rule,
+      defaultAction: RoutingAction.proxy,
+      globalAction: RoutingAction.proxy,
+      policyGroups: <RoutingPolicyGroup>[
+        RoutingPolicyGroup(
+          id: 'domestic',
+          name: 'Domestic',
+          action: RoutingAction.direct,
+        ),
+      ],
+      rules: <RoutingRule>[
+        RoutingRule(
+          id: 'rule-cn',
+          name: 'CN Direct',
+          enabled: true,
+          priority: 10,
+          match: RoutingRuleMatch(domainSuffix: '.cn'),
+          action: RoutingRuleAction.policyGroup('domestic'),
+        ),
+      ],
+    ),
+  );
+}
+
+void main() {
+  final service = ProfilePortabilityService();
+
+  test('exportProfile includes routing payload without secrets', () {
+    final exported = service.exportProfile(_profileWithRouting());
+
+    final decoded = jsonDecode(exported) as Map<String, dynamic>;
+    final profile = decoded['profile'] as Map<String, dynamic>;
+    final routing = profile['routing'] as Map<String, dynamic>?;
+
+    expect(routing, isNotNull);
+    expect(routing!['mode'], 'rule');
+    expect(routing['defaultAction'], 'proxy');
+    final rules = routing['rules'] as List<dynamic>;
+    expect(rules, hasLength(1));
+    expect((rules.first as Map<String, dynamic>)['id'], 'rule-cn');
+
+    expect(exported, isNot(contains('trojan-password')));
+    expect(exported, isNot(contains('super-secret')));
+  });
+
+  test('importBundle decodes routing payload and keeps semantics', () {
+    final bundle = service.importBundle('''
+{
+  "version": 2,
+  "kind": "trojan-pro-client-profile",
+  "profile": {
+    "id": "imported-routing",
+    "name": "Imported Routing",
+    "serverHost": "jp.example.com",
+    "serverPort": 8443,
+    "sni": "cdn.example.com",
+    "localSocksPort": 2080,
+    "verifyTls": false,
+    "notes": "with routing",
+    "updatedAt": "2026-04-15T00:00:00.000Z",
+    "routing": {
+      "mode": "rule",
+      "defaultAction": "proxy",
+      "globalAction": "proxy",
+      "policyGroups": [
+        {"id": "domestic", "name": "Domestic", "action": "direct"}
+      ],
+      "rules": [
+        {
+          "id": "rule-cn",
+          "name": "CN Direct",
+          "enabled": true,
+          "priority": 10,
+          "match": {"domainSuffix": ".cn"},
+          "action": {"kind": "policyGroup", "policyGroupId": "domestic"}
+        }
+      ]
+    }
+  },
+  "secrets": {
+    "trojanPasswordIncluded": false,
+    "sourceDeviceHadStoredPassword": true,
+    "importBehavior": "reenter_or_restore_secure_storage"
+  }
+}
+''');
+
+    expect(bundle.profile.id, 'imported-routing');
+    expect(bundle.profile.routing.policyGroups, hasLength(1));
+    expect(bundle.profile.routing.policyGroups.first.id, 'domestic');
+    expect(bundle.profile.routing.rules, hasLength(1));
+    expect(bundle.profile.routing.rules.first.id, 'rule-cn');
+  });
+}

--- a/client/test/features/profiles/application/profile_portability_service_test.dart
+++ b/client/test/features/profiles/application/profile_portability_service_test.dart
@@ -36,6 +36,7 @@ void main() {
     );
 
     final map = jsonDecode(exported) as Map<String, dynamic>;
+    expect(map['version'], 2);
     expect(map['kind'], 'trojan-pro-client-profile');
     final secrets = map['secrets'] as Map<String, dynamic>;
     expect(secrets['trojanPasswordIncluded'], false);
@@ -112,6 +113,7 @@ void main() {
     ]);
 
     final map = jsonDecode(exported) as Map<String, dynamic>;
+    expect(map['version'], 2);
     expect(map['kind'], 'trojan-pro-client-profile-bundle');
 
     final profiles = map['profiles'] as List<dynamic>;

--- a/client/test/features/profiles/application/profile_serialization_test.dart
+++ b/client/test/features/profiles/application/profile_serialization_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/profiles/application/profile_serialization.dart';
+import 'package:trojan_pro_client/features/profiles/domain/client_profile.dart';
+
+void main() {
+  final serialization = ProfileSerialization();
+
+  test('decode reads routing payload when present', () {
+    const payload = '''
+{
+  "version": 2,
+  "profiles": [
+    {
+      "id": "p1",
+      "name": "Profile 1",
+      "serverHost": "example.com",
+      "serverPort": 443,
+      "sni": "example.com",
+      "localSocksPort": 1080,
+      "verifyTls": true,
+      "updatedAt": "2026-04-15T00:00:00.000Z",
+      "routing": {
+        "mode": "rule",
+        "defaultAction": "proxy",
+        "globalAction": "proxy",
+        "policyGroups": [
+          {"id": "g1", "name": "Domestic", "action": "direct"}
+        ],
+        "rules": [
+          {
+            "id": "r1",
+            "name": "rule1",
+            "enabled": true,
+            "priority": 10,
+            "match": {"domainSuffix": ".cn"},
+            "action": {"kind": "policyGroup", "policyGroupId": "g1"}
+          }
+        ]
+      }
+    }
+  ]
+}
+''';
+
+    final decoded = serialization.decodeProfileList(payload);
+    expect(decoded, hasLength(1));
+    final profile = decoded.first;
+    expect(profile.routing.mode.name, 'rule');
+    expect(profile.routing.defaultAction.name, 'proxy');
+    expect(profile.routing.policyGroups, hasLength(1));
+    expect(profile.routing.policyGroups.first.id, 'g1');
+    expect(profile.routing.rules, hasLength(1));
+    expect(profile.routing.rules.first.id, 'r1');
+    expect(profile.routing.rules.first.action.policyGroupId, 'g1');
+  });
+
+  test('decode falls back to safe default routing when field missing', () {
+    const payload = '''
+{
+  "version": 1,
+  "profiles": [
+    {
+      "id": "p2",
+      "name": "Legacy",
+      "serverHost": "legacy.example.com",
+      "serverPort": 443,
+      "sni": "legacy.example.com",
+      "localSocksPort": 1080,
+      "verifyTls": true,
+      "updatedAt": "2026-04-15T00:00:00.000Z"
+    }
+  ]
+}
+''';
+
+    final decoded = serialization.decodeProfileList(payload);
+    final routing = decoded.first.routing;
+
+    expect(routing.mode.name, 'rule');
+    expect(routing.defaultAction.name, 'proxy');
+    expect(routing.globalAction.name, 'proxy');
+    expect(routing.rules, isEmpty);
+    expect(routing.policyGroups, isEmpty);
+  });
+
+  test('encode includes routing block and keeps deterministic shape', () {
+    final profile = ClientProfile(
+      id: 'p3',
+      name: 'Encode',
+      serverHost: 'encode.example.com',
+      serverPort: 443,
+      sni: 'encode.example.com',
+      localSocksPort: 1080,
+      verifyTls: true,
+      updatedAt: DateTime.parse('2026-04-15T00:00:00.000Z'),
+    );
+
+    final text = serialization.encodeProfileList(<ClientProfile>[profile]);
+
+    expect(text, contains('"routing"'));
+    expect(text, contains('"mode": "rule"'));
+    expect(text, contains('"defaultAction": "proxy"'));
+    expect(text, contains('"globalAction": "proxy"'));
+  });
+}

--- a/client/test/features/routing/application/routing_decision_engine_test.dart
+++ b/client/test/features/routing/application/routing_decision_engine_test.dart
@@ -1,0 +1,234 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/routing/application/routing_decision_engine.dart';
+import 'package:trojan_pro_client/features/routing/domain/routing_models.dart';
+
+RoutingRule _rule({
+  required String id,
+  required int priority,
+  required RoutingRuleMatch match,
+  required RoutingRuleAction action,
+  bool enabled = true,
+  String name = 'rule',
+}) {
+  return RoutingRule(
+    id: id,
+    name: name,
+    enabled: enabled,
+    priority: priority,
+    match: match,
+    action: action,
+  );
+}
+
+void main() {
+  const engine = RoutingDecisionEngine();
+
+  test('matches exact domain rule and returns deterministic explanation', () {
+    final profile = RoutingProfile(
+      id: 'routing-1',
+      name: 'Default Routing',
+      mode: RoutingMode.rule,
+      defaultAction: RoutingAction.proxy,
+      globalAction: RoutingAction.proxy,
+      policyGroups: const <RoutingPolicyGroup>[],
+      rules: <RoutingRule>[
+        _rule(
+          id: 'rule-domain-block',
+          priority: 10,
+          match: const RoutingRuleMatch(domainExact: 'example.com'),
+          action: const RoutingRuleAction.direct(RoutingAction.block),
+        ),
+      ],
+      updatedAt: DateTime.parse('2026-04-15T00:00:00.000Z'),
+    );
+
+    final decision = engine.resolve(
+      profile: profile,
+      request: const RoutingRequestMetadata(
+        host: 'Example.COM',
+        port: 443,
+        protocol: 'tcp',
+      ),
+    );
+
+    expect(decision.action, RoutingAction.block);
+    expect(decision.matchedRuleId, 'rule-domain-block');
+    expect(decision.explain, contains('domainExact=example.com'));
+  });
+
+  test('smaller priority wins when multiple rules match', () {
+    final profile = RoutingProfile(
+      id: 'routing-2',
+      name: 'Priority Routing',
+      mode: RoutingMode.rule,
+      defaultAction: RoutingAction.proxy,
+      globalAction: RoutingAction.proxy,
+      policyGroups: const <RoutingPolicyGroup>[],
+      rules: <RoutingRule>[
+        _rule(
+          id: 'rule-suffix-direct',
+          priority: 80,
+          match: const RoutingRuleMatch(domainSuffix: '.com'),
+          action: const RoutingRuleAction.direct(RoutingAction.direct),
+        ),
+        _rule(
+          id: 'rule-exact-block',
+          priority: 5,
+          match: const RoutingRuleMatch(domainExact: 'video.example.com'),
+          action: const RoutingRuleAction.direct(RoutingAction.block),
+        ),
+      ],
+      updatedAt: DateTime.parse('2026-04-15T00:00:00.000Z'),
+    );
+
+    final decision = engine.resolve(
+      profile: profile,
+      request: const RoutingRequestMetadata(
+        host: 'video.example.com',
+        port: 443,
+        protocol: 'tcp',
+      ),
+    );
+
+    expect(decision.action, RoutingAction.block);
+    expect(decision.matchedRuleId, 'rule-exact-block');
+  });
+
+  test('policy-group rule resolves to policy group action', () {
+    final profile = RoutingProfile(
+      id: 'routing-3',
+      name: 'Policy Group Routing',
+      mode: RoutingMode.rule,
+      defaultAction: RoutingAction.proxy,
+      globalAction: RoutingAction.proxy,
+      policyGroups: const <RoutingPolicyGroup>[
+        RoutingPolicyGroup(
+          id: 'domestic-direct',
+          name: 'Domestic Direct',
+          action: RoutingAction.direct,
+        ),
+      ],
+      rules: <RoutingRule>[
+        _rule(
+          id: 'rule-cn',
+          priority: 10,
+          match: const RoutingRuleMatch(domainSuffix: '.cn'),
+          action: const RoutingRuleAction.policyGroup('domestic-direct'),
+        ),
+      ],
+      updatedAt: DateTime.parse('2026-04-15T00:00:00.000Z'),
+    );
+
+    final decision = engine.resolve(
+      profile: profile,
+      request: const RoutingRequestMetadata(
+        host: 'news.sina.cn',
+        port: 443,
+        protocol: 'tcp',
+      ),
+    );
+
+    expect(decision.action, RoutingAction.direct);
+    expect(decision.matchedRuleId, 'rule-cn');
+    expect(decision.policyGroupId, 'domestic-direct');
+  });
+
+  test('ip cidr matcher works for ipv4 source ip metadata', () {
+    final profile = RoutingProfile(
+      id: 'routing-4',
+      name: 'IP Routing',
+      mode: RoutingMode.rule,
+      defaultAction: RoutingAction.proxy,
+      globalAction: RoutingAction.proxy,
+      policyGroups: const <RoutingPolicyGroup>[],
+      rules: <RoutingRule>[
+        _rule(
+          id: 'rule-private-ip',
+          priority: 10,
+          match: const RoutingRuleMatch(ipCidr: '10.0.0.0/8'),
+          action: const RoutingRuleAction.direct(RoutingAction.direct),
+        ),
+      ],
+      updatedAt: DateTime.parse('2026-04-15T00:00:00.000Z'),
+    );
+
+    final decision = engine.resolve(
+      profile: profile,
+      request: const RoutingRequestMetadata(
+        host: 'internal.example',
+        ip: '10.1.2.3',
+        port: 443,
+        protocol: 'tcp',
+      ),
+    );
+
+    expect(decision.action, RoutingAction.direct);
+    expect(decision.matchedRuleId, 'rule-private-ip');
+  });
+
+  test('disabled rules are ignored and fallback uses default action', () {
+    final profile = RoutingProfile(
+      id: 'routing-5',
+      name: 'Disabled Rule Routing',
+      mode: RoutingMode.rule,
+      defaultAction: RoutingAction.proxy,
+      globalAction: RoutingAction.proxy,
+      policyGroups: const <RoutingPolicyGroup>[],
+      rules: <RoutingRule>[
+        _rule(
+          id: 'rule-disabled-block',
+          priority: 1,
+          enabled: false,
+          match: const RoutingRuleMatch(domainExact: 'blocked.example'),
+          action: const RoutingRuleAction.direct(RoutingAction.block),
+        ),
+      ],
+      updatedAt: DateTime.parse('2026-04-15T00:00:00.000Z'),
+    );
+
+    final decision = engine.resolve(
+      profile: profile,
+      request: const RoutingRequestMetadata(
+        host: 'blocked.example',
+        port: 443,
+        protocol: 'tcp',
+      ),
+    );
+
+    expect(decision.action, RoutingAction.proxy);
+    expect(decision.matchedRuleId, isNull);
+  });
+
+  test('direct mode short-circuits rules and always chooses direct', () {
+    final profile = RoutingProfile(
+      id: 'routing-6',
+      name: 'Direct Mode',
+      mode: RoutingMode.direct,
+      defaultAction: RoutingAction.proxy,
+      globalAction: RoutingAction.proxy,
+      policyGroups: const <RoutingPolicyGroup>[],
+      rules: <RoutingRule>[
+        _rule(
+          id: 'rule-would-block',
+          priority: 1,
+          match: const RoutingRuleMatch(domainExact: 'example.com'),
+          action: const RoutingRuleAction.direct(RoutingAction.block),
+        ),
+      ],
+      updatedAt: DateTime.parse('2026-04-15T00:00:00.000Z'),
+    );
+
+    final decision = engine.resolve(
+      profile: profile,
+      request: const RoutingRequestMetadata(
+        host: 'example.com',
+        port: 443,
+        protocol: 'tcp',
+      ),
+    );
+
+    expect(decision.action, RoutingAction.direct);
+    expect(decision.matchedRuleId, isNull);
+    expect(decision.explain, contains('mode=direct'));
+  });
+}

--- a/docs/superpowers/specs/2026-04-15-client-traffic-splitting-v1.5.0-design.md
+++ b/docs/superpowers/specs/2026-04-15-client-traffic-splitting-v1.5.0-design.md
@@ -1,0 +1,212 @@
+# Client Traffic Splitting v1.5.0 设计规格（Draft Approved for Planning）
+
+## 1. 背景与目标
+
+当前客户端（`v1.4.0`）侧重 runtime truth、supportability、packaging/release truth，但**尚未具备业务可用的分流能力**。`ClientProfile` 仅包含基础连接参数（host/port/sni/socks port/TLS），`TrojanClientConfigRenderer` 也仅渲染最小 client 配置。
+
+`v1.5.0` 目标：
+
+1. 在现有 desktop-first 架构上引入**可演进、可验证、可观测**的流量分流能力。
+2. 吸收主流方案优势（规则匹配表达力、规则集治理、用户体验与安全边界），但不照搬实现。
+3. 为后续“远程规则分发、增量更新、策略实验”打下底层基础。
+
+---
+
+## 2. 主流分流思路对比（抽象层）
+
+> 参考维度：规则表达力、规则治理、执行性能、可解释性、运维复杂度。
+
+### A. 静态规则优先（classic rule list）
+
+**做法**：按顺序匹配域名/IP/端口/进程/网络类型，命中即路由到 target（DIRECT/PROXY/REJECT）。
+
+**优点**
+- 可读性高， deterministic（顺序明确）
+- 适合本地单机策略
+
+**缺点**
+- 规则膨胀后维护成本高
+- 缺少版本化、来源可信治理时容易失控
+
+### B. 规则集驱动（rule-set / provider）
+
+**做法**：本地仅持“策略骨架”，大规模规则放到可更新的 rule-set（如 geosite/geoip/业务域规则）。
+
+**优点**
+- 便于规模化治理与更新
+- 可将“策略逻辑”与“规则数据”解耦
+
+**缺点**
+- 对签名校验、缓存一致性要求高
+- 下载失败、版本漂移会带来不可预期行为
+
+### C. 策略组与分层决策（policy / fallback / chain）
+
+**做法**：规则先映射到策略组（如 `global`, `auto`, `direct`, `block`, `fallback`），再由策略组选择实际 outbound。
+
+**优点**
+- 业务语义清晰（用户理解“策略”而非底层细节）
+- 便于 A/B、回滚、灰度
+
+**缺点**
+- 多一层抽象，初期复杂度增加
+- 若缺可观测性，排障难度上升
+
+---
+
+## 3. v1.5.0 设计原则（我们的路线）
+
+1. **策略语义优先，规则实现托底**
+   - UI 面向“策略行为”（例如：国内直连、广告拦截、未知走代理）
+   - 引擎内部保留规则表达能力
+2. **本地 deterministic first，远程更新 second**
+   - v1.5.0 首发优先本地可复现
+   - 远程 rule-set 更新能力作为可选扩展（不阻断主功能）
+3. **可解释路由（Explainability）内建**
+   - 每次命中保留 `why matched -> routed to` 的证据摘要
+4. **安全边界前置**
+   - 规则来源、版本、签名、回滚、失败降级必须明确
+5. **与现有 runtime truth 模型兼容**
+   - 分流结果要进入 diagnostics/export/support 证据链
+
+---
+
+## 4. 目标架构（v1.5.0）
+
+## 4.1 分层结构
+
+1. **Domain Layer（Routing Domain）**
+   - `SplitProfile`：分流配置聚合根
+   - `SplitRule`：规则实体（条件+动作+优先级）
+   - `RuleSetRef`：规则集引用（本地/远程/内置）
+   - `RoutingPolicy`：策略组定义
+
+2. **Application Layer（Routing Orchestration）**
+   - `SplitPlanner`：把 profile + ruleSets 编译成运行时计划
+   - `SplitValidator`：冲突检测、覆盖率检测、死规则检测
+   - `SplitExplainService`：给 UI/diagnostics 提供命中解释
+
+3. **Infrastructure Layer（RuleSet & Runtime Bridge）**
+   - `RuleSetStore`：本地缓存与版本管理
+   - `RuleSetFetcher`（optional in v1.5.0）：远程拉取
+   - `RoutingConfigEmitter`：输出到 Trojan runtime config（或 sidecar config）
+
+4. **Presentation Layer（Profile + Settings + Diagnostics）**
+   - Profiles 增加“分流策略”编辑入口
+   - Settings 增加全局默认策略与安全开关
+   - Diagnostics 增加最近命中规则/失败回退轨迹
+
+## 4.2 决策流（简化）
+
+`request metadata` -> `rule matcher` -> `policy group` -> `outbound decision` -> `evidence log`
+
+---
+
+## 5. 数据模型（初版）
+
+```text
+SplitProfile
+- id
+- name
+- mode: rule | global | direct
+- defaultPolicy: proxy | direct | block
+- ruleRefs: [SplitRule.id]
+- ruleSetRefs: [RuleSetRef.id]
+- updatedAt
+
+SplitRule
+- id
+- name
+- enabled
+- priority (int, lower first)
+- match:
+  - domain/domainSuffix/domainKeyword/domainRegex
+  - ipCidr/ipGeo
+  - processName/processPath (platform-gated)
+  - port/network
+- action:
+  - policy: direct|proxy|block|policyGroupRef
+- noResolve: bool
+- tags: [string]
+
+RuleSetRef
+- id
+- sourceType: builtin|local|remote
+- source
+- version
+- checksum
+- signature(optional v1.5.0 soft)
+- lastUpdatedAt
+- status: ready|stale|failed
+```
+
+---
+
+## 6. 与现有代码的集成策略
+
+## 6.1 不破坏现有主线
+
+- 保持 `ClientProfile` 兼容：新增可选字段，不破坏现有序列化加载。
+- `TrojanClientConfigRenderer` 从“最小配置渲染器”升级为“可注入 split plan 的渲染器”。
+- `ProfileStore` / `ProfileSerialization` 增量扩展，并提供迁移默认值。
+
+## 6.2 首批落点文件（预计）
+
+- `client/lib/features/routing/**`（新模块）
+- `client/lib/features/profiles/domain/client_profile.dart`（扩展字段）
+- `client/lib/features/profiles/application/profile_serialization.dart`（版本迁移）
+- `client/lib/features/controller/application/trojan_client_config_renderer.dart`（注入 plan）
+- `client/lib/features/diagnostics/application/*`（新增 routing evidence）
+
+---
+
+## 7. 质量与验证策略
+
+1. **单元测试（必须）**
+   - matcher 行为（域名/IP/端口/进程）
+   - priority 决策与冲突场景
+   - noResolve 语义
+2. **契约测试（必须）**
+   - `SplitPlanner -> RoutingConfigEmitter` 输出稳定性
+3. **回归测试（必须）**
+   - 不启用分流时行为与 v1.4.0 一致
+4. **可观测性测试（建议）**
+   - 命中解释信息在 diagnostics/export 可见
+
+---
+
+## 8. 版本发布策略（v1.5.0）
+
+- 分支：`feature/v1.5.0-client-splitting`
+- 阶段发布：
+  1) domain/application 可用 + 单测
+  2) UI first-cut + 诊断证据
+  3) 打包/CI 全量 gate
+- 发布门禁：
+  - flutter analyze + target tests + release truth + packaged smoke
+
+---
+
+## 9. 风险与缓解
+
+1. **规则复杂度暴涨**
+   - 缓解：规则模板化 + lint + unused/dead rule 提示
+2. **远程 rule-set 不稳定**
+   - 缓解：本地缓存、版本锁、失败回退到 last-known-good
+3. **用户误配导致断网**
+   - 缓解：安全模式（保底直连规则 + 一键恢复）
+4. **平台差异（process/path）**
+   - 缓解：字段 capability gating，非支持平台禁用相关规则
+
+---
+
+## 10. 结论（推荐路线）
+
+采用“**策略语义层 + 可解释规则引擎 + 渐进式规则集治理**”路线：
+
+- 不做纯静态规则堆砌
+- 不直接照搬任何现成产品配置结构
+- 保留和主流方案同等级的扩展性与治理能力
+- 与当前 v1.4.0 runtime truth 主线无缝衔接
+
+该方案已满足进入实现计划阶段。


### PR DESCRIPTION
## Summary
- add a new routing domain + decision engine + codec (`client/lib/features/routing/**`) to support deterministic, explainable client-side traffic splitting policies
- integrate routing profile into existing client surfaces:
  - profile model/serialization/store portability (`ClientProfile`, `ProfileSerialization`, `ProfilePortabilityService`)
  - control path rendering/planning (`TrojanClientConfigRenderer`, `AdapterBackedClientController`, `RealShellConnectPlanner`)
  - diagnostics/export evidence (`DiagnosticsExportService` selectedProfile routing summary)
- align schema output to routing-enabled payloads (`version: 2`) for profile serialization + portability exports while keeping decode fallback defaults safe
- add focused tests for routing decision and integration contracts across profiles/controller/diagnostics

## Key files
- routing core:
  - `client/lib/features/routing/domain/routing_models.dart`
  - `client/lib/features/routing/domain/routing_profile_config.dart`
  - `client/lib/features/routing/application/routing_decision_engine.dart`
  - `client/lib/features/routing/application/routing_profile_codec.dart`
- integration points:
  - `client/lib/features/profiles/domain/client_profile.dart`
  - `client/lib/features/profiles/application/profile_serialization.dart`
  - `client/lib/features/profiles/application/profile_portability_service.dart`
  - `client/lib/features/controller/application/trojan_client_config_renderer.dart`
  - `client/lib/features/controller/application/adapter_backed_client_controller.dart`
  - `client/lib/features/controller/application/real_shell_connect_planner.dart`
  - `client/lib/features/diagnostics/application/diagnostics_export_service.dart`

## Tests / Verification
- `flutter analyze` (from `client/`) ✅
- targeted integration + routing tests ✅
- full `flutter test` (from `client/`) ✅

Executed commands:
- `flutter analyze`
- `flutter test`

## Notes
- Environment warns about running Flutter as root (`Woah! ... run flutter as root`), but analyze/test suites complete successfully.
- This PR is the v1.5.0 routing-kernel integration slice (client-side data/control/diagnostics path), with runtime-side behavior expansion to follow in subsequent slices.
