### PR TITLE
feat(client): land Iter-1 connect gating + failure policy pack

### DIFF
--- a/client/lib/features/controller/domain/failure_family.dart
+++ b/client/lib/features/controller/domain/failure_family.dart
@@ -60,8 +60,76 @@ FailureFamily classifyFailureFamily({
     return needles.any(combined.contains);
   }
 
-  if (code == 'MISSING_TROJAN_PASSWORD' ||
-      containsAny(<String>['missing_trojan_password', 'no trojan password'])) {
+  FailureFamily? fromErrorCode(String value) {
+    if (value.isEmpty) return null;
+
+    if (value == 'MISSING_TROJAN_PASSWORD' ||
+        value == 'MISSING_CONNECT_INPUTS' ||
+        value.contains('PASSWORD')) {
+      return FailureFamily.userInput;
+    }
+
+    if (value == 'UNSUPPORTED' ||
+        value.contains('UNAVAILABLE') ||
+        value.contains('ENV') ||
+        value.contains('BINARY') ||
+        value.contains('PATH')) {
+      return FailureFamily.environment;
+    }
+
+    if (value.contains('CONFIG')) {
+      return FailureFamily.config;
+    }
+
+    if (value.contains('EXPORT') ||
+        value.contains('PERMISSION') ||
+        value.contains('FILESYSTEM')) {
+      return FailureFamily.exportOs;
+    }
+
+    if (value.startsWith('RUNTIME_') ||
+        value.contains('SESSION') ||
+        value.contains('CONNECT') ||
+        value.contains('ROUTING')) {
+      return FailureFamily.connect;
+    }
+
+    if (value.contains('PROCESS') ||
+        value.contains('LAUNCH') ||
+        value.contains('KILL') ||
+        value.contains('OPERATION_IN_PROGRESS') ||
+        value.contains('NO_RUNNING_PROCESS')) {
+      return FailureFamily.launch;
+    }
+
+    return null;
+  }
+
+  final byCode = fromErrorCode(code);
+  if (byCode != null) {
+    return byCode;
+  }
+
+  if (normalizedPhase == 'user_input' || normalizedPhase == 'input') {
+    return FailureFamily.userInput;
+  }
+  if (normalizedPhase == 'config' || normalizedPhase == 'configuration') {
+    return FailureFamily.config;
+  }
+  if (normalizedPhase == 'environment') {
+    return FailureFamily.environment;
+  }
+  if (normalizedPhase == 'export' || normalizedPhase == 'export_os') {
+    return FailureFamily.exportOs;
+  }
+  if (normalizedPhase == 'runtime' || normalizedPhase == 'connect') {
+    return FailureFamily.connect;
+  }
+  if (normalizedPhase == 'launch') {
+    return FailureFamily.launch;
+  }
+
+  if (containsAny(<String>['missing_trojan_password', 'no trojan password'])) {
     return FailureFamily.userInput;
   }
 
@@ -74,13 +142,12 @@ FailureFamily classifyFailureFamily({
     return FailureFamily.exportOs;
   }
 
-  if (code == 'UNSUPPORTED' ||
-      containsAny(<String>[
-        'unsupported',
-        'does not expose runtime diagnostics',
-        'does not expose export preparation',
-        'cannot provide that runtime evidence',
-      ])) {
+  if (containsAny(<String>[
+    'unsupported',
+    'does not expose runtime diagnostics',
+    'does not expose export preparation',
+    'cannot provide that runtime evidence',
+  ])) {
     return FailureFamily.environment;
   }
 
@@ -94,10 +161,6 @@ FailureFamily classifyFailureFamily({
     return FailureFamily.config;
   }
 
-  if (normalizedPhase == 'runtime') {
-    return FailureFamily.connect;
-  }
-
   if (containsAny(<String>[
     'runtime session exited with code',
     'runtime session stopped with error',
@@ -105,10 +168,6 @@ FailureFamily classifyFailureFamily({
     'connect path failed after launch',
   ])) {
     return FailureFamily.connect;
-  }
-
-  if (normalizedPhase == 'launch') {
-    return FailureFamily.launch;
   }
 
   if (containsAny(<String>[

--- a/client/lib/features/diagnostics/application/diagnostics_export_service.dart
+++ b/client/lib/features/diagnostics/application/diagnostics_export_service.dart
@@ -109,6 +109,10 @@ class DiagnosticsExportService {
         'usageHint': runtimePosture.isRuntimeTrue
             ? 'Use as runtime-true evidence when posture remains evidence-grade.'
             : 'Treat as support context rather than proof of runtime-true execution.',
+        'secretStorageSummary': storageStatus.userFacingSummary,
+        'secretStorageMode': storageStatus.storageModeLabel,
+        'secretStoragePersistent': storageStatus.isPersistent,
+        'secretStorageSecure': storageStatus.isSecure,
       },
       'bundleKind': bundleKind,
       'generatedAt': DateTime.now().toIso8601String(),

--- a/client/lib/features/diagnostics/application/diagnostics_export_service.dart
+++ b/client/lib/features/diagnostics/application/diagnostics_export_service.dart
@@ -7,6 +7,7 @@ import '../../controller/application/client_controller_api.dart';
 import '../../controller/domain/controller_command_result.dart';
 import '../../controller/domain/controller_runtime_session.dart';
 import '../../controller/domain/runtime_posture.dart';
+import '../../diagnostics/domain/export_summary_snapshot.dart';
 import '../../diagnostics/domain/routing_evidence_record.dart';
 import '../../diagnostics/domain/routing_recovery_record.dart';
 import '../../packaging/application/packaging_store.dart';
@@ -100,20 +101,14 @@ class DiagnosticsExportService {
     final storageStatus = secureStorage.status;
     final appUnhandledError = appRuntimeErrors.lastUnhandledError;
 
+    final exportSummary = ExportSummarySnapshot.fromContext(
+      runtimePosture: runtimePosture,
+      runtimeSession: runtimeSession,
+      storageStatus: storageStatus,
+    );
+
     final payload = <String, Object?>{
-      'exportSummary': {
-        'runtimePostureLabel': runtimePosture.postureLabel,
-        'evidenceGrade': runtimePosture.evidenceGradeLabel,
-        'runtimeTruth': runtimeSession.truth.label,
-        'recoveryHint': runtimeSession.recoveryGuidance,
-        'usageHint': runtimePosture.isRuntimeTrue
-            ? 'Use as runtime-true evidence when posture remains evidence-grade.'
-            : 'Treat as support context rather than proof of runtime-true execution.',
-        'secretStorageSummary': storageStatus.userFacingSummary,
-        'secretStorageMode': storageStatus.storageModeLabel,
-        'secretStoragePersistent': storageStatus.isPersistent,
-        'secretStorageSecure': storageStatus.isSecure,
-      },
+      'exportSummary': exportSummary.toJson(),
       'bundleKind': bundleKind,
       'generatedAt': DateTime.now().toIso8601String(),
       'profileCount': profileStore.profiles.length,

--- a/client/lib/features/diagnostics/domain/export_summary_snapshot.dart
+++ b/client/lib/features/diagnostics/domain/export_summary_snapshot.dart
@@ -1,0 +1,61 @@
+import '../../controller/domain/controller_runtime_session.dart';
+import '../../controller/domain/runtime_posture.dart';
+import '../../../platform/secure_storage/secure_storage.dart';
+
+class ExportSummarySnapshot {
+  const ExportSummarySnapshot({
+    required this.runtimePostureLabel,
+    required this.evidenceGrade,
+    required this.runtimeTruth,
+    required this.recoveryHint,
+    required this.usageHint,
+    required this.secretStorageSummary,
+    required this.secretStorageMode,
+    required this.secretStoragePersistent,
+    required this.secretStorageSecure,
+  });
+
+  factory ExportSummarySnapshot.fromContext({
+    required RuntimePosture runtimePosture,
+    required ControllerRuntimeSession runtimeSession,
+    required SecureStorageStatus storageStatus,
+  }) {
+    return ExportSummarySnapshot(
+      runtimePostureLabel: runtimePosture.postureLabel,
+      evidenceGrade: runtimePosture.evidenceGradeLabel,
+      runtimeTruth: runtimeSession.truth.label,
+      recoveryHint: runtimeSession.recoveryGuidance,
+      usageHint: runtimePosture.isRuntimeTrue
+          ? 'Use as runtime-true evidence when posture remains evidence-grade.'
+          : 'Treat as support context rather than proof of runtime-true execution.',
+      secretStorageSummary: storageStatus.userFacingSummary,
+      secretStorageMode: storageStatus.storageModeLabel,
+      secretStoragePersistent: storageStatus.isPersistent,
+      secretStorageSecure: storageStatus.isSecure,
+    );
+  }
+
+  final String runtimePostureLabel;
+  final String evidenceGrade;
+  final String runtimeTruth;
+  final String recoveryHint;
+  final String usageHint;
+  final String secretStorageSummary;
+  final String secretStorageMode;
+  final bool secretStoragePersistent;
+  final bool secretStorageSecure;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'runtimePostureLabel': runtimePostureLabel,
+      'evidenceGrade': evidenceGrade,
+      'runtimeTruth': runtimeTruth,
+      'recoveryHint': recoveryHint,
+      'usageHint': usageHint,
+      'secretStorageSummary': secretStorageSummary,
+      'secretStorageMode': secretStorageMode,
+      'secretStoragePersistent': secretStoragePersistent,
+      'secretStorageSecure': secretStorageSecure,
+    };
+  }
+}

--- a/client/lib/features/diagnostics/presentation/diagnostics_page.dart
+++ b/client/lib/features/diagnostics/presentation/diagnostics_page.dart
@@ -104,6 +104,10 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
             ExportSummarySheet.fromRuntimePosture(
               posture: runtimePosture,
               recoveryHint: supportPolicy.currentTruthMessage,
+              secretStorageSummary:
+                  widget.services.profileSecrets.storageSummary,
+              secretStorageMode:
+                  widget.services.profileSecrets.storageStatus.storageModeLabel,
             ),
             const SizedBox(height: 16),
             _RuntimeTruthSupportCard(

--- a/client/lib/features/diagnostics/presentation/diagnostics_page.dart
+++ b/client/lib/features/diagnostics/presentation/diagnostics_page.dart
@@ -6,6 +6,7 @@ import '../../controller/domain/controller_runtime_session.dart';
 import '../../controller/domain/runtime_operator_advice.dart';
 import '../../controller/domain/runtime_posture.dart';
 import '../application/support_issue_descriptor.dart';
+import '../domain/export_summary_snapshot.dart';
 import '../../profiles/presentation/import_export_dialog.dart';
 import 'diagnostics_support_policy.dart';
 import 'export_summary_sheet.dart';
@@ -49,6 +50,12 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
       operatorAdvice: operatorAdvice,
       exportedRuntimeSession: _lastExportRuntimeSession,
       exportedBundleKindLabel: _lastExportKindLabel,
+    );
+
+    final exportSummary = ExportSummarySnapshot.fromContext(
+      runtimePosture: runtimePosture,
+      runtimeSession: runtimeSession,
+      storageStatus: widget.services.profileSecrets.storageStatus,
     );
 
     return SingleChildScrollView(
@@ -101,14 +108,7 @@ class _DiagnosticsPageState extends State<DiagnosticsPage> {
               runtimePosture: runtimePosture,
             ),
             const SizedBox(height: 12),
-            ExportSummarySheet.fromRuntimePosture(
-              posture: runtimePosture,
-              recoveryHint: supportPolicy.currentTruthMessage,
-              secretStorageSummary:
-                  widget.services.profileSecrets.storageSummary,
-              secretStorageMode:
-                  widget.services.profileSecrets.storageStatus.storageModeLabel,
-            ),
+            ExportSummarySheet.fromSnapshot(exportSummary),
             const SizedBox(height: 16),
             _RuntimeTruthSupportCard(
               runtimeSession: runtimeSession,

--- a/client/lib/features/diagnostics/presentation/export_summary_sheet.dart
+++ b/client/lib/features/diagnostics/presentation/export_summary_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../domain/export_summary_snapshot.dart';
 import '../../controller/domain/runtime_posture.dart';
 
 class ExportSummarySheet extends StatelessWidget {
@@ -30,6 +31,17 @@ class ExportSummarySheet extends StatelessWidget {
           : 'Use this export for support triage only.',
       secretStorageSummary: secretStorageSummary,
       secretStorageMode: secretStorageMode,
+    );
+  }
+
+  factory ExportSummarySheet.fromSnapshot(ExportSummarySnapshot snapshot) {
+    return ExportSummarySheet(
+      runtimePostureLabel: snapshot.runtimePostureLabel,
+      recoveryHint: snapshot.recoveryHint,
+      evidenceGradeLabel: snapshot.evidenceGrade,
+      exportUsageHint: snapshot.usageHint,
+      secretStorageSummary: snapshot.secretStorageSummary,
+      secretStorageMode: snapshot.secretStorageMode,
     );
   }
 

--- a/client/lib/features/diagnostics/presentation/export_summary_sheet.dart
+++ b/client/lib/features/diagnostics/presentation/export_summary_sheet.dart
@@ -10,11 +10,15 @@ class ExportSummarySheet extends StatelessWidget {
     this.evidenceGradeLabel,
     this.evidenceNote,
     this.exportUsageHint,
+    this.secretStorageSummary,
+    this.secretStorageMode,
   });
 
   factory ExportSummarySheet.fromRuntimePosture({
     required RuntimePosture posture,
     required String recoveryHint,
+    String? secretStorageSummary,
+    String? secretStorageMode,
   }) {
     return ExportSummarySheet(
       runtimePostureLabel: posture.postureLabel,
@@ -24,6 +28,8 @@ class ExportSummarySheet extends StatelessWidget {
       exportUsageHint: posture.isRuntimeTrue
           ? 'Use this export for operator handoff and evidence packaging.'
           : 'Use this export for support triage only.',
+      secretStorageSummary: secretStorageSummary,
+      secretStorageMode: secretStorageMode,
     );
   }
 
@@ -32,6 +38,8 @@ class ExportSummarySheet extends StatelessWidget {
   final String? evidenceGradeLabel;
   final String? evidenceNote;
   final String? exportUsageHint;
+  final String? secretStorageSummary;
+  final String? secretStorageMode;
 
   @override
   Widget build(BuildContext context) {
@@ -71,6 +79,17 @@ class ExportSummarySheet extends StatelessWidget {
               exportUsageHint!,
               style: const TextStyle(fontWeight: FontWeight.w600),
             ),
+          ],
+          if ((secretStorageSummary ?? '').isNotEmpty) ...<Widget>[
+            const SizedBox(height: 8),
+            Text(
+              'Secret storage: $secretStorageSummary',
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+            if ((secretStorageMode ?? '').isNotEmpty) ...<Widget>[
+              const SizedBox(height: 4),
+              Text('Storage mode: $secretStorageMode'),
+            ],
           ],
         ],
       ),

--- a/client/lib/features/profiles/presentation/connect_timeline_card.dart
+++ b/client/lib/features/profiles/presentation/connect_timeline_card.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/widgets/section_card.dart';
+import '../../controller/domain/client_connection_status.dart';
+import '../../controller/domain/controller_runtime_session.dart';
+import '../../controller/domain/failure_family.dart';
+import 'next_action_policy.dart';
+
+class ConnectTimelineCard extends StatelessWidget {
+  const ConnectTimelineCard({
+    super.key,
+    required this.status,
+    required this.runtimeSession,
+    required this.failureFamily,
+    required this.nextAction,
+  });
+
+  final ClientConnectionStatus status;
+  final ControllerRuntimeSession runtimeSession;
+  final FailureFamily failureFamily;
+  final ProfileNextActionDecision nextAction;
+
+  static const List<_ConnectTimelineStage> _stages = <_ConnectTimelineStage>[
+    _ConnectTimelineStage(
+      key: 'planned',
+      description: 'Build and validate managed runtime launch inputs.',
+    ),
+    _ConnectTimelineStage(
+      key: 'launching',
+      description: 'Start runtime process and watch early bootstrap signals.',
+    ),
+    _ConnectTimelineStage(
+      key: 'alive',
+      description: 'Runtime process is alive and emits runtime evidence.',
+    ),
+    _ConnectTimelineStage(
+      key: 'session-ready',
+      description: 'Runtime-true session-ready reached. Connect is trustworthy.',
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final stageIndex = _stageIndex(status: status, runtimeSession: runtimeSession);
+    final currentStageLabel =
+        stageIndex == null ? 'idle' : _stages[stageIndex].key;
+
+    return SectionCard(
+      title: 'Connect timeline',
+      subtitle: 'Runtime phase progression for first-connect transparency.',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            'Current stage: $currentStageLabel',
+            style: const TextStyle(fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 8),
+          ..._stages.asMap().entries.map((entry) {
+            final index = entry.key;
+            final stage = entry.value;
+            final state = _stateFor(index: index, currentStageIndex: stageIndex);
+            return _buildStageRow(context, stage, state);
+          }),
+          if (_showExitConfirmationWarning(status, runtimeSession)) ...<Widget>[
+            const SizedBox(height: 8),
+            const Text(
+              'Waiting for exit confirmation before marking disconnected.',
+              style: TextStyle(
+                color: Colors.deepOrange,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+          if (status.phase == ClientConnectionPhase.error) ...<Widget>[
+            const SizedBox(height: 8),
+            Text(
+              'Failure family: ${failureFamily.displayLabel}',
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+            if (nextAction.isActionable) ...<Widget>[
+              const SizedBox(height: 4),
+              Text(
+                'Next action: ${nextAction.label}',
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(height: 4),
+              Text(nextAction.detail),
+            ],
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStageRow(
+    BuildContext context,
+    _ConnectTimelineStage stage,
+    _ConnectTimelineStageState state,
+  ) {
+    final palette = switch (state) {
+      _ConnectTimelineStageState.completed => (
+          icon: Icons.check_circle,
+          color: Colors.green,
+          tag: 'completed',
+        ),
+      _ConnectTimelineStageState.active => (
+          icon: Icons.play_circle_fill,
+          color: Colors.blue,
+          tag: 'active',
+        ),
+      _ConnectTimelineStageState.pending => (
+          icon: Icons.radio_button_unchecked,
+          color: Colors.grey,
+          tag: 'pending',
+        ),
+    };
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(
+            palette.icon,
+            size: 18,
+            color: palette.color,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  '${stage.key} • ${palette.tag}',
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: palette.color,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  stage.description,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  _ConnectTimelineStageState _stateFor({
+    required int index,
+    required int? currentStageIndex,
+  }) {
+    if (currentStageIndex == null) {
+      return _ConnectTimelineStageState.pending;
+    }
+    if (index < currentStageIndex) {
+      return _ConnectTimelineStageState.completed;
+    }
+    if (index == currentStageIndex) {
+      return _ConnectTimelineStageState.active;
+    }
+    return _ConnectTimelineStageState.pending;
+  }
+
+  int? _stageIndex({
+    required ClientConnectionStatus status,
+    required ControllerRuntimeSession runtimeSession,
+  }) {
+    if (status.phase == ClientConnectionPhase.disconnected &&
+        !runtimeSession.isRunning) {
+      return null;
+    }
+
+    return switch (runtimeSession.phase) {
+      ControllerRuntimePhase.planned => 0,
+      ControllerRuntimePhase.launching => 1,
+      ControllerRuntimePhase.alive => 2,
+      ControllerRuntimePhase.sessionReady => 3,
+      ControllerRuntimePhase.failed => 2,
+      ControllerRuntimePhase.stopped =>
+        status.phase == ClientConnectionPhase.connected ? 3 : null,
+    };
+  }
+
+  bool _showExitConfirmationWarning(
+    ClientConnectionStatus status,
+    ControllerRuntimeSession runtimeSession,
+  ) {
+    return status.phase == ClientConnectionPhase.disconnecting ||
+        runtimeSession.truth == ControllerRuntimeSessionTruth.stopping;
+  }
+}
+
+enum _ConnectTimelineStageState {
+  completed,
+  active,
+  pending,
+}
+
+class _ConnectTimelineStage {
+  const _ConnectTimelineStage({
+    required this.key,
+    required this.description,
+  });
+
+  final String key;
+  final String description;
+}

--- a/client/lib/features/profiles/presentation/first_connect_guidance_card.dart
+++ b/client/lib/features/profiles/presentation/first_connect_guidance_card.dart
@@ -5,14 +5,19 @@ class FirstConnectGuidanceCard extends StatelessWidget {
     super.key,
     required this.blockingReason,
     required this.nextAction,
+    this.actionLabel,
+    this.onAction,
   });
 
   final String? blockingReason;
   final String nextAction;
+  final String? actionLabel;
+  final VoidCallback? onAction;
 
   @override
   Widget build(BuildContext context) {
-    final hasBlocker = blockingReason != null && blockingReason!.trim().isNotEmpty;
+    final hasBlocker =
+        blockingReason != null && blockingReason!.trim().isNotEmpty;
 
     return Container(
       width: double.infinity,
@@ -39,6 +44,13 @@ class FirstConnectGuidanceCard extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           Text('Next step: $nextAction'),
+          if (actionLabel != null && onAction != null) ...<Widget>[
+            const SizedBox(height: 8),
+            OutlinedButton(
+              onPressed: onAction,
+              child: Text(actionLabel!),
+            ),
+          ],
         ],
       ),
     );

--- a/client/lib/features/profiles/presentation/next_action_policy.dart
+++ b/client/lib/features/profiles/presentation/next_action_policy.dart
@@ -1,0 +1,226 @@
+import '../../controller/domain/client_connection_status.dart';
+import '../../controller/domain/failure_family.dart';
+import '../../readiness/domain/readiness_report.dart';
+
+enum ProfileNextActionType {
+  openProfiles,
+  openTroubleshooting,
+  openSettings,
+  retryConnect,
+  exportSupportBundle,
+  none,
+}
+
+class ProfileNextActionDecision {
+  const ProfileNextActionDecision({
+    required this.type,
+    required this.label,
+    required this.detail,
+  });
+
+  static const ProfileNextActionDecision none = ProfileNextActionDecision(
+    type: ProfileNextActionType.none,
+    label: 'No action',
+    detail: 'No follow-up action is required right now.',
+  );
+
+  final ProfileNextActionType type;
+  final String label;
+  final String detail;
+
+  bool get isActionable => type != ProfileNextActionType.none;
+
+  ReadinessAction? get readinessAction {
+    return switch (type) {
+      ProfileNextActionType.openProfiles => ReadinessAction.openProfiles,
+      ProfileNextActionType.openTroubleshooting =>
+        ReadinessAction.openTroubleshooting,
+      ProfileNextActionType.openSettings => ReadinessAction.openSettings,
+      ProfileNextActionType.retryConnect ||
+      ProfileNextActionType.exportSupportBundle ||
+      ProfileNextActionType.none => null,
+    };
+  }
+}
+
+class ProfileNextActionPolicy {
+  static ProfileNextActionDecision resolve({
+    required ClientConnectionStatus status,
+    required ReadinessReport? readinessReport,
+    required FailureFamily failureFamily,
+    required bool troubleshootingAvailable,
+    required bool settingsAvailable,
+  }) {
+    if (readinessReport != null &&
+        readinessReport.overallLevel == ReadinessLevel.blocked) {
+      return _fromReadiness(
+        report: readinessReport,
+        troubleshootingAvailable: troubleshootingAvailable,
+        settingsAvailable: settingsAvailable,
+      );
+    }
+
+    if (status.phase == ClientConnectionPhase.error) {
+      return _fromFailureFamily(
+        failureFamily,
+        troubleshootingAvailable: troubleshootingAvailable,
+        settingsAvailable: settingsAvailable,
+      );
+    }
+
+    if (status.phase == ClientConnectionPhase.disconnecting) {
+      return troubleshootingAvailable
+          ? const ProfileNextActionDecision(
+              type: ProfileNextActionType.openTroubleshooting,
+              label: 'Open Troubleshooting',
+              detail:
+                  'Wait for runtime exit confirmation before assuming shutdown has finished.',
+            )
+          : const ProfileNextActionDecision(
+              type: ProfileNextActionType.openProfiles,
+              label: 'Open Profiles',
+              detail:
+                  'Wait for runtime exit confirmation before assuming shutdown has finished.',
+            );
+    }
+
+    return ProfileNextActionDecision.none;
+  }
+
+  static ProfileNextActionDecision _fromReadiness({
+    required ReadinessReport report,
+    required bool troubleshootingAvailable,
+    required bool settingsAvailable,
+  }) {
+    final recommendation = report.recommendation;
+    if (recommendation != null) {
+      return switch (recommendation.action) {
+        ReadinessAction.openProfiles => ProfileNextActionDecision(
+            type: ProfileNextActionType.openProfiles,
+            label: recommendation.label,
+            detail: recommendation.detail,
+          ),
+        ReadinessAction.openTroubleshooting => ProfileNextActionDecision(
+            type: troubleshootingAvailable
+                ? ProfileNextActionType.openTroubleshooting
+                : ProfileNextActionType.openProfiles,
+            label:
+                troubleshootingAvailable ? recommendation.label : 'Open Profiles',
+            detail: recommendation.detail,
+          ),
+        ReadinessAction.openSettings => ProfileNextActionDecision(
+            type: settingsAvailable
+                ? ProfileNextActionType.openSettings
+                : ProfileNextActionType.openProfiles,
+            label: settingsAvailable ? recommendation.label : 'Open Profiles',
+            detail: recommendation.detail,
+          ),
+      };
+    }
+
+    final blocked = _firstBlockedCheck(report.checks);
+    if (blocked == null) {
+      return const ProfileNextActionDecision(
+        type: ProfileNextActionType.openProfiles,
+        label: 'Open Profiles',
+        detail: 'Review profile details and retry the connect test.',
+      );
+    }
+
+    return switch (blocked.domain) {
+      ReadinessDomain.password => ProfileNextActionDecision(
+          type: ProfileNextActionType.openProfiles,
+          label: 'Set Password',
+          detail: blocked.detail ?? blocked.summary,
+        ),
+      ReadinessDomain.profile || ReadinessDomain.config =>
+        ProfileNextActionDecision(
+          type: ProfileNextActionType.openProfiles,
+          label: 'Open Profiles',
+          detail: blocked.detail ?? blocked.summary,
+        ),
+      ReadinessDomain.secureStorage => ProfileNextActionDecision(
+          type: settingsAvailable
+              ? ProfileNextActionType.openSettings
+              : ProfileNextActionType.openProfiles,
+          label: settingsAvailable ? 'Open Settings' : 'Open Profiles',
+          detail: blocked.detail ?? blocked.summary,
+        ),
+      ReadinessDomain.environment ||
+      ReadinessDomain.runtimePath ||
+      ReadinessDomain.runtimeBinary ||
+      ReadinessDomain.filesystem =>
+        ProfileNextActionDecision(
+          type: troubleshootingAvailable
+              ? ProfileNextActionType.openTroubleshooting
+              : ProfileNextActionType.openProfiles,
+          label:
+              troubleshootingAvailable ? 'Open Troubleshooting' : 'Open Profiles',
+          detail: blocked.detail ?? blocked.summary,
+        ),
+    };
+  }
+
+  static ProfileNextActionDecision _fromFailureFamily(
+    FailureFamily family, {
+    required bool troubleshootingAvailable,
+    required bool settingsAvailable,
+  }) {
+    return switch (family) {
+      FailureFamily.userInput => const ProfileNextActionDecision(
+          type: ProfileNextActionType.openProfiles,
+          label: 'Set Password',
+          detail: 'Save the Trojan password, then retry connect test.',
+        ),
+      FailureFamily.config => const ProfileNextActionDecision(
+          type: ProfileNextActionType.openProfiles,
+          label: 'Open Profiles',
+          detail: 'Review profile config fields before retrying.',
+        ),
+      FailureFamily.launch || FailureFamily.connect =>
+        const ProfileNextActionDecision(
+          type: ProfileNextActionType.retryConnect,
+          label: 'Retry Connect Test',
+          detail: 'Retry the connect test after preserving current evidence.',
+        ),
+      FailureFamily.environment => ProfileNextActionDecision(
+          type: settingsAvailable
+              ? ProfileNextActionType.openSettings
+              : (troubleshootingAvailable
+                  ? ProfileNextActionType.openTroubleshooting
+                  : ProfileNextActionType.openProfiles),
+          label: settingsAvailable
+              ? 'Open Settings'
+              : (troubleshootingAvailable
+                  ? 'Open Troubleshooting'
+                  : 'Open Profiles'),
+          detail:
+              'Check runtime environment availability before the next attempt.',
+        ),
+      FailureFamily.exportOs => const ProfileNextActionDecision(
+          type: ProfileNextActionType.exportSupportBundle,
+          label: 'Export Support Bundle',
+          detail:
+              'Capture a support bundle after checking file permissions and target path.',
+        ),
+      FailureFamily.unknown => ProfileNextActionDecision(
+          type: troubleshootingAvailable
+              ? ProfileNextActionType.openTroubleshooting
+              : ProfileNextActionType.openProfiles,
+          label:
+              troubleshootingAvailable ? 'Open Troubleshooting' : 'Open Profiles',
+          detail:
+              'Open Troubleshooting and capture runtime evidence before retrying.',
+        ),
+    };
+  }
+
+  static ReadinessCheck? _firstBlockedCheck(List<ReadinessCheck> checks) {
+    for (final check in checks) {
+      if (check.level == ReadinessLevel.blocked) {
+        return check;
+      }
+    }
+    return null;
+  }
+}

--- a/client/lib/features/profiles/presentation/profile_connection_action_policy.dart
+++ b/client/lib/features/profiles/presentation/profile_connection_action_policy.dart
@@ -94,7 +94,7 @@ class ProfileConnectionActionPolicy {
       return ProfileConnectionActionPolicy(
         canToggleConnection: false,
         buttonEnabled: false,
-        buttonLabel: 'Connect Blocked',
+        buttonLabel: 'Connect Test Blocked',
         statusHint: 'Readiness blocked: ${readinessReport.summary}',
         primaryAction: ProfileConnectionPrimaryAction.none,
         actionableSessionTruth: actionableSessionTruth,
@@ -170,7 +170,7 @@ class ProfileConnectionActionPolicy {
     return ProfileConnectionActionPolicy(
       canToggleConnection: true,
       buttonEnabled: true,
-      buttonLabel: runtimePosture.qualifyAction('Connect'),
+      buttonLabel: runtimePosture.qualifyAction('Connect Test'),
       statusHint: status.message,
       primaryAction: ProfileConnectionPrimaryAction.connect,
       actionableSessionTruth: actionableSessionTruth,

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -455,20 +455,11 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
                                 connectionPolicy.primaryAction ==
                                     ProfileConnectionPrimaryAction.disconnect;
                             if (!isDisconnectAction) {
-                              final readinessReport = await services.readiness
-                                  .buildReport(profileOverride: selected);
-                              if (!mounted) return;
-                              _readinessController
-                                  .replaceLatestReport(readinessReport);
-                              if (readinessReport.overallLevel ==
-                                  ReadinessLevel.blocked) {
-                                messenger.showSnackBar(
-                                  SnackBar(
-                                    content: Text(
-                                      'Connect blocked: ${readinessReport.summary}',
-                                    ),
-                                  ),
-                                );
+                              final allowed =
+                                  await _runConnectReadinessPreflight(
+                                messenger: messenger,
+                              );
+                              if (!mounted || !allowed) {
                                 return;
                               }
                             }
@@ -612,18 +603,10 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
                   return;
                 }
 
-                final readinessReport =
-                    await services.readiness.buildReport(profileOverride: selected);
-                if (!mounted) return;
-                _readinessController.replaceLatestReport(readinessReport);
-                if (readinessReport.overallLevel == ReadinessLevel.blocked) {
-                  messenger.showSnackBar(
-                    SnackBar(
-                      content: Text(
-                        'Connect blocked: ${readinessReport.summary}',
-                      ),
-                    ),
-                  );
+                final allowed = await _runConnectReadinessPreflight(
+                  messenger: messenger,
+                );
+                if (!mounted || !allowed) {
                   return;
                 }
 
@@ -726,6 +709,35 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
         ),
       ),
     );
+  }
+
+  String _buildConnectBlockedCopy(ReadinessReport report) {
+    final nextActionLabel = report.recommendation?.label.trim();
+    if (nextActionLabel == null || nextActionLabel.isEmpty) {
+      return 'Connect blocked: ${report.summary}';
+    }
+    return 'Connect blocked: ${report.summary} Next action: $nextActionLabel';
+  }
+
+  Future<bool> _runConnectReadinessPreflight({
+    required ScaffoldMessengerState messenger,
+  }) async {
+    final readinessReport = await services.readiness.buildReport(
+      profileOverride: selected,
+    );
+    if (!mounted) return false;
+    _readinessController.replaceLatestReport(readinessReport);
+
+    if (readinessReport.overallLevel != ReadinessLevel.blocked) {
+      return true;
+    }
+
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(_buildConnectBlockedCopy(readinessReport)),
+      ),
+    );
+    return false;
   }
 
   Future<void> _edit(BuildContext context) async {

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -8,6 +8,8 @@ import '../../controller/domain/client_connection_status.dart';
 import '../../controller/domain/controller_runtime_session.dart';
 import '../../controller/domain/runtime_action_feedback.dart';
 import '../../controller/domain/runtime_posture.dart';
+import '../../controller/domain/failure_family.dart';
+import 'next_action_policy.dart';
 import 'profile_connection_action_policy.dart';
 import '../../readiness/domain/readiness_refresh_fingerprint.dart';
 import '../../readiness/domain/readiness_report.dart';
@@ -345,8 +347,8 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
     );
   }
 
-  void _runRecommendation(BuildContext context, ReadinessRecommendation rec) {
-    switch (rec.action) {
+  void _runReadinessAction(BuildContext context, ReadinessAction action) {
+    switch (action) {
       case ReadinessAction.openProfiles:
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
@@ -357,7 +359,7 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
         return;
       case ReadinessAction.openTroubleshooting:
         if (widget.onOpenAdvanced != null) {
-          widget.onOpenAdvanced!.call(rec.action);
+          widget.onOpenAdvanced!.call(action);
           return;
         }
         ScaffoldMessenger.of(context).showSnackBar(
@@ -385,6 +387,24 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
   Widget build(BuildContext context) {
     final posture = _runtimePosture;
     final connectionPolicy = _connectionPolicy;
+
+    final failureFamily = parseFailureFamily(status.failureFamilyHint) ==
+            FailureFamily.unknown
+        ? classifyFailureFamily(
+            errorCode: status.errorCode,
+            summary: status.message,
+            detail: status.message,
+            phase: status.phase.name,
+          )
+        : parseFailureFamily(status.failureFamilyHint);
+
+    final nextActionDecision = ProfileNextActionPolicy.resolve(
+      status: status,
+      readinessReport: _readinessController.latestReport,
+      failureFamily: failureFamily,
+      troubleshootingAvailable: widget.onOpenAdvanced != null,
+      settingsAvailable: widget.onOpenSettings != null,
+    );
 
     return SectionCard(
       title: selected.name,
@@ -551,14 +571,15 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
                       (check) => check != null,
                       orElse: () => null,
                     );
-                final nextAction = report?.recommendation?.detail ??
-                    (blockingCheck?.detail ??
-                        (blockingCheck?.summary ??
-                            'Try connect now and check diagnostics if needed.'));
-
                 return FirstConnectGuidanceCard(
                   blockingReason: blockingCheck?.summary,
-                  nextAction: nextAction,
+                  nextAction: nextActionDecision.detail,
+                  actionLabel: nextActionDecision.isActionable
+                      ? nextActionDecision.label
+                      : null,
+                  onAction: nextActionDecision.isActionable
+                      ? () => _runNextActionDecision(context, nextActionDecision)
+                      : null,
                 );
               },
             ),
@@ -573,12 +594,11 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
                   report: report,
                   showCachedRefreshHint: report?.isCachedSnapshot == true &&
                       snapshot.connectionState != ConnectionState.done,
-                  onRecommendation: report?.recommendation == null
-                      ? null
-                      : () => _runRecommendation(
-                            context,
-                            report!.recommendation!,
-                          ),
+                  onRecommendation: nextActionDecision.isActionable
+                      ? () => _runNextActionDecision(context, nextActionDecision)
+                      : null,
+                  recommendationLabel:
+                      nextActionDecision.isActionable ? nextActionDecision.label : null,
                 );
               },
             ),
@@ -711,9 +731,55 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
     );
   }
 
+  void _runNextActionDecision(
+    BuildContext context,
+    ProfileNextActionDecision decision,
+  ) {
+    switch (decision.type) {
+      case ProfileNextActionType.openProfiles:
+        _runReadinessAction(context, ReadinessAction.openProfiles);
+        return;
+      case ProfileNextActionType.openTroubleshooting:
+        _runReadinessAction(context, ReadinessAction.openTroubleshooting);
+        return;
+      case ProfileNextActionType.openSettings:
+        _runReadinessAction(context, ReadinessAction.openSettings);
+        return;
+      case ProfileNextActionType.retryConnect:
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Retry Connect Test from the primary action after reviewing current evidence.',
+            ),
+          ),
+        );
+        return;
+      case ProfileNextActionType.exportSupportBundle:
+        if (widget.onOpenAdvanced != null) {
+          widget.onOpenAdvanced!.call(ReadinessAction.openTroubleshooting);
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Open Troubleshooting to export support evidence.'),
+            ),
+          );
+        }
+        return;
+      case ProfileNextActionType.none:
+        return;
+    }
+  }
+
   String _buildConnectBlockedCopy(ReadinessReport report) {
-    final nextActionLabel = report.recommendation?.label.trim();
-    if (nextActionLabel == null || nextActionLabel.isEmpty) {
+    final nextActionDecision = ProfileNextActionPolicy.resolve(
+      status: status,
+      readinessReport: report,
+      failureFamily: FailureFamily.unknown,
+      troubleshootingAvailable: widget.onOpenAdvanced != null,
+      settingsAvailable: widget.onOpenSettings != null,
+    );
+    final nextActionLabel = nextActionDecision.label.trim();
+    if (nextActionLabel.isEmpty || !nextActionDecision.isActionable) {
       return 'Connect blocked: ${report.summary}';
     }
     return 'Connect blocked: ${report.summary} Next action: $nextActionLabel';
@@ -1039,11 +1105,13 @@ class _ProfileReadinessNotice extends StatelessWidget {
   const _ProfileReadinessNotice({
     required this.report,
     this.showCachedRefreshHint = false,
+    this.recommendationLabel,
     this.onRecommendation,
   });
 
   final ReadinessReport? report;
   final bool showCachedRefreshHint;
+  final String? recommendationLabel;
   final VoidCallback? onRecommendation;
 
   Color _tone(ReadinessLevel level) {
@@ -1070,6 +1138,8 @@ class _ProfileReadinessNotice extends StatelessWidget {
 
     final tone = _tone(report!.overallLevel);
     final recommendation = report!.recommendation;
+    final effectiveRecommendationLabel =
+        recommendationLabel ?? recommendation?.label;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(12),
@@ -1101,18 +1171,22 @@ class _ProfileReadinessNotice extends StatelessWidget {
               'Showing a cached snapshot while the live readiness refresh runs.',
             ),
           ],
-          if (recommendation != null) ...<Widget>[
+          if (effectiveRecommendationLabel != null) ...<Widget>[
             const SizedBox(height: 8),
             Text(
-              'Recommended next step: ${recommendation.label}',
+              'Recommended next step: $effectiveRecommendationLabel',
               style: const TextStyle(fontWeight: FontWeight.w600),
             ),
-            const SizedBox(height: 8),
-            OutlinedButton.icon(
-              onPressed: onRecommendation,
-              icon: Icon(_recommendationIcon(recommendation.action)),
-              label: Text(recommendation.label),
-            ),
+            if (onRecommendation != null) ...<Widget>[
+              const SizedBox(height: 8),
+              OutlinedButton.icon(
+                onPressed: onRecommendation,
+                icon: Icon(_recommendationIcon(
+                  recommendation?.action ?? ReadinessAction.openProfiles,
+                )),
+                label: Text(effectiveRecommendationLabel),
+              ),
+            ],
           ],
         ],
       ),

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -15,6 +15,7 @@ import '../../readiness/domain/readiness_refresh_fingerprint.dart';
 import '../../readiness/domain/readiness_report.dart';
 import '../../readiness/presentation/readiness_surface_controller.dart';
 import '../domain/client_profile.dart';
+import 'connect_timeline_card.dart';
 import 'first_connect_guidance_card.dart';
 import 'high_frequency_actions_strip.dart';
 import 'import_export_dialog.dart';
@@ -601,6 +602,13 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
                       nextActionDecision.isActionable ? nextActionDecision.label : null,
                 );
               },
+            ),
+            const SizedBox(height: 12),
+            ConnectTimelineCard(
+              status: status,
+              runtimeSession: _runtimeSession,
+              failureFamily: failureFamily,
+              nextAction: nextActionDecision,
             ),
             const SizedBox(height: 12),
             HighFrequencyActionsStrip(

--- a/client/test/features/controller/application/adapter_backed_client_controller_test.dart
+++ b/client/test/features/controller/application/adapter_backed_client_controller_test.dart
@@ -489,8 +489,9 @@ void main() {
         endpointHint: 'local-controller://test',
         enableVerboseTelemetry: true,
       ),
-      commandAccepted: true,
-      commandSummary: 'Launch requested.',
+      commandAccepted: false,
+      commandSummary: 'Launch request rejected by adapter.',
+      commandError: 'launch denied',
       commandDetails: const <String, Object?>{},
       initialSession: _session(isRunning: false),
     );
@@ -507,7 +508,23 @@ void main() {
     );
     addTearDown(controller.dispose);
 
-    await controller.connect(_demoProfile());
+    final firstAttempt = await controller.connect(_demoProfile());
+    expect(firstAttempt.accepted, isFalse);
+    expect(controller.status.phase, ClientConnectionPhase.error);
+    expect(controller.status.failureFamilyHint, 'launch');
+    expect(controller.status.errorCode, 'launch denied');
+
+    adapter
+      ..commandAccepted = true
+      ..commandSummary = 'Launch requested.'
+      ..commandError = null;
+
+    final retryAttempt = await controller.connect(_demoProfile());
+    expect(retryAttempt.accepted, isTrue);
+    expect(controller.status.phase, ClientConnectionPhase.connecting);
+    expect(controller.status.failureFamilyHint, isNull);
+    expect(controller.status.errorCode, isNull);
+
     adapter.setSession(_session(isRunning: true, pid: 4321));
 
     await _waitFor(
@@ -562,6 +579,51 @@ void main() {
       controller.latestRoutingProbeEvidence.first.isRuntimeTrueDataplane,
       isTrue,
     );
+  });
+
+  test('disconnect clears stale failure fields after failed attempt', () async {
+    final adapter = _ControllableShellControllerAdapter(
+      runtimeConfig: const ControllerRuntimeConfig(
+        mode: 'external-runtime-boundary',
+        endpointHint: 'local-controller://test',
+        enableVerboseTelemetry: true,
+      ),
+      commandAccepted: false,
+      commandSummary: 'Launch request rejected by adapter.',
+      commandError: 'launch denied',
+      commandDetails: const <String, Object?>{},
+      initialSession: _session(isRunning: false),
+    );
+    final secrets = ProfileSecretsService(secureStorage: MemorySecureStorage());
+    await secrets.saveTrojanPassword(
+      profileId: 'profile-demo',
+      password: 'secret',
+    );
+
+    final controller = AdapterBackedClientController(
+      adapter: adapter,
+      profileSecrets: secrets,
+      sessionPollInterval: const Duration(milliseconds: 20),
+    );
+    addTearDown(controller.dispose);
+
+    final failedResult = await controller.connect(_demoProfile());
+    expect(failedResult.accepted, isFalse);
+    expect(controller.status.phase, ClientConnectionPhase.error);
+    expect(controller.status.errorCode, isNotNull);
+    expect(controller.status.failureFamilyHint, isNotNull);
+
+    adapter
+      ..commandAccepted = true
+      ..commandSummary = 'Disconnect requested.'
+      ..commandError = null;
+
+    final disconnectResult = await controller.disconnect();
+    expect(disconnectResult.accepted, isTrue);
+
+    expect(controller.status.phase, ClientConnectionPhase.disconnected);
+    expect(controller.status.errorCode, isNull);
+    expect(controller.status.failureFamilyHint, isNull);
   });
 
   test('disconnect keeps disconnected state despite stale runtime poll updates',

--- a/client/test/features/controller/domain/failure_family_test.dart
+++ b/client/test/features/controller/domain/failure_family_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/failure_family.dart';
+
+void main() {
+  group('classifyFailureFamily', () {
+    test('prioritizes structured errorCode over free-form summary/detail', () {
+      final family = classifyFailureFamily(
+        errorCode: 'MISSING_TROJAN_PASSWORD',
+        summary: 'config invalid for runtime launch',
+        detail: 'runtime session exited with code 7',
+        phase: 'runtime',
+      );
+
+      expect(family, FailureFamily.userInput);
+    });
+
+    test('maps key structured error codes to expected families', () {
+      expect(
+        classifyFailureFamily(errorCode: 'MISSING_TROJAN_PASSWORD'),
+        FailureFamily.userInput,
+      );
+      expect(
+        classifyFailureFamily(errorCode: 'CONFIG_INVALID_FOR_RUNTIME_LAUNCH'),
+        FailureFamily.config,
+      );
+      expect(
+        classifyFailureFamily(errorCode: 'UNSUPPORTED'),
+        FailureFamily.environment,
+      );
+      expect(
+        classifyFailureFamily(errorCode: 'RUNTIME_SESSION_EXIT_NONZERO'),
+        FailureFamily.connect,
+      );
+      expect(
+        classifyFailureFamily(errorCode: 'DIAGNOSTICS_EXPORT_FAILED'),
+        FailureFamily.exportOs,
+      );
+      expect(
+        classifyFailureFamily(errorCode: 'PROCESS_ALREADY_RUNNING'),
+        FailureFamily.launch,
+      );
+    });
+
+    test('uses phase as fallback when no structured mapping is available', () {
+      expect(
+        classifyFailureFamily(
+          errorCode: 'SOMETHING_UNMAPPED',
+          phase: 'launch',
+        ),
+        FailureFamily.launch,
+      );
+      expect(
+        classifyFailureFamily(
+          errorCode: 'SOMETHING_UNMAPPED',
+          phase: 'config',
+        ),
+        FailureFamily.config,
+      );
+      expect(
+        classifyFailureFamily(
+          errorCode: 'SOMETHING_UNMAPPED',
+          phase: 'runtime',
+        ),
+        FailureFamily.connect,
+      );
+      expect(
+        classifyFailureFamily(
+          errorCode: 'SOMETHING_UNMAPPED',
+          phase: 'environment',
+        ),
+        FailureFamily.environment,
+      );
+      expect(
+        classifyFailureFamily(
+          errorCode: 'SOMETHING_UNMAPPED',
+          phase: 'export',
+        ),
+        FailureFamily.exportOs,
+      );
+      expect(
+        classifyFailureFamily(
+          errorCode: 'SOMETHING_UNMAPPED',
+          phase: 'user_input',
+        ),
+        FailureFamily.userInput,
+      );
+    });
+
+    test('keeps backward compatibility for legacy free-form inference', () {
+      expect(
+        classifyFailureFamily(
+          summary: 'permission denied for diagnostics export',
+        ),
+        FailureFamily.exportOs,
+      );
+      expect(
+        classifyFailureFamily(
+          summary: 'runtime session exited with code 9',
+        ),
+        FailureFamily.connect,
+      );
+      expect(
+        classifyFailureFamily(
+          summary: 'failed to execute trojan client launch plan',
+        ),
+        FailureFamily.launch,
+      );
+      expect(
+        classifyFailureFamily(
+          summary: 'config preparation failed',
+        ),
+        FailureFamily.config,
+      );
+    });
+
+    test('returns unknown when no structured/fallback signal exists', () {
+      expect(
+        classifyFailureFamily(
+          errorCode: 'SOMETHING_UNMAPPED',
+          summary: 'totally generic failure text',
+        ),
+        FailureFamily.unknown,
+      );
+    });
+  });
+}

--- a/client/test/features/diagnostics/application/diagnostics_export_service_test.dart
+++ b/client/test/features/diagnostics/application/diagnostics_export_service_test.dart
@@ -169,6 +169,10 @@ void main() {
     expect(exportSummary['runtimePostureLabel'], runtimePosture['label']);
     expect(exportSummary['runtimeTruth'], runtimeSession['truth']);
     expect(exportSummary['recoveryHint'], isNotEmpty);
+    expect(exportSummary['secretStorageSummary'], 'Session-only storage');
+    expect(exportSummary['secretStorageMode'], 'Session-only');
+    expect(exportSummary['secretStoragePersistent'], isFalse);
+    expect(exportSummary['secretStorageSecure'], isFalse);
 
     final profilesExport = payload['profilesExport'] as Map<String, dynamic>;
     expect(profilesExport['kind'], 'trojan-pro-client-profile-bundle');

--- a/client/test/features/diagnostics/domain/export_summary_snapshot_test.dart
+++ b/client/test/features/diagnostics/domain/export_summary_snapshot_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_posture.dart';
+import 'package:trojan_pro_client/features/diagnostics/domain/export_summary_snapshot.dart';
+import 'package:trojan_pro_client/platform/secure_storage/secure_storage.dart';
+
+void main() {
+  test('builds export summary snapshot from runtime posture/session/storage', () {
+    final posture = describeRuntimePosture(
+      runtimeMode: 'stubbed-local-boundary',
+      backendKind: 'fake-shell-controller',
+    );
+    final runtimeSession = ControllerRuntimeSession(
+      isRunning: false,
+      updatedAt: DateTime.parse('2026-04-20T08:00:00.000Z'),
+      phase: ControllerRuntimePhase.failed,
+    );
+    const storageStatus = SecureStorageStatus(
+      backendName: 'memory-only-stub',
+      activeBackendName: 'memory-only-stub',
+      isSecure: false,
+      isPersistent: false,
+    );
+
+    final snapshot = ExportSummarySnapshot.fromContext(
+      runtimePosture: posture,
+      runtimeSession: runtimeSession,
+      storageStatus: storageStatus,
+    );
+
+    expect(snapshot.runtimePostureLabel, 'Stub-only');
+    expect(snapshot.evidenceGrade, 'Shell-grade only');
+    expect(snapshot.runtimeTruth, 'Residual snapshot');
+    expect(snapshot.recoveryHint, contains('leftover session state'));
+    expect(snapshot.usageHint,
+        contains('support context rather than proof of runtime-true execution'));
+    expect(snapshot.secretStorageSummary, 'Session-only storage');
+    expect(snapshot.secretStorageMode, 'Session-only');
+    expect(snapshot.secretStoragePersistent, isFalse);
+    expect(snapshot.secretStorageSecure, isFalse);
+  });
+
+  test('serializes export summary snapshot to stable payload fields', () {
+    const snapshot = ExportSummarySnapshot(
+      runtimePostureLabel: 'Runtime-true',
+      evidenceGrade: 'Evidence-grade',
+      runtimeTruth: 'Live',
+      recoveryHint: 'No recovery action is needed.',
+      usageHint: 'Use as runtime-true evidence when posture remains evidence-grade.',
+      secretStorageSummary: 'Secure storage ready',
+      secretStorageMode: 'Secure persistent',
+      secretStoragePersistent: true,
+      secretStorageSecure: true,
+    );
+
+    final json = snapshot.toJson();
+
+    expect(json['runtimePostureLabel'], 'Runtime-true');
+    expect(json['evidenceGrade'], 'Evidence-grade');
+    expect(json['runtimeTruth'], 'Live');
+    expect(json['recoveryHint'], 'No recovery action is needed.');
+    expect(
+      json['usageHint'],
+      'Use as runtime-true evidence when posture remains evidence-grade.',
+    );
+    expect(json['secretStorageSummary'], 'Secure storage ready');
+    expect(json['secretStorageMode'], 'Secure persistent');
+    expect(json['secretStoragePersistent'], isTrue);
+    expect(json['secretStorageSecure'], isTrue);
+  });
+}

--- a/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
+++ b/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
@@ -207,6 +207,8 @@ void main() {
     expect(find.text('Current runtime truth: Residual snapshot'), findsOneWidget);
     expect(find.text('Needs attention: Yes'), findsOneWidget);
     expect(find.textContaining('support context rather than proof'), findsOneWidget);
+    expect(find.textContaining('Secret storage: Session-only storage'), findsOneWidget);
+    expect(find.textContaining('Storage mode: Session-only'), findsOneWidget);
     expect(
       find.widgetWithText(OutlinedButton, 'Export runtime-proof artifact'),
       findsNothing,

--- a/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
+++ b/client/test/features/diagnostics/presentation/diagnostics_page_test.dart
@@ -163,7 +163,7 @@ void main() {
     expect(find.text('Runtime truth & recovery'), findsOneWidget);
     expect(find.text('Current runtime truth: Live'), findsOneWidget);
     expect(find.text('Needs attention: No'), findsOneWidget);
-    expect(find.textContaining('runtime-true evidence'), findsOneWidget);
+    expect(find.textContaining('runtime-true evidence'), findsWidgets);
 
     await tester
         .tap(find.widgetWithText(FilledButton, 'Generate support preview'));
@@ -206,7 +206,7 @@ void main() {
     expect(find.text('Runtime truth & recovery'), findsOneWidget);
     expect(find.text('Current runtime truth: Residual snapshot'), findsOneWidget);
     expect(find.text('Needs attention: Yes'), findsOneWidget);
-    expect(find.textContaining('support context rather than proof'), findsOneWidget);
+    expect(find.textContaining('support context rather than proof'), findsWidgets);
     expect(find.textContaining('Secret storage: Session-only storage'), findsOneWidget);
     expect(find.textContaining('Storage mode: Session-only'), findsOneWidget);
     expect(

--- a/client/test/features/diagnostics/presentation/export_summary_sheet_test.dart
+++ b/client/test/features/diagnostics/presentation/export_summary_sheet_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:trojan_pro_client/features/controller/domain/runtime_posture.dart';
+import 'package:trojan_pro_client/features/diagnostics/domain/export_summary_snapshot.dart';
 import 'package:trojan_pro_client/features/diagnostics/presentation/export_summary_sheet.dart';
 
 void main() {
@@ -49,5 +50,39 @@ void main() {
       findsOneWidget,
     );
     expect(find.textContaining('Storage mode: Session-only'), findsOneWidget);
+  });
+
+  testWidgets('renders from snapshot payload with unified usage hint',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ExportSummarySheet.fromSnapshot(
+            const ExportSummarySnapshot(
+              runtimePostureLabel: 'Runtime-true',
+              evidenceGrade: 'Evidence-grade',
+              runtimeTruth: 'Live',
+              recoveryHint: 'No recovery action is needed.',
+              usageHint:
+                  'Use as runtime-true evidence when posture remains evidence-grade.',
+              secretStorageSummary: 'Secure storage ready',
+              secretStorageMode: 'Secure persistent',
+              secretStoragePersistent: true,
+              secretStorageSecure: true,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('Runtime-true'), findsOneWidget);
+    expect(
+      find.textContaining('Use as runtime-true evidence when posture remains evidence-grade.'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Secret storage: Secure storage ready'),
+        findsOneWidget);
+    expect(find.textContaining('Storage mode: Secure persistent'),
+        findsOneWidget);
   });
 }

--- a/client/test/features/diagnostics/presentation/export_summary_sheet_test.dart
+++ b/client/test/features/diagnostics/presentation/export_summary_sheet_test.dart
@@ -32,6 +32,8 @@ void main() {
               backendKind: 'fake-shell-controller',
             ),
             recoveryHint: 'Safe mode rollback is active.',
+            secretStorageSummary: 'Temporary session-only fallback',
+            secretStorageMode: 'Session-only',
           ),
         ),
       ),
@@ -42,5 +44,10 @@ void main() {
       find.textContaining('support triage only'),
       findsOneWidget,
     );
+    expect(
+      find.textContaining('Secret storage: Temporary session-only fallback'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Storage mode: Session-only'), findsOneWidget);
   });
 }

--- a/client/test/features/profiles/presentation/connect_timeline_card_test.dart
+++ b/client/test/features/profiles/presentation/connect_timeline_card_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
+import 'package:trojan_pro_client/features/controller/domain/failure_family.dart';
+import 'package:trojan_pro_client/features/profiles/presentation/connect_timeline_card.dart';
+import 'package:trojan_pro_client/features/profiles/presentation/next_action_policy.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  testWidgets('shows planned → launching stage progression while connecting',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        ConnectTimelineCard(
+          status: ClientConnectionStatus(
+            phase: ClientConnectionPhase.connecting,
+            message: 'Launch plan accepted. Preparing managed runtime config.',
+            updatedAt: DateTime.parse('2026-04-20T02:00:00.000Z'),
+            activeProfileId: 'sample-hk-1',
+          ),
+          runtimeSession: ControllerRuntimeSession(
+            isRunning: true,
+            updatedAt: DateTime.now(),
+            phase: ControllerRuntimePhase.launching,
+            expectedLocalSocksPort: 10808,
+          ),
+          failureFamily: FailureFamily.unknown,
+          nextAction: ProfileNextActionDecision.none,
+        ),
+      ),
+    );
+
+    expect(find.textContaining('Current stage: launching'), findsOneWidget);
+    expect(find.textContaining('planned • completed'), findsOneWidget);
+    expect(find.textContaining('launching • active'), findsOneWidget);
+    expect(find.textContaining('alive • pending'), findsOneWidget);
+    expect(find.textContaining('session-ready • pending'), findsOneWidget);
+  });
+
+  testWidgets('shows failure family + next action on error',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        ConnectTimelineCard(
+          status: ClientConnectionStatus(
+            phase: ClientConnectionPhase.error,
+            message: 'Runtime session exited with code 7.',
+            updatedAt: DateTime.parse('2026-04-20T02:00:00.000Z'),
+            activeProfileId: 'sample-hk-1',
+            errorCode: 'RUNTIME_SESSION_EXIT_NONZERO',
+            failureFamilyHint: 'connect',
+          ),
+          runtimeSession: ControllerRuntimeSession(
+            isRunning: false,
+            updatedAt: DateTime.now(),
+            phase: ControllerRuntimePhase.failed,
+            expectedLocalSocksPort: 10808,
+            lastExitCode: 7,
+          ),
+          failureFamily: FailureFamily.connect,
+          nextAction: const ProfileNextActionDecision(
+            type: ProfileNextActionType.retryConnect,
+            label: 'Retry Connect Test',
+            detail: 'Retry after preserving current evidence.',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('Failure family: Connect'), findsOneWidget);
+    expect(find.textContaining('Next action: Retry Connect Test'), findsOneWidget);
+  });
+
+  testWidgets('shows waiting for exit confirmation during disconnecting',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        ConnectTimelineCard(
+          status: ClientConnectionStatus(
+            phase: ClientConnectionPhase.disconnecting,
+            message: 'Disconnecting current session...',
+            updatedAt: DateTime.parse('2026-04-20T02:00:00.000Z'),
+            activeProfileId: 'sample-hk-1',
+          ),
+          runtimeSession: ControllerRuntimeSession(
+            isRunning: true,
+            updatedAt: DateTime.now(),
+            phase: ControllerRuntimePhase.alive,
+            stopRequested: true,
+            stopRequestedAt: DateTime.now(),
+            expectedLocalSocksPort: 10808,
+          ),
+          failureFamily: FailureFamily.unknown,
+          nextAction: ProfileNextActionDecision.none,
+        ),
+      ),
+    );
+
+    expect(
+      find.textContaining('Waiting for exit confirmation before marking disconnected.'),
+      findsOneWidget,
+    );
+  });
+}

--- a/client/test/features/profiles/presentation/first_connect_guidance_card_test.dart
+++ b/client/test/features/profiles/presentation/first_connect_guidance_card_test.dart
@@ -18,6 +18,7 @@ void main() {
 
     expect(find.textContaining('MISSING_TROJAN_PASSWORD'), findsOneWidget);
     expect(find.textContaining('Next step'), findsOneWidget);
+    expect(find.text('Set Password'), findsNothing);
   });
 
   testWidgets('shows ready message when no blocker exists',
@@ -35,5 +36,30 @@ void main() {
 
     expect(find.textContaining('Ready for first connect'), findsOneWidget);
     expect(find.textContaining('Next step'), findsOneWidget);
+  });
+
+  testWidgets('renders actionable next step button when action is provided',
+      (WidgetTester tester) async {
+    var tapped = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: FirstConnectGuidanceCard(
+            blockingReason: 'Check runtime path',
+            nextAction: 'Open troubleshooting to revalidate runtime path.',
+            actionLabel: 'Open Troubleshooting',
+            onAction: () => tapped = true,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.widgetWithText(OutlinedButton, 'Open Troubleshooting'),
+        findsOneWidget);
+
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Open Troubleshooting'));
+    await tester.pump();
+
+    expect(tapped, isTrue);
   });
 }

--- a/client/test/features/profiles/presentation/next_action_policy_test.dart
+++ b/client/test/features/profiles/presentation/next_action_policy_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
+import 'package:trojan_pro_client/features/controller/domain/failure_family.dart';
+import 'package:trojan_pro_client/features/profiles/presentation/next_action_policy.dart';
+import 'package:trojan_pro_client/features/readiness/domain/readiness_report.dart';
+
+void main() {
+  group('ProfileNextActionPolicy', () {
+    test('maps readiness blocked password to set password action', () {
+      final decision = ProfileNextActionPolicy.resolve(
+        status: ClientConnectionStatus.disconnected(),
+        readinessReport: ReadinessReport.fromChecks(
+          const <ReadinessCheck>[
+            ReadinessCheck(
+              domain: ReadinessDomain.password,
+              level: ReadinessLevel.blocked,
+              summary: 'Trojan password missing',
+              detail: 'Store the Trojan password before connect test.',
+            ),
+          ],
+          generatedAt: DateTime.parse('2026-04-20T01:00:00.000Z'),
+        ),
+        failureFamily: FailureFamily.unknown,
+        troubleshootingAvailable: true,
+        settingsAvailable: true,
+      );
+
+      expect(decision.type, ProfileNextActionType.openProfiles);
+      expect(decision.label, 'Set Password');
+      expect(decision.detail, contains('password'));
+    });
+
+    test('maps readiness blocked environment to troubleshooting', () {
+      final decision = ProfileNextActionPolicy.resolve(
+        status: ClientConnectionStatus.disconnected(),
+        readinessReport: ReadinessReport.fromChecks(
+          const <ReadinessCheck>[
+            ReadinessCheck(
+              domain: ReadinessDomain.runtimeBinary,
+              level: ReadinessLevel.blocked,
+              summary: 'runtime binary missing',
+              detail: 'Runtime binary could not be found.',
+            ),
+          ],
+          generatedAt: DateTime.parse('2026-04-20T01:00:00.000Z'),
+        ),
+        failureFamily: FailureFamily.unknown,
+        troubleshootingAvailable: true,
+        settingsAvailable: false,
+      );
+
+      expect(decision.type, ProfileNextActionType.openTroubleshooting);
+      expect(decision.label, 'Open Troubleshooting');
+    });
+
+    test('maps connect failure family to retry action', () {
+      final decision = ProfileNextActionPolicy.resolve(
+        status: ClientConnectionStatus(
+          phase: ClientConnectionPhase.error,
+          message: 'Runtime session exited with code 7.',
+          updatedAt: DateTime.parse('2026-04-20T01:00:00.000Z'),
+          errorCode: 'RUNTIME_SESSION_EXIT_NONZERO',
+          failureFamilyHint: 'connect',
+        ),
+        readinessReport: null,
+        failureFamily: FailureFamily.connect,
+        troubleshootingAvailable: true,
+        settingsAvailable: true,
+      );
+
+      expect(decision.type, ProfileNextActionType.retryConnect);
+      expect(decision.label, 'Retry Connect Test');
+    });
+
+    test('maps export_os failure family to export support bundle action', () {
+      final decision = ProfileNextActionPolicy.resolve(
+        status: ClientConnectionStatus(
+          phase: ClientConnectionPhase.error,
+          message: 'Diagnostics export failed: permission denied.',
+          updatedAt: DateTime.parse('2026-04-20T01:00:00.000Z'),
+          errorCode: 'DIAGNOSTICS_EXPORT_FAILED',
+          failureFamilyHint: 'export_os',
+        ),
+        readinessReport: null,
+        failureFamily: FailureFamily.exportOs,
+        troubleshootingAvailable: true,
+        settingsAvailable: true,
+      );
+
+      expect(decision.type, ProfileNextActionType.exportSupportBundle);
+      expect(decision.label, 'Export Support Bundle');
+    });
+
+    test('maps user_input failure family to set password action', () {
+      final decision = ProfileNextActionPolicy.resolve(
+        status: ClientConnectionStatus(
+          phase: ClientConnectionPhase.error,
+          message: 'Trojan password missing.',
+          updatedAt: DateTime.parse('2026-04-20T01:00:00.000Z'),
+          errorCode: 'MISSING_TROJAN_PASSWORD',
+          failureFamilyHint: 'user_input',
+        ),
+        readinessReport: null,
+        failureFamily: FailureFamily.userInput,
+        troubleshootingAvailable: true,
+        settingsAvailable: true,
+      );
+
+      expect(decision.type, ProfileNextActionType.openProfiles);
+      expect(decision.label, 'Set Password');
+    });
+
+    test('disconnecting prefers troubleshooting by default', () {
+      final decision = ProfileNextActionPolicy.resolve(
+        status: ClientConnectionStatus(
+          phase: ClientConnectionPhase.disconnecting,
+          message: 'Disconnecting current session...',
+          updatedAt: DateTime.parse('2026-04-20T01:00:00.000Z'),
+          activeProfileId: 'sample-hk-1',
+        ),
+        readinessReport: null,
+        failureFamily: FailureFamily.unknown,
+        troubleshootingAvailable: true,
+        settingsAvailable: false,
+      );
+
+      expect(decision.type, ProfileNextActionType.openTroubleshooting);
+      expect(decision.label, 'Open Troubleshooting');
+      expect(decision.detail, contains('exit confirmation'));
+    });
+  });
+}

--- a/client/test/features/profiles/presentation/profile_connection_action_policy_test.dart
+++ b/client/test/features/profiles/presentation/profile_connection_action_policy_test.dart
@@ -104,7 +104,7 @@ void main() {
       onOpenAdvancedAvailable: false,
     );
 
-    expect(policy.buttonLabel, 'Connect Blocked');
+    expect(policy.buttonLabel, 'Connect Test Blocked');
     expect(policy.buttonEnabled, isFalse);
     expect(policy.statusHint, contains('Readiness blocked'));
   });

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -435,7 +435,10 @@ void main() {
     );
     await tester.pump();
 
-    await tester.tap(find.widgetWithText(FilledButton, 'Quick Connect'));
+    final quickConnectButton =
+        find.widgetWithText(FilledButton, 'Quick Connect');
+    await tester.ensureVisible(quickConnectButton);
+    await tester.tap(quickConnectButton);
     await tester.pump(const Duration(milliseconds: 360));
 
     expect(
@@ -693,6 +696,8 @@ void main() {
     await tester.pump();
 
     expect(find.text('Action safety'), findsOneWidget);
+    expect(find.text('Connect timeline'), findsOneWidget);
+    expect(find.textContaining('Current stage: alive'), findsOneWidget);
     expect(find.text('Wait for exit confirmation'), findsOneWidget);
     expect(find.widgetWithText(FilledButton, 'Open Troubleshooting'),
         findsOneWidget);

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -71,6 +71,14 @@ class _UnavailableRuntimeController extends FakeClientController {
   }
 }
 
+class _SlowHealthController extends FakeClientController {
+  @override
+  Future<ControllerRuntimeHealth> checkHealth() async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    return super.checkHealth();
+  }
+}
+
 class _StaleConnectedController extends FakeClientController {
   ClientConnectionStatus statusOverride = ClientConnectionStatus(
     phase: ClientConnectionPhase.connected,
@@ -353,7 +361,7 @@ void main() {
     );
 
     final blockedButton = tester.widget<FilledButton>(
-      find.widgetWithText(FilledButton, 'Connect Blocked'),
+      find.widgetWithText(FilledButton, 'Connect Test Blocked'),
     );
     expect(blockedButton.onPressed, isNull);
 
@@ -361,6 +369,83 @@ void main() {
         services.controller.status.phase, ClientConnectionPhase.disconnected);
     expect(find.textContaining('Recommended next step: Open Profiles'),
         findsOneWidget);
+  });
+
+  testWidgets(
+      'primary connect preflight shows blocked reason + next action copy',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    final services = _buildServices(controllerOverride: _SlowHealthController());
+    final selected = services.profileStore.selectedProfile!;
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: selected.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      selected.copyWith(
+        hasStoredPassword: true,
+        serverHost: '',
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ProfilesPage(services: services)),
+      ),
+    );
+    await tester.pump();
+
+    await tester
+        .tap(find.widgetWithText(FilledButton, 'Connect Test (stub path)'));
+    await tester.pump(const Duration(milliseconds: 360));
+
+    expect(
+      find.textContaining(
+        'Connect blocked: Check server host / server port / local SOCKS port before connecting.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Next action: Open Profiles'), findsOneWidget);
+    expect(services.controller.status.phase, ClientConnectionPhase.disconnected);
+  });
+
+  testWidgets(
+      'quick connect preflight shows blocked reason + next action copy',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    final services = _buildServices(controllerOverride: _SlowHealthController());
+    final selected = services.profileStore.selectedProfile!;
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: selected.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      selected.copyWith(
+        hasStoredPassword: true,
+        serverHost: '',
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ProfilesPage(services: services)),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Quick Connect'));
+    await tester.pump(const Duration(milliseconds: 360));
+
+    expect(
+      find.textContaining(
+        'Connect blocked: Check server host / server port / local SOCKS port before connecting.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Next action: Open Profiles'), findsOneWidget);
+    expect(services.controller.status.phase, ClientConnectionPhase.disconnected);
   });
 
   testWidgets(
@@ -403,7 +488,7 @@ void main() {
 
     expect(find.text('Readiness: Ready with warnings'), findsOneWidget);
     expect(
-      find.widgetWithText(FilledButton, 'Connect (stub path)'),
+      find.widgetWithText(FilledButton, 'Connect Test (stub path)'),
       findsOneWidget,
     );
   });
