### PR TITLE
chore(release): cut v1.5.0-beta.2 release truth and gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,44 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v1.5.0-beta.2] - 2026-04-16
+
+### EN
+
+#### Added
+- Promoted `Routing Safety & UX P0` completion to `main` via PR #16, including:
+  - routing guardrail preflight risk checks before profile apply
+  - routing dry-run diff impact reporting
+  - profile editor submit gate integrating preflight + dry-run evidence
+  - runtime rollback registry with anti-flap quarantine (`2 / 30m`) and safe-mode signaling
+  - diagnostics export closure for routing recovery evidence
+  - profiles surface for safe-mode and quarantined status visibility
+- CI smoke targeted gate expanded to continuously enforce routing safety + dataplane evidence slices in one deterministic lane.
+
+#### Changed
+- Packaging release truth defaults advanced for this cut:
+  - version label: `1.5.0-beta.2`
+  - channel: `beta`
+
+### 中文
+
+#### 新增
+- 已将 `Routing Safety & UX P0`（PR #16）提升到 `main`，核心包括：
+  - profile 提交前 routing guardrail preflight 风险拦截
+  - routing dry-run 差异影响预演
+  - editor submit 与 preflight + dry-run 证据联动门禁
+  - 运行期 rollback 注册与 anti-flap quarantine（`30 分钟内 2 次`）+ safe-mode 信号
+  - diagnostics 导出补齐 routing recovery evidence
+  - Profiles 页面可视化 safe-mode / quarantined 状态
+- CI smoke 的 targeted gate 已扩展，持续覆盖 routing safety 与 dataplane evidence 关键切片。
+
+#### 变更
+- 本次发版将 packaging release truth 默认值推进到：
+  - version label：`1.5.0-beta.2`
+  - channel：`beta`
+
+---
+
 ## [v1.5.0-beta.1] - 2026-04-16
 
 ### EN

--- a/client/lib/features/packaging/application/packaging_store.dart
+++ b/client/lib/features/packaging/application/packaging_store.dart
@@ -185,6 +185,6 @@ class PackagingStore extends ChangeNotifier {
   }
 
   static String _stubUpdateSummaryFor(UpdateChannel channel) {
-    return 'Update check stub executed for ${channel.name}. No remote release feed is wired in v1.5.0-beta.1 yet; use exported release metadata + packaging docs instead.';
+    return 'Update check stub executed for ${channel.name}. No remote release feed is wired in v1.5.0-beta.2 yet; use exported release metadata + packaging docs instead.';
   }
 }

