### PR TITLE
feat(iter2): unify recovery ladder decision hub across profiles/dashboard

### DIFF
--- a/client/lib/features/controller/domain/recovery_ladder_policy.dart
+++ b/client/lib/features/controller/domain/recovery_ladder_policy.dart
@@ -1,0 +1,398 @@
+import '../../readiness/domain/readiness_report.dart';
+import 'client_connection_status.dart';
+import 'controller_runtime_session.dart';
+import 'failure_family.dart';
+import 'runtime_posture.dart';
+
+enum RecoveryLadderAction {
+  openProfiles,
+  openTroubleshooting,
+  openSettings,
+  retryConnect,
+  exportSupportBundle,
+  none,
+}
+
+enum RecoveryRecentActionContext {
+  none,
+  connectAttempted,
+  retryRequested,
+  disconnectRequested,
+}
+
+class RecoveryLadderPolicyInput {
+  const RecoveryLadderPolicyInput({
+    required this.status,
+    required this.readinessReport,
+    required this.failureFamily,
+    required this.runtimePosture,
+    required this.runtimeSession,
+    required this.recentAction,
+    required this.troubleshootingAvailable,
+    required this.settingsAvailable,
+  });
+
+  final ClientConnectionStatus status;
+  final ReadinessReport? readinessReport;
+  final FailureFamily failureFamily;
+  final RuntimePosture runtimePosture;
+  final ControllerRuntimeSession runtimeSession;
+  final RecoveryRecentActionContext recentAction;
+  final bool troubleshootingAvailable;
+  final bool settingsAvailable;
+}
+
+class RecoveryLadderDecision {
+  const RecoveryLadderDecision({
+    required this.primaryAction,
+    required this.primaryLabel,
+    required this.detail,
+    this.secondaryAction,
+    this.secondaryLabel,
+  });
+
+  static const RecoveryLadderDecision none = RecoveryLadderDecision(
+    primaryAction: RecoveryLadderAction.none,
+    primaryLabel: 'No action',
+    detail: 'No follow-up action is required right now.',
+  );
+
+  final RecoveryLadderAction primaryAction;
+  final String primaryLabel;
+  final String detail;
+  final RecoveryLadderAction? secondaryAction;
+  final String? secondaryLabel;
+
+  bool get isActionable => primaryAction != RecoveryLadderAction.none;
+}
+
+class RecoveryLadderPolicy {
+  static RecoveryLadderDecision resolve({
+    required RecoveryLadderPolicyInput input,
+  }) {
+    if (_shouldDriveByReadiness(input.readinessReport, input.status.phase)) {
+      return _fromReadiness(
+        report: input.readinessReport!,
+        troubleshootingAvailable: input.troubleshootingAvailable,
+        settingsAvailable: input.settingsAvailable,
+      );
+    }
+
+    final actionableSessionTruth = _isActionableSessionTruth(
+      posture: input.runtimePosture,
+      session: input.runtimeSession,
+    );
+
+    if (input.status.phase == ClientConnectionPhase.disconnecting ||
+        input.runtimeSession.truth == ControllerRuntimeSessionTruth.stopping) {
+      return _disconnectingDecision(
+        troubleshootingAvailable: input.troubleshootingAvailable,
+      );
+    }
+
+    if (input.status.phase == ClientConnectionPhase.connected) {
+      if (!actionableSessionTruth) {
+        return RecoveryLadderDecision.none;
+      }
+      return RecoveryLadderDecision(
+        primaryAction: input.troubleshootingAvailable
+            ? RecoveryLadderAction.openTroubleshooting
+            : RecoveryLadderAction.openProfiles,
+        primaryLabel: input.troubleshootingAvailable
+            ? 'Revalidate in Troubleshooting'
+            : 'Open Profiles',
+        detail:
+            'Session truth looks drifted; revalidate runtime evidence before changing state.',
+        secondaryAction: input.troubleshootingAvailable
+            ? RecoveryLadderAction.openProfiles
+            : null,
+        secondaryLabel: input.troubleshootingAvailable ? 'Open Profiles' : null,
+      );
+    }
+
+    if (input.status.phase == ClientConnectionPhase.connecting &&
+        actionableSessionTruth) {
+      return RecoveryLadderDecision(
+        primaryAction: input.troubleshootingAvailable
+            ? RecoveryLadderAction.openTroubleshooting
+            : RecoveryLadderAction.openProfiles,
+        primaryLabel: input.troubleshootingAvailable
+            ? 'Open Troubleshooting'
+            : 'Open Profiles',
+        detail:
+            'The connect attempt is still in-flight while runtime evidence is aging; revalidate before retrying.',
+      );
+    }
+
+    if (input.status.phase == ClientConnectionPhase.error) {
+      return _fromFailureFamily(
+        family: input.failureFamily,
+        troubleshootingAvailable: input.troubleshootingAvailable,
+        settingsAvailable: input.settingsAvailable,
+        actionableSessionTruth: actionableSessionTruth,
+        sessionTruth: input.runtimeSession.truth,
+        recentAction: input.recentAction,
+      );
+    }
+
+    return RecoveryLadderDecision.none;
+  }
+
+  static bool _shouldDriveByReadiness(
+    ReadinessReport? report,
+    ClientConnectionPhase phase,
+  ) {
+    if (report == null || report.overallLevel != ReadinessLevel.blocked) {
+      return false;
+    }
+
+    return phase != ClientConnectionPhase.error &&
+        phase != ClientConnectionPhase.connected &&
+        phase != ClientConnectionPhase.connecting &&
+        phase != ClientConnectionPhase.disconnecting;
+  }
+
+  static RecoveryLadderDecision _fromReadiness({
+    required ReadinessReport report,
+    required bool troubleshootingAvailable,
+    required bool settingsAvailable,
+  }) {
+    final recommendation = report.recommendation;
+    if (recommendation != null) {
+      return switch (recommendation.action) {
+        ReadinessAction.openProfiles => RecoveryLadderDecision(
+            primaryAction: RecoveryLadderAction.openProfiles,
+            primaryLabel: recommendation.label,
+            detail: recommendation.detail,
+          ),
+        ReadinessAction.openTroubleshooting => RecoveryLadderDecision(
+            primaryAction: troubleshootingAvailable
+                ? RecoveryLadderAction.openTroubleshooting
+                : RecoveryLadderAction.openProfiles,
+            primaryLabel: troubleshootingAvailable
+                ? recommendation.label
+                : 'Open Profiles',
+            detail: troubleshootingAvailable
+                ? recommendation.detail
+                : _fallbackDetail(
+                    recommendation.detail,
+                    fallbackSurface: 'Profiles',
+                  ),
+          ),
+        ReadinessAction.openSettings => RecoveryLadderDecision(
+            primaryAction: settingsAvailable
+                ? RecoveryLadderAction.openSettings
+                : RecoveryLadderAction.openProfiles,
+            primaryLabel:
+                settingsAvailable ? recommendation.label : 'Open Profiles',
+            detail: settingsAvailable
+                ? recommendation.detail
+                : _fallbackDetail(
+                    recommendation.detail,
+                    fallbackSurface: 'Profiles',
+                  ),
+          ),
+      };
+    }
+
+    final blocked = _firstBlockedCheck(report.checks);
+    if (blocked == null) {
+      return const RecoveryLadderDecision(
+        primaryAction: RecoveryLadderAction.openProfiles,
+        primaryLabel: 'Open Profiles',
+        detail: 'Review profile details and retry the connect test.',
+      );
+    }
+
+    return switch (blocked.domain) {
+      ReadinessDomain.password => RecoveryLadderDecision(
+          primaryAction: RecoveryLadderAction.openProfiles,
+          primaryLabel: 'Set Password',
+          detail: blocked.detail ?? blocked.summary,
+        ),
+      ReadinessDomain.profile ||
+      ReadinessDomain.config =>
+        RecoveryLadderDecision(
+          primaryAction: RecoveryLadderAction.openProfiles,
+          primaryLabel: 'Open Profiles',
+          detail: blocked.detail ?? blocked.summary,
+        ),
+      ReadinessDomain.secureStorage => RecoveryLadderDecision(
+          primaryAction: settingsAvailable
+              ? RecoveryLadderAction.openSettings
+              : RecoveryLadderAction.openProfiles,
+          primaryLabel: settingsAvailable ? 'Open Settings' : 'Open Profiles',
+          detail: settingsAvailable
+              ? (blocked.detail ?? blocked.summary)
+              : _fallbackDetail(
+                  blocked.detail ?? blocked.summary,
+                  fallbackSurface: 'Profiles',
+                ),
+        ),
+      ReadinessDomain.environment ||
+      ReadinessDomain.runtimePath ||
+      ReadinessDomain.runtimeBinary ||
+      ReadinessDomain.filesystem =>
+        RecoveryLadderDecision(
+          primaryAction: troubleshootingAvailable
+              ? RecoveryLadderAction.openTroubleshooting
+              : RecoveryLadderAction.openProfiles,
+          primaryLabel: troubleshootingAvailable
+              ? 'Open Troubleshooting'
+              : 'Open Profiles',
+          detail: troubleshootingAvailable
+              ? (blocked.detail ?? blocked.summary)
+              : _fallbackDetail(
+                  blocked.detail ?? blocked.summary,
+                  fallbackSurface: 'Profiles',
+                ),
+        ),
+    };
+  }
+
+  static RecoveryLadderDecision _disconnectingDecision({
+    required bool troubleshootingAvailable,
+  }) {
+    return RecoveryLadderDecision(
+      primaryAction: troubleshootingAvailable
+          ? RecoveryLadderAction.openTroubleshooting
+          : RecoveryLadderAction.openProfiles,
+      primaryLabel:
+          troubleshootingAvailable ? 'Open Troubleshooting' : 'Open Profiles',
+      detail:
+          'Do not treat this runtime as fully closed yet. Wait for runtime exit confirmation before assuming shutdown has finished.',
+      secondaryAction:
+          troubleshootingAvailable ? RecoveryLadderAction.openProfiles : null,
+      secondaryLabel: troubleshootingAvailable ? 'Open Profiles' : null,
+    );
+  }
+
+  static RecoveryLadderDecision _fromFailureFamily({
+    required FailureFamily family,
+    required bool troubleshootingAvailable,
+    required bool settingsAvailable,
+    required bool actionableSessionTruth,
+    required ControllerRuntimeSessionTruth sessionTruth,
+    required RecoveryRecentActionContext recentAction,
+  }) {
+    switch (family) {
+      case FailureFamily.userInput:
+        return const RecoveryLadderDecision(
+          primaryAction: RecoveryLadderAction.openProfiles,
+          primaryLabel: 'Set Password',
+          detail: 'Save the Trojan password, then retry connect test.',
+        );
+      case FailureFamily.config:
+        return const RecoveryLadderDecision(
+          primaryAction: RecoveryLadderAction.openProfiles,
+          primaryLabel: 'Open Profiles',
+          detail: 'Review profile config fields before retrying.',
+        );
+      case FailureFamily.connect:
+      case FailureFamily.launch:
+        final evidenceFirst = _shouldCaptureEvidenceFirst(
+          actionableSessionTruth: actionableSessionTruth,
+          sessionTruth: sessionTruth,
+          recentAction: recentAction,
+        );
+        if (evidenceFirst) {
+          return RecoveryLadderDecision(
+            primaryAction: troubleshootingAvailable
+                ? RecoveryLadderAction.openTroubleshooting
+                : RecoveryLadderAction.openProfiles,
+            primaryLabel: troubleshootingAvailable
+                ? 'Open Troubleshooting'
+                : 'Open Profiles',
+            detail:
+                'Preserve current runtime evidence before retrying the connect path.',
+          );
+        }
+        return const RecoveryLadderDecision(
+          primaryAction: RecoveryLadderAction.retryConnect,
+          primaryLabel: 'Retry Connect Test',
+          detail: 'Retry the connect test after preserving current evidence.',
+        );
+      case FailureFamily.environment:
+        return RecoveryLadderDecision(
+          primaryAction: settingsAvailable
+              ? RecoveryLadderAction.openSettings
+              : (troubleshootingAvailable
+                  ? RecoveryLadderAction.openTroubleshooting
+                  : RecoveryLadderAction.openProfiles),
+          primaryLabel: settingsAvailable
+              ? 'Open Settings'
+              : (troubleshootingAvailable
+                  ? 'Open Troubleshooting'
+                  : 'Open Profiles'),
+          detail:
+              'Check runtime environment availability before the next attempt.',
+        );
+      case FailureFamily.exportOs:
+        return const RecoveryLadderDecision(
+          primaryAction: RecoveryLadderAction.exportSupportBundle,
+          primaryLabel: 'Export Support Bundle',
+          detail:
+              'Capture a support bundle after checking file permissions and target path.',
+        );
+      case FailureFamily.unknown:
+        return RecoveryLadderDecision(
+          primaryAction: troubleshootingAvailable
+              ? RecoveryLadderAction.openTroubleshooting
+              : RecoveryLadderAction.openProfiles,
+          primaryLabel: troubleshootingAvailable
+              ? 'Open Troubleshooting'
+              : 'Open Profiles',
+          detail:
+              'Open Troubleshooting and capture runtime evidence before retrying.',
+        );
+    }
+  }
+
+  static bool _isActionableSessionTruth({
+    required RuntimePosture posture,
+    required ControllerRuntimeSession session,
+  }) {
+    return session.needsAttention &&
+        (!posture.isStubOnly || session.isRunning || session.stopRequested);
+  }
+
+  static bool _shouldCaptureEvidenceFirst({
+    required bool actionableSessionTruth,
+    required ControllerRuntimeSessionTruth sessionTruth,
+    required RecoveryRecentActionContext recentAction,
+  }) {
+    if (!actionableSessionTruth) {
+      return false;
+    }
+
+    if (recentAction == RecoveryRecentActionContext.retryRequested ||
+        recentAction == RecoveryRecentActionContext.disconnectRequested) {
+      return true;
+    }
+
+    return switch (sessionTruth) {
+      ControllerRuntimeSessionTruth.stopping => true,
+      ControllerRuntimeSessionTruth.aging => true,
+      ControllerRuntimeSessionTruth.stale => true,
+      ControllerRuntimeSessionTruth.residual => true,
+      ControllerRuntimeSessionTruth.live => false,
+      ControllerRuntimeSessionTruth.stopped => false,
+    };
+  }
+
+  static ReadinessCheck? _firstBlockedCheck(List<ReadinessCheck> checks) {
+    for (final check in checks) {
+      if (check.level == ReadinessLevel.blocked) {
+        return check;
+      }
+    }
+    return null;
+  }
+
+  static String _fallbackDetail(
+    String sourceDetail, {
+    required String fallbackSurface,
+  }) {
+    return 'fallback to $fallbackSurface: $sourceDetail';
+  }
+}