@@ -514,7 +599,8 @@ void main() {
     await tester.pump();
     await tester.pump();
 
-    await tester.tap(find.widgetWithText(FilledButton, 'Connect (stub path)'));
+    await tester
+        .tap(find.widgetWithText(FilledButton, 'Connect Test (stub path)'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 1200));
     await tester.pumpAndSettle();

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -526,8 +526,13 @@ void main() {
     expect(find.textContaining('Recommended next step: Open Troubleshooting'),
         findsOneWidget);
 
-    await tester
-        .tap(find.widgetWithText(OutlinedButton, 'Open Troubleshooting'));
+    final troubleshootingButtons = find.widgetWithText(
+      OutlinedButton,
+      'Open Troubleshooting',
+    );
+    expect(troubleshootingButtons, findsAtLeastNWidgets(1));
+
+    await tester.tap(troubleshootingButtons.first);
     await tester.pump();
 
     expect(openedAdvanced, isTrue);


### PR DESCRIPTION
## Summary
This PR packages the ongoing Iter-1 first-connect stream in the committed order and keeps gating/action policy centralized.

### Included commits
- `97ee7d7` fix(client): unify connect-test gating copy across entry points  
  - Unifies blocked copy for primary CTA + quick connect preflight.
- `4a67659` test(client): stabilize failure family classification precedence  
  - Makes `classifyFailureFamily` prefer structured `errorCode`, then phase fallback, then summary/detail compatibility.
- `870a002` test(client): cover failure lifecycle retry and disconnect cleanup  
  - Extends controller lifecycle tests for fail→retry→success and fail→disconnect cleanup.
- `df18bb1` feat(client): centralize profile next-action policy for blocked/failure states  
  - Adds centralized `ProfileNextActionPolicy` mapping readiness blocked + failure families to default actionable next steps.
  - Wires policy into guidance card/readiness notice/action handling in Profiles.

## Issue mapping
- ✅ #27 readiness blocked gating copy parity across connect entry points
- ✅ #22 failure family deterministic precedence
- ✅ #23 failure lifecycle cleanup coverage
- ✅ #26 next action policy centralization + mapping tests
- 🔄 #20 partially advanced (profiles primary path + blocked next action UX strengthened; runtime-true acceptance + docs evidence still pending)

## Validation evidence
- `flutter analyze` (client): **No issues found**
- `flutter test` suites:
  - `test/features/profiles/presentation/next_action_policy_test.dart`
  - `test/features/profiles/presentation/first_connect_guidance_card_test.dart`
  - `test/features/profiles/presentation/profiles_page_action_gating_test.dart`
  - `test/features/profiles/presentation/profile_connection_action_policy_test.dart`
  - `test/features/controller/domain/failure_family_test.dart`
  - `test/features/controller/application/adapter_backed_client_controller_test.dart`
  - `test/features/diagnostics/application/support_issue_descriptor_test.dart`
- `./scripts/validate_iter1_first_connect.sh`:
  - `[1/4]` python tests passed
  - `[2/4]` flutter analyze passed
  - `[3/4]` Iter-1 key suite passed (`All tests passed!`)
  - `[4/4] done`

## Notes
- The Flutter root warning remains environment-level and non-blocking for CI semantics.
- Follow-up sequence remains unchanged: `#20 -> #21 -> #24 -> #25 -> #28 -> #29 -> #30` (with `#22/#23/#26/#27` closed by this PR once merged).



### Additional commit after PR creation
- `60c151b` feat(client): add connect timeline card with staged runtime visibility  
  - Adds reusable `ConnectTimelineCard` in Profiles for planned/launching/alive/session-ready progression.
  - Exposes error-state failure family + next action in timeline card.
  - Reinforces disconnecting/stopping truth with explicit "waiting for exit confirmation" warning.
  - Adds widget coverage in `connect_timeline_card_test.dart` and profiles-page regression assertions.

### Updated validation
- `flutter analyze` (client): **No issues found**
- `flutter test` (focused + regression suites): **All tests passed**



- `a01eba2` feat(client): align secret storage truth across diagnostics export and UI  
  - Extends `exportSummary` with secret storage posture fields (`summary/mode/persistent/secure`).
  - Surfaces the same secret storage truth in diagnostics pre-export summary UI.
  - Adds/extends tests to lock parity between export payload and Diagnostics/Profiles copy.

### Validation refresh after latest commit
- `flutter analyze` (client): **No issues found**
- `flutter test` (diagnostics + profiles/controller focused suites): **All tests passed**
- `./scripts/validate_iter1_first_connect.sh`: **[4/4] done**, key suite passed



- `0cda352` refactor(client): unify diagnostics export summary snapshot across payload and UI  
  - Adds shared `ExportSummarySnapshot` domain model.
  - Uses the same snapshot for diagnostics payload (`exportSummary`) and pre-export UI summary rendering.
  - Removes drift-prone duplicate copy logic by centralizing runtime truth + storage truth synthesis.
  - Adds snapshot unit tests and updates diagnostics widget tests for parity assertions.