--- a/client/lib/features/packaging/domain/update_workflow_state.dart
+++ b/client/lib/features/packaging/domain/update_workflow_state.dart
@@ -61,7 +61,7 @@ class UpdateWorkflowState {
 
   static const UpdateWorkflowState initial = UpdateWorkflowState(
     selectedChannel: UpdateChannel.beta,
-    currentVersionLabel: '1.5.0-beta.1',
+    currentVersionLabel: '1.5.0-beta.2',
     updateChecksEnabled: true,
     lastCheckSummary:
         'No update check has been executed in this shell environment yet.',

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: trojan_pro_client
 description: Desktop-first, mobile-ready client shell for Trojan-Pro.
 publish_to: "none"
-version: 1.5.0-beta.1+1
+version: 1.5.0-beta.2+1
 
 environment:
   sdk: ^3.3.0

--- a/client/test/features/packaging/application/packaging_store_test.dart
+++ b/client/test/features/packaging/application/packaging_store_test.dart
@@ -8,7 +8,7 @@ void main() {
     final store = PackagingStore();
 
     expect(store.state.selectedChannel, UpdateChannel.beta);
-    expect(store.state.currentVersionLabel, '1.5.0-beta.1');
+    expect(store.state.currentVersionLabel, '1.5.0-beta.2');
   });
 
   test('stub update check records status and timestamp', () {

--- a/client/test/features/packaging/presentation/packaging_page_test.dart
+++ b/client/test/features/packaging/presentation/packaging_page_test.dart
@@ -134,7 +134,7 @@ void main() {
     expect(find.text('Check for Updates (Stub)'), findsOneWidget);
     expect(find.textContaining('Metadata Contract'), findsOneWidget);
     expect(find.textContaining('Contract Version'), findsOneWidget);
-    expect(find.text('1.5.0-beta.1'), findsOneWidget);
+    expect(find.text('1.5.0-beta.2'), findsOneWidget);
     expect(find.text('beta'), findsWidgets);
   });
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ This directory only keeps the current, useful project documentation.
 - `v1.4.0-sprint-5-plan.md` — execution plan for the release truth & beta validation sprint
 - `v1.4.0-roadmap.md` — milestone sequence for the runtime-true desktop client line
 - `v1.4.0-release-gates.md` — completion and release gates for the v1.4.0 milestone
+- `v1.5.0-release-gates.md` — completion and release gates for the v1.5.0 milestone
 - `../CHANGELOG.md` — versioned release history
 
 ## Decisions

--- a/docs/v1.5.0-release-gates.md
+++ b/docs/v1.5.0-release-gates.md
@@ -1,0 +1,50 @@
+# v1.5.0 Release Gates
+
+## Purpose
+
+Define what must be true before `v1.5.0` can be promoted from milestone-complete to releasable.
+
+---
+
+## Gate 1 — Product truth
+- [x] routing rule/policy editing baseline is usable end-to-end
+- [x] risky routing changes are blocked pre-apply by guardrail preflight
+- [x] user can preview routing impact via dry-run before applying changes
+- [x] runtime rollback and anti-flap quarantine posture are visible in product surfaces
+
+### Current snapshot — 2026-04-16
+`Routing Safety & UX P0` is merged to `main` via PR #16 (`acbdb83`).
+
+## Gate 2 — Support truth
+- [x] diagnostics export includes routing recovery evidence payloads
+- [x] safe-mode / quarantine status is visible in Profiles for operator triage
+- [x] routing failure/recovery evidence is structured for support handoff
+
+### Current snapshot — 2026-04-16
+Diagnostics export now includes routing recovery artifacts and Profiles surfaces safe-mode/quarantine signals for direct operator consumption.
+
+## Gate 3 — Release truth
+- [x] pubspec / packaging metadata / workflow state are version-aligned
+- [x] product-visible channel/version matches packaging metadata
+- [x] changelog records the current release scope and truth posture
+
+### Current snapshot — 2026-04-16
+Release truth validated by `python3 scripts/validate_client_release_truth.py` for `1.5.0-beta.2`.
+
+## Gate 4 — Validation truth
+- [x] CI Smoke is green on `main` after merge
+- [x] Build and Release workflow (manual dispatch) completed with core + client artifact validation
+- [x] packaged smoke gates passed for Linux/Windows/macOS client lanes
+
+### Current snapshot — 2026-04-16
+- CI Smoke (main): run `24507803880` ✅
+- Build and Release (manual dispatch): run `24508193811` ✅
+
+---
+
+## Non-gates
+
+The following remain valuable but are not blockers for this cut:
+- updater remote feed implementation
+- notarization/signing hardening for broader distribution channels
+- mobile parity beyond current desktop-first release commitment

--- a/packaging/linux/release-metadata.env
+++ b/packaging/linux/release-metadata.env
@@ -10,8 +10,8 @@ ICON_NAME="trojan-pro-client"
 ICON_SOURCE="packaging/linux/assets/trojan-pro-client.png"
 
 CHANNEL="beta"
-VERSION_LABEL="1.5.0-beta.1"
-DEB_VERSION="1.5.0~beta.1-1"
+VERSION_LABEL="1.5.0-beta.2"
+DEB_VERSION="1.5.0~beta.2-1"
 PACKAGE_ARCH="amd64"
 ARTIFACT_STEM="trojan-pro-client"
 


### PR DESCRIPTION
## 摘要\n- 将 release truth 从 1.5.0-beta.1 提升到 1.5.0-beta.2（pubspec / packaging metadata / workflow state / packaging tests 同步）\n- 更新 CHANGELOG，新增 v1.5.0-beta.2 条目并记录 Routing Safety & UX P0 已并入 main（PR #16）\n- 新增 docs/v1.5.0-release-gates.md 并在 docs/README.md 挂载\n\n## 验证\n- flutter analyze\n- flutter test test/features/packaging/application/packaging_store_test.dart test/features/packaging/presentation/packaging_page_test.dart\n- python3 scripts/validate_client_release_truth.py\n- GitHub Actions: Build and Release (workflow_dispatch) run 24508193811 全绿