--- a/client/lib/features/dashboard/presentation/dashboard_guide_policy.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_guide_policy.dart
@@ -1,5 +1,7 @@
 import '../../controller/domain/client_connection_status.dart';
 import '../../controller/domain/controller_runtime_session.dart';
+import '../../controller/domain/failure_family.dart';
+import '../../controller/domain/recovery_ladder_policy.dart';
 import '../../controller/domain/runtime_action_matrix.dart';
 import '../../controller/domain/runtime_action_safety.dart';
 import '../../controller/domain/runtime_operator_advice.dart';
@@ -49,6 +51,7 @@ class DashboardGuidePolicy {
     required ControllerRuntimeSession runtimeSession,
     required RuntimeOperatorAdvice operatorAdvice,
     required ReadinessReport? readiness,
+    required bool settingsAvailable,
   }) {
     final actionSafety = RuntimeActionSafety.resolve(
       status: status,
@@ -71,9 +74,18 @@ class DashboardGuidePolicy {
       );
     }
 
-    if (activeProfile == null &&
-        selectedProfile != null &&
-        !selectedProfile.hasStoredPassword) {
+    final profileContext = activeProfile ?? selectedProfile;
+    if (profileContext == null) {
+      return DashboardGuidePolicy(
+        title: 'Start by adding one profile',
+        body: 'Open Profiles and create one profile before testing.',
+        primaryLabel: 'Open Profiles',
+        primaryAction: DashboardGuideAction.openProfiles,
+        actionSafety: actionSafety,
+      );
+    }
+
+    if (activeProfile == null && !profileContext.hasStoredPassword) {
       return DashboardGuidePolicy(
         title: 'Save the password before testing',
         body:
@@ -84,96 +96,33 @@ class DashboardGuidePolicy {
       );
     }
 
-    if (readiness != null &&
-        readiness.overallLevel == ReadinessLevel.blocked &&
-        status.phase != ClientConnectionPhase.error &&
-        status.phase != ClientConnectionPhase.connected &&
-        status.phase != ClientConnectionPhase.connecting &&
-        status.phase != ClientConnectionPhase.disconnecting) {
-      final recommendation = readiness.recommendation;
-      return DashboardGuidePolicy(
-        title: readiness.headline,
-        body: readiness.summary,
-        primaryLabel: recommendation?.label ?? 'Open Troubleshooting',
-        primaryAction: recommendation == null
-            ? DashboardGuideAction.openAdvanced
-            : _guideActionFor(recommendation.action),
-        actionSafety: actionSafety,
-        secondaryLabel: 'Open Profiles',
-        secondaryAction: DashboardGuideAction.openProfiles,
-      );
-    }
+    final parsedFamily = parseFailureFamily(status.failureFamilyHint);
+    final failureFamily = parsedFamily == FailureFamily.unknown
+        ? classifyFailureFamily(
+            errorCode: status.errorCode,
+            summary: status.message,
+            detail: status.message,
+            phase: status.phase.name,
+          )
+        : parsedFamily;
 
-    if (status.phase == ClientConnectionPhase.error) {
-      final errorBody = operatorAdvice.actionableSessionTruth
-          ? operatorAdvice.message ??
-              '${lifecycle.detail} ${runtimeSession.recoveryGuidance}'
-          : lifecycle.detail;
-      final evidenceFirst = actionMatrix.preferredEvidenceAction ==
-          RuntimePreferredEvidenceAction.generateSupportPreview;
-      return DashboardGuidePolicy(
-        title: lifecycle.headline,
-        body: errorBody,
-        primaryLabel: evidenceFirst
-            ? (operatorAdvice.primaryLabel ?? 'Open Troubleshooting')
-            : lifecycle.showRetry
-                ? posture.qualifyAction('Retry now')
-                : 'Open Profiles',
-        primaryAction: evidenceFirst
-            ? (actionMatrix.preferredOperatorAction ==
-                    RuntimePreferredOperatorAction.openTroubleshooting
-                ? DashboardGuideAction.openAdvanced
-                : DashboardGuideAction.openProfiles)
-            : lifecycle.showRetry
-                ? DashboardGuideAction.retryNow
-                : DashboardGuideAction.openProfiles,
-        actionSafety: actionSafety,
-        secondaryLabel: evidenceFirst
-            ? null
-            : lifecycle.showOpenTroubleshooting
-                ? 'Open Troubleshooting'
-                : null,
-        secondaryAction: evidenceFirst
-            ? null
-            : lifecycle.showOpenTroubleshooting
-                ? DashboardGuideAction.openAdvanced
-                : null,
-        operatorTitle: evidenceFirst
-            ? 'Recommended right now: capture a support snapshot first'
-            : null,
-        operatorBody: evidenceFirst
-            ? 'Open Troubleshooting and preserve the current runtime evidence before retrying. A fast retry now may erase the signal that explains this failure.'
-            : null,
-      );
-    }
+    final ladderDecision = RecoveryLadderPolicy.resolve(
+      input: RecoveryLadderPolicyInput(
+        status: status,
+        readinessReport: readiness,
+        failureFamily: failureFamily,
+        runtimePosture: posture,
+        runtimeSession: runtimeSession,
+        recentAction: _recentActionFor(status),
+        troubleshootingAvailable: operatorAdvice.primaryEnabled,
+        settingsAvailable: settingsAvailable,
+      ),
+    );
 
-    if (status.phase == ClientConnectionPhase.connected) {
-      if (operatorAdvice.actionableSessionTruth) {
-        return DashboardGuidePolicy(
-          title: operatorAdvice.headline ?? 'Connection state needs revalidation',
-          body: operatorAdvice.message ??
-              '${runtimeSession.truthNote} ${runtimeSession.recoveryGuidance}',
-          primaryLabel: operatorAdvice.primaryLabel ?? 'Open Troubleshooting',
-          primaryAction: actionMatrix.preferredOperatorAction ==
-                  RuntimePreferredOperatorAction.openTroubleshooting
-              ? DashboardGuideAction.openAdvanced
-              : DashboardGuideAction.openProfiles,
-          actionSafety: actionSafety,
-          secondaryLabel: actionMatrix.secondaryStateChangeContract ==
-                  RuntimeSecondaryStateChangeContract.withholdFallback
-              ? null
-              : 'Disconnect now',
-          secondaryAction: actionMatrix.secondaryStateChangeContract ==
-                  RuntimeSecondaryStateChangeContract.withholdFallback
-              ? null
-              : DashboardGuideAction.disconnectNow,
-          operatorTitle: 'Recommended right now',
-          operatorBody: actionMatrix.nextStepContract ==
-                  RuntimeNextStepContract.openTroubleshooting
-              ? 'Open Troubleshooting first, confirm whether the session is still trustworthy, and only then decide whether to disconnect or reconnect.'
-              : 'Review the current runtime state before making another state-changing move.',
-        );
-      }
+    final guideAction = _mapLadderAction(ladderDecision.primaryAction);
+
+    if (status.phase == ClientConnectionPhase.connected &&
+        !operatorAdvice.actionableSessionTruth) {
       return DashboardGuidePolicy(
         title: 'Connection is active',
         body:
@@ -186,64 +135,170 @@ class DashboardGuidePolicy {
       );
     }
 
-    if (status.phase == ClientConnectionPhase.disconnecting) {
+    if (status.phase == ClientConnectionPhase.disconnected &&
+        readiness?.overallLevel != ReadinessLevel.blocked) {
       return DashboardGuidePolicy(
-        title: operatorAdvice.headline ?? lifecycle.headline,
-        body: operatorAdvice.message ?? lifecycle.detail,
-        primaryLabel: operatorAdvice.primaryLabel ?? 'Open Troubleshooting',
-        primaryAction: actionMatrix.preferredOperatorAction ==
-                RuntimePreferredOperatorAction.openTroubleshooting
-            ? DashboardGuideAction.openAdvanced
-            : DashboardGuideAction.openProfiles,
+        title: 'You are ready for a quick test',
+        body:
+            'Use one clear Connect action here, or open Profiles if you want to review the selected profile first.',
+        primaryLabel: posture.qualifyAction('Connect now'),
+        primaryAction: DashboardGuideAction.connectNow,
         actionSafety: actionSafety,
         secondaryLabel: 'Open Profiles',
         secondaryAction: DashboardGuideAction.openProfiles,
-        operatorTitle: actionMatrix.evidenceCaptureContract ==
-                RuntimeEvidenceCaptureContract.preferBeforeMutation
-            ? 'Recommended right now: capture a support snapshot first'
-            : 'Recommended right now',
-        operatorBody: actionMatrix.nextStepContract ==
-                RuntimeNextStepContract.captureSupportEvidence
-            ? 'Open Troubleshooting and capture the current support evidence before you retry or assume shutdown has finished. This keeps the stop-pending state visible while it is still fresh.'
-            : 'Open Troubleshooting before making another change.',
       );
     }
 
-    if (status.phase == ClientConnectionPhase.connecting) {
-      return DashboardGuidePolicy(
-        title: lifecycle.headline,
-        body: operatorAdvice.message ?? lifecycle.detail,
-        primaryLabel: operatorAdvice.primaryLabel ?? 'Open Troubleshooting',
-        primaryAction: actionMatrix.preferredOperatorAction ==
-                RuntimePreferredOperatorAction.openTroubleshooting
-            ? DashboardGuideAction.openAdvanced
-            : DashboardGuideAction.openProfiles,
-        actionSafety: actionSafety,
-        secondaryLabel: 'Open Profiles',
-        secondaryAction: DashboardGuideAction.openProfiles,
-        operatorTitle: 'Recommended right now',
-        operatorBody:
-            'Let the current connection attempt settle first. If the runtime keeps looking suspicious, open Troubleshooting before retrying again.',
-      );
-    }
+    final body = status.phase == ClientConnectionPhase.error
+        ? ladderDecision.detail
+        : (operatorAdvice.message ?? ladderDecision.detail);
+
+    final title = status.phase == ClientConnectionPhase.connected
+        ? (operatorAdvice.headline ?? 'Connection state needs revalidation')
+        : status.phase == ClientConnectionPhase.disconnecting
+            ? (operatorAdvice.headline ?? lifecycle.headline)
+            : status.phase == ClientConnectionPhase.connecting
+                ? lifecycle.headline
+                : status.phase == ClientConnectionPhase.error
+                    ? lifecycle.headline
+                    : (readiness?.headline ?? lifecycle.headline);
+
+    final secondaryAction = _secondaryActionFor(
+      status: status,
+      actionMatrix: actionMatrix,
+      ladderDecision: ladderDecision,
+    );
 
     return DashboardGuidePolicy(
-      title: 'You are ready for a quick test',
-      body:
-          'Use one clear Connect action here, or open Profiles if you want to review the selected profile first.',
-      primaryLabel: posture.qualifyAction('Connect now'),
-      primaryAction: DashboardGuideAction.connectNow,
+      title: title,
+      body: body,
+      primaryLabel: ladderDecision.primaryLabel,
+      primaryAction: guideAction,
       actionSafety: actionSafety,
-      secondaryLabel: 'Open Profiles',
-      secondaryAction: DashboardGuideAction.openProfiles,
+      secondaryLabel: secondaryAction?.$1,
+      secondaryAction: secondaryAction?.$2,
+      operatorTitle: _operatorTitleFor(
+        status: status,
+        actionMatrix: actionMatrix,
+        operatorAdvice: operatorAdvice,
+      ),
+      operatorBody: _operatorBodyFor(
+        status: status,
+        actionMatrix: actionMatrix,
+      ),
     );
   }
 
-  static DashboardGuideAction _guideActionFor(ReadinessAction action) {
-    return switch (action) {
-      ReadinessAction.openProfiles => DashboardGuideAction.openProfiles,
-      ReadinessAction.openTroubleshooting => DashboardGuideAction.openAdvanced,
-      ReadinessAction.openSettings => DashboardGuideAction.openSettings,
+  static RecoveryRecentActionContext _recentActionFor(
+    ClientConnectionStatus status,
+  ) {
+    return switch (status.phase) {
+      ClientConnectionPhase.connecting =>
+        RecoveryRecentActionContext.connectAttempted,
+      ClientConnectionPhase.disconnecting =>
+        RecoveryRecentActionContext.disconnectRequested,
+      ClientConnectionPhase.error => RecoveryRecentActionContext.retryRequested,
+      ClientConnectionPhase.connected ||
+      ClientConnectionPhase.disconnected =>
+        RecoveryRecentActionContext.none,
     };
+  }
+
+  static DashboardGuideAction _mapLadderAction(RecoveryLadderAction action) {
+    return switch (action) {
+      RecoveryLadderAction.openProfiles => DashboardGuideAction.openProfiles,
+      RecoveryLadderAction.openTroubleshooting =>
+        DashboardGuideAction.openAdvanced,
+      RecoveryLadderAction.openSettings => DashboardGuideAction.openSettings,
+      RecoveryLadderAction.retryConnect => DashboardGuideAction.retryNow,
+      RecoveryLadderAction.exportSupportBundle =>
+        DashboardGuideAction.openAdvanced,
+      RecoveryLadderAction.none => DashboardGuideAction.openProfiles,
+    };
+  }
+
+  static (String, DashboardGuideAction)? _secondaryActionFor({
+    required ClientConnectionStatus status,
+    required RuntimeActionMatrix actionMatrix,
+    required RecoveryLadderDecision ladderDecision,
+  }) {
+    if (status.phase == ClientConnectionPhase.connected &&
+        actionMatrix.secondaryStateChangeContract !=
+            RuntimeSecondaryStateChangeContract.withholdFallback) {
+      return ('Disconnect now', DashboardGuideAction.disconnectNow);
+    }
+
+    if (ladderDecision.secondaryAction != null) {
+      return (
+        ladderDecision.secondaryLabel ?? 'Open Profiles',
+        _mapLadderAction(ladderDecision.secondaryAction!),
+      );
+    }
+
+    if (status.phase == ClientConnectionPhase.disconnected ||
+        status.phase == ClientConnectionPhase.connecting ||
+        status.phase == ClientConnectionPhase.disconnecting) {
+      return ('Open Profiles', DashboardGuideAction.openProfiles);
+    }
+
+    return null;
+  }
+
+  static String? _operatorTitleFor({
+    required ClientConnectionStatus status,
+    required RuntimeActionMatrix actionMatrix,
+    required RuntimeOperatorAdvice operatorAdvice,
+  }) {
+    if (status.phase == ClientConnectionPhase.error &&
+        actionMatrix.preferredEvidenceAction ==
+            RuntimePreferredEvidenceAction.generateSupportPreview) {
+      return 'Recommended right now: capture a support snapshot first';
+    }
+
+    if (status.phase == ClientConnectionPhase.disconnecting &&
+        actionMatrix.evidenceCaptureContract ==
+            RuntimeEvidenceCaptureContract.preferBeforeMutation) {
+      return 'Recommended right now: capture a support snapshot first';
+    }
+
+    if (status.phase == ClientConnectionPhase.connected &&
+        operatorAdvice.actionableSessionTruth) {
+      return 'Recommended right now';
+    }
+
+    if (status.phase == ClientConnectionPhase.connecting) {
+      return 'Recommended right now';
+    }
+
+    return null;
+  }
+
+  static String? _operatorBodyFor({
+    required ClientConnectionStatus status,
+    required RuntimeActionMatrix actionMatrix,
+  }) {
+    if (status.phase == ClientConnectionPhase.error &&
+        actionMatrix.preferredEvidenceAction ==
+            RuntimePreferredEvidenceAction.generateSupportPreview) {
+      return 'Open Troubleshooting and preserve the current runtime evidence before retrying. A fast retry now may erase the signal that explains this failure.';
+    }
+
+    if (status.phase == ClientConnectionPhase.disconnecting &&
+        actionMatrix.nextStepContract ==
+            RuntimeNextStepContract.captureSupportEvidence) {
+      return 'Open Troubleshooting and capture the current support evidence before you retry or assume shutdown has finished. This keeps the stop-pending state visible while it is still fresh.';
+    }
+
+    if (status.phase == ClientConnectionPhase.connected &&
+        actionMatrix.nextStepContract ==
+            RuntimeNextStepContract.openTroubleshooting) {
+      return 'Open Troubleshooting first, confirm whether the session is still trustworthy, and only then decide whether to disconnect or reconnect.';
+    }
+
+    if (status.phase == ClientConnectionPhase.connecting) {
+      return 'Let the current connection attempt settle first. If the runtime keeps looking suspicious, open Troubleshooting before retrying again.';
+    }
+
+    return null;
   }
 }

--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -531,7 +531,8 @@ class _NextStepGuide extends StatelessWidget {
             ],
           ),
         ),
-        if (model.operatorTitle != null && model.operatorBody != null) ...<Widget>[
+        if (model.operatorTitle != null &&
+            model.operatorBody != null) ...<Widget>[
           const SizedBox(height: 12),
           Container(
             width: double.infinity,
@@ -663,6 +664,7 @@ class _NextStepGuide extends StatelessWidget {
       runtimeSession: runtimeSession,
       operatorAdvice: operatorAdvice,
       readiness: readiness,
+      settingsAvailable: onOpenSettings != null,
     );
 
     return _GuideModel(
@@ -1067,7 +1069,8 @@ class _RuntimeSessionSummary extends StatelessWidget {
               children: <Widget>[
                 KeyValuePair(
                     label: 'Running', value: session.isRunning ? 'Yes' : 'No'),
-                KeyValuePair(label: 'Runtime Truth', value: session.truth.label),
+                KeyValuePair(
+                    label: 'Runtime Truth', value: session.truth.label),
                 KeyValuePair(label: 'Snapshot Age', value: session.ageLabel),
                 KeyValuePair(label: 'Runtime Phase', value: session.phase.name),
                 KeyValuePair(

--- a/client/lib/features/profiles/presentation/next_action_policy.dart
+++ b/client/lib/features/profiles/presentation/next_action_policy.dart
@@ -1,5 +1,8 @@
 import '../../controller/domain/client_connection_status.dart';
+import '../../controller/domain/controller_runtime_session.dart';
 import '../../controller/domain/failure_family.dart';
+import '../../controller/domain/recovery_ladder_policy.dart';
+import '../../controller/domain/runtime_posture.dart';
 import '../../readiness/domain/readiness_report.dart';
 
 enum ProfileNextActionType {
@@ -38,7 +41,8 @@ class ProfileNextActionDecision {
       ProfileNextActionType.openSettings => ReadinessAction.openSettings,
       ProfileNextActionType.retryConnect ||
       ProfileNextActionType.exportSupportBundle ||
-      ProfileNextActionType.none => null,
+      ProfileNextActionType.none =>
+        null,
     };
   }
 }
@@ -50,177 +54,49 @@ class ProfileNextActionPolicy {
     required FailureFamily failureFamily,
     required bool troubleshootingAvailable,
     required bool settingsAvailable,
+    RuntimePosture? runtimePosture,
+    ControllerRuntimeSession? runtimeSession,
+    RecoveryRecentActionContext recentAction = RecoveryRecentActionContext.none,
   }) {
-    if (readinessReport != null &&
-        readinessReport.overallLevel == ReadinessLevel.blocked) {
-      return _fromReadiness(
-        report: readinessReport,
+    final decision = RecoveryLadderPolicy.resolve(
+      input: RecoveryLadderPolicyInput(
+        status: status,
+        readinessReport: readinessReport,
+        failureFamily: failureFamily,
+        runtimePosture: runtimePosture ??
+            describeRuntimePosture(
+              runtimeMode: 'stubbed-local-boundary',
+              backendKind: 'legacy-profile-next-action',
+            ),
+        runtimeSession: runtimeSession ??
+            ControllerRuntimeSession(
+              isRunning: false,
+              updatedAt: DateTime.now(),
+              phase: ControllerRuntimePhase.stopped,
+            ),
+        recentAction: recentAction,
         troubleshootingAvailable: troubleshootingAvailable,
         settingsAvailable: settingsAvailable,
-      );
-    }
+      ),
+    );
 
-    if (status.phase == ClientConnectionPhase.error) {
-      return _fromFailureFamily(
-        failureFamily,
-        troubleshootingAvailable: troubleshootingAvailable,
-        settingsAvailable: settingsAvailable,
-      );
-    }
-
-    if (status.phase == ClientConnectionPhase.disconnecting) {
-      return troubleshootingAvailable
-          ? const ProfileNextActionDecision(
-              type: ProfileNextActionType.openTroubleshooting,
-              label: 'Open Troubleshooting',
-              detail:
-                  'Wait for runtime exit confirmation before assuming shutdown has finished.',
-            )
-          : const ProfileNextActionDecision(
-              type: ProfileNextActionType.openProfiles,
-              label: 'Open Profiles',
-              detail:
-                  'Wait for runtime exit confirmation before assuming shutdown has finished.',
-            );
-    }
-
-    return ProfileNextActionDecision.none;
+    return ProfileNextActionDecision(
+      type: _mapType(decision.primaryAction),
+      label: decision.primaryLabel,
+      detail: decision.detail,
+    );
   }
 
-  static ProfileNextActionDecision _fromReadiness({
-    required ReadinessReport report,
-    required bool troubleshootingAvailable,
-    required bool settingsAvailable,
-  }) {
-    final recommendation = report.recommendation;
-    if (recommendation != null) {
-      return switch (recommendation.action) {
-        ReadinessAction.openProfiles => ProfileNextActionDecision(
-            type: ProfileNextActionType.openProfiles,
-            label: recommendation.label,
-            detail: recommendation.detail,
-          ),
-        ReadinessAction.openTroubleshooting => ProfileNextActionDecision(
-            type: troubleshootingAvailable
-                ? ProfileNextActionType.openTroubleshooting
-                : ProfileNextActionType.openProfiles,
-            label:
-                troubleshootingAvailable ? recommendation.label : 'Open Profiles',
-            detail: recommendation.detail,
-          ),
-        ReadinessAction.openSettings => ProfileNextActionDecision(
-            type: settingsAvailable
-                ? ProfileNextActionType.openSettings
-                : ProfileNextActionType.openProfiles,
-            label: settingsAvailable ? recommendation.label : 'Open Profiles',
-            detail: recommendation.detail,
-          ),
-      };
-    }
-
-    final blocked = _firstBlockedCheck(report.checks);
-    if (blocked == null) {
-      return const ProfileNextActionDecision(
-        type: ProfileNextActionType.openProfiles,
-        label: 'Open Profiles',
-        detail: 'Review profile details and retry the connect test.',
-      );
-    }
-
-    return switch (blocked.domain) {
-      ReadinessDomain.password => ProfileNextActionDecision(
-          type: ProfileNextActionType.openProfiles,
-          label: 'Set Password',
-          detail: blocked.detail ?? blocked.summary,
-        ),
-      ReadinessDomain.profile || ReadinessDomain.config =>
-        ProfileNextActionDecision(
-          type: ProfileNextActionType.openProfiles,
-          label: 'Open Profiles',
-          detail: blocked.detail ?? blocked.summary,
-        ),
-      ReadinessDomain.secureStorage => ProfileNextActionDecision(
-          type: settingsAvailable
-              ? ProfileNextActionType.openSettings
-              : ProfileNextActionType.openProfiles,
-          label: settingsAvailable ? 'Open Settings' : 'Open Profiles',
-          detail: blocked.detail ?? blocked.summary,
-        ),
-      ReadinessDomain.environment ||
-      ReadinessDomain.runtimePath ||
-      ReadinessDomain.runtimeBinary ||
-      ReadinessDomain.filesystem =>
-        ProfileNextActionDecision(
-          type: troubleshootingAvailable
-              ? ProfileNextActionType.openTroubleshooting
-              : ProfileNextActionType.openProfiles,
-          label:
-              troubleshootingAvailable ? 'Open Troubleshooting' : 'Open Profiles',
-          detail: blocked.detail ?? blocked.summary,
-        ),
+  static ProfileNextActionType _mapType(RecoveryLadderAction action) {
+    return switch (action) {
+      RecoveryLadderAction.openProfiles => ProfileNextActionType.openProfiles,
+      RecoveryLadderAction.openTroubleshooting =>
+        ProfileNextActionType.openTroubleshooting,
+      RecoveryLadderAction.openSettings => ProfileNextActionType.openSettings,
+      RecoveryLadderAction.retryConnect => ProfileNextActionType.retryConnect,
+      RecoveryLadderAction.exportSupportBundle =>
+        ProfileNextActionType.exportSupportBundle,
+      RecoveryLadderAction.none => ProfileNextActionType.none,
     };
-  }
-
-  static ProfileNextActionDecision _fromFailureFamily(
-    FailureFamily family, {
-    required bool troubleshootingAvailable,
-    required bool settingsAvailable,
-  }) {
-    return switch (family) {
-      FailureFamily.userInput => const ProfileNextActionDecision(
-          type: ProfileNextActionType.openProfiles,
-          label: 'Set Password',
-          detail: 'Save the Trojan password, then retry connect test.',
-        ),
-      FailureFamily.config => const ProfileNextActionDecision(
-          type: ProfileNextActionType.openProfiles,
-          label: 'Open Profiles',
-          detail: 'Review profile config fields before retrying.',
-        ),
-      FailureFamily.launch || FailureFamily.connect =>
-        const ProfileNextActionDecision(
-          type: ProfileNextActionType.retryConnect,
-          label: 'Retry Connect Test',
-          detail: 'Retry the connect test after preserving current evidence.',
-        ),
-      FailureFamily.environment => ProfileNextActionDecision(
-          type: settingsAvailable
-              ? ProfileNextActionType.openSettings
-              : (troubleshootingAvailable
-                  ? ProfileNextActionType.openTroubleshooting
-                  : ProfileNextActionType.openProfiles),
-          label: settingsAvailable
-              ? 'Open Settings'
-              : (troubleshootingAvailable
-                  ? 'Open Troubleshooting'
-                  : 'Open Profiles'),
-          detail:
-              'Check runtime environment availability before the next attempt.',
-        ),
-      FailureFamily.exportOs => const ProfileNextActionDecision(
-          type: ProfileNextActionType.exportSupportBundle,
-          label: 'Export Support Bundle',
-          detail:
-              'Capture a support bundle after checking file permissions and target path.',
-        ),
-      FailureFamily.unknown => ProfileNextActionDecision(
-          type: troubleshootingAvailable
-              ? ProfileNextActionType.openTroubleshooting
-              : ProfileNextActionType.openProfiles,
-          label:
-              troubleshootingAvailable ? 'Open Troubleshooting' : 'Open Profiles',
-          detail:
-              'Open Troubleshooting and capture runtime evidence before retrying.',
-        ),
-    };
-  }
-
-  static ReadinessCheck? _firstBlockedCheck(List<ReadinessCheck> checks) {
-    for (final check in checks) {
-      if (check.level == ReadinessLevel.blocked) {
-        return check;
-      }
-    }
-    return null;
   }
 }

--- a/client/test/features/controller/domain/recovery_ladder_policy_test.dart
+++ b/client/test/features/controller/domain/recovery_ladder_policy_test.dart
@@ -1,0 +1,701 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
+import 'package:trojan_pro_client/features/controller/domain/failure_family.dart';
+import 'package:trojan_pro_client/features/controller/domain/recovery_ladder_policy.dart';
+import 'package:trojan_pro_client/features/controller/domain/runtime_posture.dart';
+import 'package:trojan_pro_client/features/readiness/domain/readiness_report.dart';
+
+ClientConnectionStatus _status({
+  ClientConnectionPhase phase = ClientConnectionPhase.disconnected,
+  String message = 'Disconnected',
+  String? errorCode,
+  String? failureFamilyHint,
+}) {
+  return ClientConnectionStatus(
+    phase: phase,
+    message: message,
+    updatedAt: DateTime.parse('2026-04-20T02:00:00.000Z'),
+    activeProfileId: 'sample-hk-1',
+    errorCode: errorCode,
+    failureFamilyHint: failureFamilyHint,
+  );
+}
+
+ControllerRuntimeSession _session({
+  bool isRunning = false,
+  ControllerRuntimePhase phase = ControllerRuntimePhase.stopped,
+  bool stopRequested = false,
+  Duration age = Duration.zero,
+  int? exitCode,
+}) {
+  return ControllerRuntimeSession(
+    isRunning: isRunning,
+    updatedAt: DateTime.now().subtract(age),
+    phase: phase,
+    stopRequested: stopRequested,
+    stopRequestedAt: stopRequested
+        ? DateTime.now().subtract(const Duration(seconds: 3))
+        : null,
+    lastExitCode: exitCode,
+  );
+}
+
+RuntimePosture _posture({
+  String runtimeMode = 'real-runtime-boundary',
+  String backendKind = 'real-shell-controller',
+}) {
+  return describeRuntimePosture(
+    runtimeMode: runtimeMode,
+    backendKind: backendKind,
+  );
+}
+
+ReadinessReport _blockedReport(ReadinessCheck check) {
+  return ReadinessReport.fromChecks(
+    <ReadinessCheck>[check],
+    generatedAt: DateTime.parse('2026-04-20T01:55:00.000Z'),
+  );
+}
+
+void main() {
+  group('RecoveryLadderPolicy', () {
+    test('blocked readiness openProfiles recommendation keeps profiles action',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(),
+          readinessReport: _blockedReport(
+            const ReadinessCheck(
+              domain: ReadinessDomain.profile,
+              level: ReadinessLevel.blocked,
+              summary: 'profile missing host',
+              detail: 'Set a valid server host first.',
+              action: ReadinessAction.openProfiles,
+              actionLabel: 'Open Profiles',
+            ),
+          ),
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.none,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openProfiles);
+      expect(decision.primaryLabel, 'Open Profiles');
+      expect(decision.detail, contains('server host'));
+    });
+
+    test(
+        'blocked readiness openTroubleshooting recommendation uses troubleshooting when available',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(),
+          readinessReport: _blockedReport(
+            const ReadinessCheck(
+              domain: ReadinessDomain.environment,
+              level: ReadinessLevel.blocked,
+              summary: 'runtime binary missing',
+              detail: 'Runtime binary is unavailable.',
+              action: ReadinessAction.openTroubleshooting,
+              actionLabel: 'Open Troubleshooting',
+            ),
+          ),
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.none,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openTroubleshooting);
+      expect(decision.primaryLabel, 'Open Troubleshooting');
+      expect(decision.detail, contains('Runtime binary'));
+    });
+
+    test(
+        'blocked readiness openTroubleshooting recommendation falls back to profiles when unavailable',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(),
+          readinessReport: _blockedReport(
+            const ReadinessCheck(
+              domain: ReadinessDomain.environment,
+              level: ReadinessLevel.blocked,
+              summary: 'runtime binary missing',
+              detail: 'Runtime binary is unavailable.',
+              action: ReadinessAction.openTroubleshooting,
+              actionLabel: 'Open Troubleshooting',
+            ),
+          ),
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.none,
+          troubleshootingAvailable: false,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openProfiles);
+      expect(decision.primaryLabel, 'Open Profiles');
+      expect(decision.detail, contains('fallback'));
+    });
+
+    test(
+        'blocked readiness openSettings recommendation uses settings when available',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(),
+          readinessReport: _blockedReport(
+            const ReadinessCheck(
+              domain: ReadinessDomain.secureStorage,
+              level: ReadinessLevel.blocked,
+              summary: 'secure storage unavailable',
+              detail: 'Secure storage provider is unavailable.',
+              action: ReadinessAction.openSettings,
+              actionLabel: 'Open Settings',
+            ),
+          ),
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.none,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openSettings);
+      expect(decision.primaryLabel, 'Open Settings');
+    });
+
+    test(
+        'blocked readiness openSettings recommendation falls back to profiles when unavailable',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(),
+          readinessReport: _blockedReport(
+            const ReadinessCheck(
+              domain: ReadinessDomain.secureStorage,
+              level: ReadinessLevel.blocked,
+              summary: 'secure storage unavailable',
+              detail: 'Secure storage provider is unavailable.',
+              action: ReadinessAction.openSettings,
+              actionLabel: 'Open Settings',
+            ),
+          ),
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.none,
+          troubleshootingAvailable: true,
+          settingsAvailable: false,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openProfiles);
+      expect(decision.primaryLabel, 'Open Profiles');
+      expect(decision.detail, contains('fallback'));
+    });
+
+    test('blocked readiness password domain maps to Set Password on profiles',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(),
+          readinessReport: _blockedReport(
+            const ReadinessCheck(
+              domain: ReadinessDomain.password,
+              level: ReadinessLevel.blocked,
+              summary: 'password missing',
+              detail: 'Store Trojan password first.',
+            ),
+          ),
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.none,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openProfiles);
+      expect(decision.primaryLabel, 'Set Password');
+      expect(decision.detail, contains('Trojan password'));
+    });
+
+    test(
+        'blocked readiness secureStorage domain falls back to profiles when settings unavailable',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(),
+          readinessReport: _blockedReport(
+            const ReadinessCheck(
+              domain: ReadinessDomain.secureStorage,
+              level: ReadinessLevel.blocked,
+              summary: 'secure storage unavailable',
+              detail: 'Secure storage provider is unavailable.',
+            ),
+          ),
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.none,
+          troubleshootingAvailable: true,
+          settingsAvailable: false,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openProfiles);
+      expect(decision.primaryLabel, 'Open Profiles');
+    });
+
+    test(
+        'blocked readiness runtime domain maps to troubleshooting when available',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(),
+          readinessReport: _blockedReport(
+            const ReadinessCheck(
+              domain: ReadinessDomain.runtimeBinary,
+              level: ReadinessLevel.blocked,
+              summary: 'runtime binary missing',
+              detail: 'Runtime binary missing from configured path.',
+            ),
+          ),
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.none,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openTroubleshooting);
+      expect(decision.primaryLabel, 'Open Troubleshooting');
+    });
+
+    test('error user_input maps to set password action', () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.error,
+            message: 'Trojan password missing.',
+            errorCode: 'MISSING_TROJAN_PASSWORD',
+            failureFamilyHint: 'user_input',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.userInput,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.connectAttempted,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openProfiles);
+      expect(decision.primaryLabel, 'Set Password');
+    });
+
+    test('error config maps to open profiles action', () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.error,
+            message: 'Config invalid.',
+            errorCode: 'CONFIG_INVALID',
+            failureFamilyHint: 'config',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.config,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.connectAttempted,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openProfiles);
+      expect(decision.primaryLabel, 'Open Profiles');
+    });
+
+    test(
+        'error connect maps to retry connect when no evidence-first guard is active',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.error,
+            message: 'Runtime session exited with code 7.',
+            errorCode: 'RUNTIME_SESSION_EXIT_NONZERO',
+            failureFamilyHint: 'connect',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.connect,
+          runtimePosture: _posture(),
+          runtimeSession: _session(
+            isRunning: false,
+            phase: ControllerRuntimePhase.stopped,
+          ),
+          recentAction: RecoveryRecentActionContext.connectAttempted,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.retryConnect);
+      expect(decision.primaryLabel, 'Retry Connect Test');
+    });
+
+    test(
+        'error launch maps to retry connect when no evidence-first guard is active',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.error,
+            message: 'Launch request rejected.',
+            errorCode: 'LAUNCH_REQUEST_REJECTED',
+            failureFamilyHint: 'launch',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.launch,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.connectAttempted,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.retryConnect);
+      expect(decision.primaryLabel, 'Retry Connect Test');
+    });
+
+    test(
+        'error connect with stale runtime prioritizes troubleshooting evidence capture',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.error,
+            message: 'Runtime session exited with code 7.',
+            errorCode: 'RUNTIME_SESSION_EXIT_NONZERO',
+            failureFamilyHint: 'connect',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.connect,
+          runtimePosture: _posture(),
+          runtimeSession: _session(
+            isRunning: true,
+            phase: ControllerRuntimePhase.alive,
+            age: const Duration(minutes: 3),
+          ),
+          recentAction: RecoveryRecentActionContext.retryRequested,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openTroubleshooting);
+      expect(decision.primaryLabel, 'Open Troubleshooting');
+      expect(decision.detail, contains('Preserve'));
+    });
+
+    test('error environment prefers settings when available', () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.error,
+            message: 'Runtime binary missing.',
+            errorCode: 'RUNTIME_BINARY_MISSING',
+            failureFamilyHint: 'environment',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.environment,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.connectAttempted,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openSettings);
+      expect(decision.primaryLabel, 'Open Settings');
+    });
+
+    test(
+        'error environment falls back to troubleshooting when settings unavailable',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.error,
+            message: 'Runtime binary missing.',
+            errorCode: 'RUNTIME_BINARY_MISSING',
+            failureFamilyHint: 'environment',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.environment,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.connectAttempted,
+          troubleshootingAvailable: true,
+          settingsAvailable: false,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openTroubleshooting);
+      expect(decision.primaryLabel, 'Open Troubleshooting');
+    });
+
+    test(
+        'error environment falls back to profiles when no entrypoint is available',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.error,
+            message: 'Runtime binary missing.',
+            errorCode: 'RUNTIME_BINARY_MISSING',
+            failureFamilyHint: 'environment',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.environment,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.connectAttempted,
+          troubleshootingAvailable: false,
+          settingsAvailable: false,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openProfiles);
+      expect(decision.primaryLabel, 'Open Profiles');
+    });
+
+    test('error export_os maps to support bundle export action', () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.error,
+            message: 'Diagnostics export failed: permission denied.',
+            errorCode: 'DIAGNOSTICS_EXPORT_FAILED',
+            failureFamilyHint: 'export_os',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.exportOs,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.connectAttempted,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.exportSupportBundle);
+      expect(decision.primaryLabel, 'Export Support Bundle');
+    });
+
+    test('error unknown defaults to troubleshooting when available', () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.error,
+            message: 'Unknown runtime failure.',
+            errorCode: 'UNCLASSIFIED_RUNTIME_FAILURE',
+            failureFamilyHint: 'unknown',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.connectAttempted,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openTroubleshooting);
+      expect(decision.primaryLabel, 'Open Troubleshooting');
+      expect(decision.detail, contains('capture runtime evidence'));
+    });
+
+    test(
+        'error unknown falls back to profiles when troubleshooting unavailable',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.error,
+            message: 'Unknown runtime failure.',
+            errorCode: 'UNCLASSIFIED_RUNTIME_FAILURE',
+            failureFamilyHint: 'unknown',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(),
+          recentAction: RecoveryRecentActionContext.connectAttempted,
+          troubleshootingAvailable: false,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openProfiles);
+      expect(decision.primaryLabel, 'Open Profiles');
+    });
+
+    test('disconnecting state recommends troubleshooting when available', () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.disconnecting,
+            message: 'Disconnecting current session...',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(
+            isRunning: true,
+            phase: ControllerRuntimePhase.alive,
+            stopRequested: true,
+            age: const Duration(seconds: 8),
+          ),
+          recentAction: RecoveryRecentActionContext.disconnectRequested,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openTroubleshooting);
+      expect(decision.primaryLabel, 'Open Troubleshooting');
+      expect(decision.detail, contains('exit confirmation'));
+    });
+
+    test(
+        'disconnecting state falls back to profiles when troubleshooting unavailable',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.disconnecting,
+            message: 'Disconnecting current session...',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(
+            isRunning: true,
+            phase: ControllerRuntimePhase.alive,
+            stopRequested: true,
+            age: const Duration(seconds: 8),
+          ),
+          recentAction: RecoveryRecentActionContext.disconnectRequested,
+          troubleshootingAvailable: false,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openProfiles);
+      expect(decision.primaryLabel, 'Open Profiles');
+    });
+
+    test('connected stale runtime recommends revalidate in troubleshooting',
+        () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.connected,
+            message: 'Runtime session is ready.',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(
+            isRunning: true,
+            phase: ControllerRuntimePhase.sessionReady,
+            age: const Duration(minutes: 3),
+          ),
+          recentAction: RecoveryRecentActionContext.connectAttempted,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openTroubleshooting);
+      expect(decision.primaryLabel, 'Revalidate in Troubleshooting');
+      expect(decision.detail, contains('revalidate'));
+    });
+
+    test('connected stub residual state does not force action by itself', () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.connected,
+            message: 'Connected via fake controller boundary',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(
+            runtimeMode: 'stubbed-local-boundary',
+            backendKind: 'fake-shell-controller',
+          ),
+          runtimeSession: _session(
+            isRunning: false,
+            phase: ControllerRuntimePhase.sessionReady,
+          ),
+          recentAction: RecoveryRecentActionContext.connectAttempted,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.none);
+      expect(decision.primaryLabel, 'No action');
+    });
+
+    test('connecting state with stale runtime recommends troubleshooting', () {
+      final decision = RecoveryLadderPolicy.resolve(
+        input: RecoveryLadderPolicyInput(
+          status: _status(
+            phase: ClientConnectionPhase.connecting,
+            message: 'Connection attempt is running',
+          ),
+          readinessReport: null,
+          failureFamily: FailureFamily.unknown,
+          runtimePosture: _posture(),
+          runtimeSession: _session(
+            isRunning: true,
+            phase: ControllerRuntimePhase.alive,
+            age: const Duration(minutes: 2),
+          ),
+          recentAction: RecoveryRecentActionContext.connectAttempted,
+          troubleshootingAvailable: true,
+          settingsAvailable: true,
+        ),
+      );
+
+      expect(decision.primaryAction, RecoveryLadderAction.openTroubleshooting);
+      expect(decision.primaryLabel, 'Open Troubleshooting');
+      expect(decision.detail, contains('revalidate'));
+    });
+  });
+}

--- a/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart
@@ -1,12 +1,15 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
 import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
+import 'package:trojan_pro_client/features/controller/domain/failure_family.dart';
 import 'package:trojan_pro_client/features/controller/domain/runtime_action_safety.dart';
 import 'package:trojan_pro_client/features/controller/domain/runtime_operator_advice.dart';
 import 'package:trojan_pro_client/features/controller/domain/runtime_posture.dart';
 import 'package:trojan_pro_client/features/dashboard/application/connection_lifecycle_view_model.dart';
 import 'package:trojan_pro_client/features/dashboard/presentation/dashboard_guide_policy.dart';
 import 'package:trojan_pro_client/features/profiles/domain/client_profile.dart';
+import 'package:trojan_pro_client/features/profiles/presentation/next_action_policy.dart';
+import 'package:trojan_pro_client/features/readiness/domain/readiness_report.dart';
 
 ClientProfile _profile({
   String id = 'sample-hk-1',
@@ -26,43 +29,171 @@ ClientProfile _profile({
   );
 }
 
+ClientConnectionStatus _status({
+  ClientConnectionPhase phase = ClientConnectionPhase.disconnected,
+  String message = 'Disconnected',
+  String? activeProfileId = 'sample-hk-1',
+  String? errorCode,
+  String? failureFamilyHint,
+}) {
+  return ClientConnectionStatus(
+    phase: phase,
+    message: message,
+    updatedAt: DateTime.parse('2026-04-20T02:00:00.000Z'),
+    activeProfileId: activeProfileId,
+    errorCode: errorCode,
+    failureFamilyHint: failureFamilyHint,
+  );
+}
+
+ControllerRuntimeSession _session({
+  bool isRunning = false,
+  ControllerRuntimePhase phase = ControllerRuntimePhase.stopped,
+  bool stopRequested = false,
+  Duration age = Duration.zero,
+  int? lastExitCode,
+}) {
+  return ControllerRuntimeSession(
+    isRunning: isRunning,
+    updatedAt: DateTime.now().subtract(age),
+    phase: phase,
+    stopRequested: stopRequested,
+    stopRequestedAt: stopRequested
+        ? DateTime.now().subtract(const Duration(seconds: 5))
+        : null,
+    lastExitCode: lastExitCode,
+  );
+}
+
+RuntimePosture _posture({
+  String runtimeMode = 'real-runtime-boundary',
+  String backendKind = 'real-shell-controller',
+}) {
+  return describeRuntimePosture(
+    runtimeMode: runtimeMode,
+    backendKind: backendKind,
+  );
+}
+
+ReadinessReport _blockedReadiness({
+  required ReadinessDomain domain,
+  required String summary,
+  String? detail,
+  ReadinessAction? action,
+  String? actionLabel,
+}) {
+  return ReadinessReport.fromChecks(
+    <ReadinessCheck>[
+      ReadinessCheck(
+        domain: domain,
+        level: ReadinessLevel.blocked,
+        summary: summary,
+        detail: detail,
+        action: action,
+        actionLabel: actionLabel,
+      ),
+    ],
+    generatedAt: DateTime.parse('2026-04-20T01:55:00.000Z'),
+  );
+}
+
+DashboardGuidePolicy _resolveGuide({
+  required ClientConnectionStatus status,
+  required ClientProfile? selectedProfile,
+  required ClientProfile? activeProfile,
+  required RuntimePosture posture,
+  required ControllerRuntimeSession session,
+  required bool troubleshootingAvailable,
+  bool settingsAvailable = true,
+  ReadinessReport? readiness,
+}) {
+  final advice = RuntimeOperatorAdvice.resolve(
+    status: status,
+    session: session,
+    posture: posture,
+    troubleshootingAvailable: troubleshootingAvailable,
+  );
+
+  return DashboardGuidePolicy.resolve(
+    lifecycle: ConnectionLifecycleViewModel.fromStatus(
+      status: status,
+      selectedProfile: selectedProfile,
+    ),
+    selectedProfile: selectedProfile,
+    activeProfile: activeProfile,
+    status: status,
+    posture: posture,
+    runtimeSession: session,
+    operatorAdvice: advice,
+    readiness: readiness,
+    settingsAvailable: settingsAvailable,
+  );
+}
+
+ProfileNextActionDecision _resolveProfileDecision({
+  required ClientConnectionStatus status,
+  required ReadinessReport? readiness,
+  required RuntimePosture posture,
+  required ControllerRuntimeSession session,
+  required bool troubleshootingAvailable,
+  required bool settingsAvailable,
+}) {
+  final parsedFamily = parseFailureFamily(status.failureFamilyHint);
+  final family = parsedFamily == FailureFamily.unknown
+      ? classifyFailureFamily(
+          errorCode: status.errorCode,
+          summary: status.message,
+          detail: status.message,
+          phase: status.phase.name,
+        )
+      : parsedFamily;
+
+  return ProfileNextActionPolicy.resolve(
+    status: status,
+    readinessReport: readiness,
+    failureFamily: family,
+    troubleshootingAvailable: troubleshootingAvailable,
+    settingsAvailable: settingsAvailable,
+    runtimePosture: posture,
+    runtimeSession: session,
+  );
+}
+
+ProfileNextActionType? _mapGuidePrimaryAction(DashboardGuideAction action) {
+  return switch (action) {
+    DashboardGuideAction.openProfiles => ProfileNextActionType.openProfiles,
+    DashboardGuideAction.openAdvanced =>
+      ProfileNextActionType.openTroubleshooting,
+    DashboardGuideAction.openSettings => ProfileNextActionType.openSettings,
+    DashboardGuideAction.retryNow => ProfileNextActionType.retryConnect,
+    DashboardGuideAction.connectNow ||
+    DashboardGuideAction.disconnectNow =>
+      null,
+  };
+}
+
 void main() {
   test('stale connected runtime produces revalidation guide', () {
     final profile = _profile();
-    final status = ClientConnectionStatus(
+    final status = _status(
       phase: ClientConnectionPhase.connected,
       message: 'Runtime session is ready.',
-      updatedAt: DateTime.now(),
       activeProfileId: profile.id,
     );
-    final session = ControllerRuntimeSession(
+    final session = _session(
       isRunning: true,
-      updatedAt: DateTime.now().subtract(const Duration(minutes: 3)),
       phase: ControllerRuntimePhase.sessionReady,
+      age: const Duration(minutes: 3),
     );
-    final posture = describeRuntimePosture(
-      runtimeMode: 'real-runtime-boundary',
-      backendKind: 'real-shell-controller',
-    );
-    final advice = RuntimeOperatorAdvice.resolve(
-      status: status,
-      session: session,
-      posture: posture,
-      troubleshootingAvailable: true,
-    );
+    final posture = _posture();
 
-    final guide = DashboardGuidePolicy.resolve(
-      lifecycle: ConnectionLifecycleViewModel.fromStatus(
-        status: status,
-        selectedProfile: profile,
-      ),
+    final guide = _resolveGuide(
+      status: status,
       selectedProfile: profile,
       activeProfile: profile,
-      status: status,
       posture: posture,
-      runtimeSession: session,
-      operatorAdvice: advice,
-      readiness: null,
+      session: session,
+      troubleshootingAvailable: true,
     );
 
     expect(guide.title, 'Connection state needs revalidation');
@@ -72,76 +203,52 @@ void main() {
     expect(guide.operatorBody, contains('Open Troubleshooting first'));
     expect(guide.actionSafety.state, RuntimeActionSafetyState.revalidateFirst);
     expect(guide.actionSafety.blocksRetry, isTrue);
-    expect(guide.secondaryAction, DashboardGuideAction.disconnectNow);
   });
 
   test('idle missing-password state still routes to profiles', () {
     final profile = _profile(hasStoredPassword: false);
-    final status = ClientConnectionStatus.disconnected();
-    final posture = describeRuntimePosture(
+    final status = _status();
+    final posture = _posture(
       runtimeMode: 'stubbed-local-boundary',
       backendKind: 'fake-shell-controller',
     );
 
-    final guide = DashboardGuidePolicy.resolve(
-      lifecycle: ConnectionLifecycleViewModel.fromStatus(
-        status: status,
-        selectedProfile: profile,
-      ),
+    final guide = _resolveGuide(
+      status: status,
       selectedProfile: profile,
       activeProfile: null,
-      status: status,
       posture: posture,
-      runtimeSession: ControllerRuntimeSession(
-        isRunning: false,
-        updatedAt: DateTime.now(),
-        phase: ControllerRuntimePhase.stopped,
-      ),
-      operatorAdvice: RuntimeOperatorAdvice.none,
-      readiness: null,
+      session: _session(),
+      troubleshootingAvailable: true,
     );
 
     expect(guide.title, 'Save the password before testing');
     expect(guide.primaryAction, DashboardGuideAction.openProfiles);
   });
 
-  test('error runtime with residual evidence prefers troubleshooting over retry shortcut', () {
+  test(
+      'error runtime with residual evidence prefers troubleshooting over retry shortcut',
+      () {
     final profile = _profile();
-    final status = ClientConnectionStatus(
+    final status = _status(
       phase: ClientConnectionPhase.error,
       message: 'Runtime session exited with code 7.',
-      updatedAt: DateTime.now(),
       activeProfileId: profile.id,
     );
-    final session = ControllerRuntimeSession(
+    final session = _session(
       isRunning: false,
-      updatedAt: DateTime.now(),
       phase: ControllerRuntimePhase.failed,
       lastExitCode: 7,
     );
-    final posture = describeRuntimePosture(
-      runtimeMode: 'real-runtime-boundary',
-      backendKind: 'real-shell-controller',
-    );
-    final advice = RuntimeOperatorAdvice.resolve(
-      status: status,
-      session: session,
-      posture: posture,
-      troubleshootingAvailable: true,
-    );
+    final posture = _posture();
 
-    final guide = DashboardGuidePolicy.resolve(
-      lifecycle: ConnectionLifecycleViewModel.fromStatus(
-        status: status,
-        selectedProfile: profile,
-      ),
+    final guide = _resolveGuide(
+      status: status,
       selectedProfile: profile,
       activeProfile: profile,
-      status: status,
       posture: posture,
-      runtimeSession: session,
-      operatorAdvice: advice,
-      readiness: null,
+      session: session,
+      troubleshootingAvailable: true,
     );
 
     expect(guide.primaryAction, DashboardGuideAction.openAdvanced);
@@ -151,49 +258,37 @@ void main() {
       guide.operatorTitle,
       'Recommended right now: capture a support snapshot first',
     );
-    expect(guide.operatorBody, contains('preserve the current runtime evidence'));
-    expect(guide.actionSafety.state,
-        RuntimeActionSafetyState.captureSnapshotFirst);
+    expect(
+        guide.operatorBody, contains('preserve the current runtime evidence'));
+    expect(
+      guide.actionSafety.state,
+      RuntimeActionSafetyState.captureSnapshotFirst,
+    );
   });
 
-  test('disconnecting stop-pending runtime uses exit confirmation headline', () {
+  test('disconnecting stop-pending runtime uses exit confirmation headline',
+      () {
     final profile = _profile();
-    final status = ClientConnectionStatus(
+    final status = _status(
       phase: ClientConnectionPhase.disconnecting,
       message: 'Disconnecting current session...',
-      updatedAt: DateTime.now(),
       activeProfileId: profile.id,
     );
-    final session = ControllerRuntimeSession(
+    final session = _session(
       isRunning: true,
-      updatedAt: DateTime.now().subtract(const Duration(seconds: 10)),
       phase: ControllerRuntimePhase.alive,
       stopRequested: true,
-      stopRequestedAt: DateTime.now().subtract(const Duration(seconds: 5)),
+      age: const Duration(seconds: 10),
     );
-    final posture = describeRuntimePosture(
-      runtimeMode: 'real-runtime-boundary',
-      backendKind: 'real-shell-controller',
-    );
-    final advice = RuntimeOperatorAdvice.resolve(
-      status: status,
-      session: session,
-      posture: posture,
-      troubleshootingAvailable: true,
-    );
+    final posture = _posture();
 
-    final guide = DashboardGuidePolicy.resolve(
-      lifecycle: ConnectionLifecycleViewModel.fromStatus(
-        status: status,
-        selectedProfile: profile,
-      ),
+    final guide = _resolveGuide(
+      status: status,
       selectedProfile: profile,
       activeProfile: profile,
-      status: status,
       posture: posture,
-      runtimeSession: session,
-      operatorAdvice: advice,
-      readiness: null,
+      session: session,
+      troubleshootingAvailable: true,
     );
 
     expect(guide.title, 'Exit confirmation pending');
@@ -203,9 +298,129 @@ void main() {
       guide.operatorTitle,
       'Recommended right now: capture a support snapshot first',
     );
-    expect(guide.operatorBody, contains('capture the current support evidence'));
-    expect(guide.actionSafety.state,
-        RuntimeActionSafetyState.waitForExitConfirmation);
+    expect(
+        guide.operatorBody, contains('capture the current support evidence'));
+    expect(
+      guide.actionSafety.state,
+      RuntimeActionSafetyState.waitForExitConfirmation,
+    );
     expect(guide.actionSafety.recommendsSnapshotFirst, isTrue);
+  });
+
+  test('error config keeps same action label and detail as profile next action',
+      () {
+    final profile = _profile();
+    final status = _status(
+      phase: ClientConnectionPhase.error,
+      message: 'Config invalid.',
+      activeProfileId: profile.id,
+      errorCode: 'CONFIG_INVALID',
+      failureFamilyHint: 'config',
+    );
+    final session = _session();
+    final posture = _posture();
+
+    final guide = _resolveGuide(
+      status: status,
+      selectedProfile: profile,
+      activeProfile: profile,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: true,
+    );
+
+    final profileDecision = _resolveProfileDecision(
+      status: status,
+      readiness: null,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: true,
+      settingsAvailable: true,
+    );
+
+    expect(_mapGuidePrimaryAction(guide.primaryAction), profileDecision.type);
+    expect(guide.primaryLabel, profileDecision.label);
+    expect(guide.body, profileDecision.detail);
+  });
+
+  test(
+      'error unknown without troubleshooting keeps same fallback action as profile',
+      () {
+    final profile = _profile();
+    final status = _status(
+      phase: ClientConnectionPhase.error,
+      message: 'Unknown runtime failure.',
+      activeProfileId: profile.id,
+      errorCode: 'UNCLASSIFIED_RUNTIME_FAILURE',
+      failureFamilyHint: 'unknown',
+    );
+    final session = _session();
+    final posture = _posture();
+
+    final guide = _resolveGuide(
+      status: status,
+      selectedProfile: profile,
+      activeProfile: profile,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: false,
+    );
+
+    final profileDecision = _resolveProfileDecision(
+      status: status,
+      readiness: null,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: false,
+      settingsAvailable: true,
+    );
+
+    expect(_mapGuidePrimaryAction(guide.primaryAction), profileDecision.type);
+    expect(guide.primaryLabel, profileDecision.label);
+    expect(guide.body, profileDecision.detail);
+  });
+
+  test(
+      'blocked readiness openSettings recommendation falls back consistently when settings are unavailable',
+      () {
+    final profile = _profile();
+    final status = _status(
+      phase: ClientConnectionPhase.disconnected,
+      message: 'Disconnected',
+      activeProfileId: profile.id,
+    );
+    final session = _session();
+    final posture = _posture();
+    final readiness = _blockedReadiness(
+      domain: ReadinessDomain.secureStorage,
+      summary: 'secure storage unavailable',
+      detail: 'Secure storage provider is unavailable.',
+      action: ReadinessAction.openSettings,
+      actionLabel: 'Open Settings',
+    );
+
+    final guide = _resolveGuide(
+      status: status,
+      selectedProfile: profile,
+      activeProfile: null,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: true,
+      settingsAvailable: false,
+      readiness: readiness,
+    );
+
+    final profileDecision = _resolveProfileDecision(
+      status: status,
+      readiness: readiness,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: true,
+      settingsAvailable: false,
+    );
+
+    expect(_mapGuidePrimaryAction(guide.primaryAction), profileDecision.type);
+    expect(guide.primaryLabel, profileDecision.label);
+    expect(guide.body, profileDecision.detail);
   });
 }


### PR DESCRIPTION
## Summary
- add `RecoveryLadderPolicy` as a single decision hub with unified input/output contract
- route `ProfileNextActionPolicy` through the shared ladder policy to keep labels/details consistent
- route `DashboardGuidePolicy` through the same ladder policy and keep runtime safety/operator overlays intact
- add/expand tests to verify cross-surface parity and recovery-ladder branches (`blocked/error/disconnecting/stale/residual`)

## Verification
- `flutter test test/features/profiles/presentation/next_action_policy_test.dart test/features/controller/domain/recovery_ladder_policy_test.dart test/features/dashboard/presentation/dashboard_guide_policy_test.dart test/features/controller/domain/runtime_operator_advice_test.dart test/features/controller/domain/runtime_action_safety_test.dart test/features/controller/domain/runtime_action_matrix_test.dart test/features/profiles/presentation/profiles_page_action_gating_test.dart`
- `flutter analyze`

Closes #35
