### PR TITLE
test(iter2): cover Top5 failure-family recovery ladder parity

### DIFF
--- a/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart
@@ -343,6 +343,185 @@ void main() {
     expect(guide.body, profileDecision.detail);
   });
 
+  test('error launch keeps same retry action as profile next action', () {
+    final profile = _profile();
+    final status = _status(
+      phase: ClientConnectionPhase.error,
+      message: 'Runtime launch failed before session ready.',
+      activeProfileId: profile.id,
+      errorCode: 'RUNTIME_LAUNCH_FAILED',
+      failureFamilyHint: 'launch',
+    );
+    final session = _session(
+      isRunning: false,
+      phase: ControllerRuntimePhase.failed,
+      lastExitCode: 65,
+    );
+    final posture = _posture();
+
+    final guide = _resolveGuide(
+      status: status,
+      selectedProfile: profile,
+      activeProfile: profile,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: true,
+    );
+
+    final profileDecision = _resolveProfileDecision(
+      status: status,
+      readiness: null,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: true,
+      settingsAvailable: true,
+    );
+
+    expect(_mapGuidePrimaryAction(guide.primaryAction), profileDecision.type);
+    expect(guide.primaryLabel, profileDecision.label);
+    expect(guide.body, profileDecision.detail);
+  });
+
+  test('error user_input keeps same password action as profile next action',
+      () {
+    final profile = _profile(hasStoredPassword: false);
+    final status = _status(
+      phase: ClientConnectionPhase.error,
+      message: 'Trojan password missing.',
+      activeProfileId: profile.id,
+      errorCode: 'MISSING_TROJAN_PASSWORD',
+      failureFamilyHint: 'user_input',
+    );
+    final session = _session();
+    final posture = _posture();
+
+    final guide = _resolveGuide(
+      status: status,
+      selectedProfile: profile,
+      activeProfile: profile,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: true,
+    );
+
+    final profileDecision = _resolveProfileDecision(
+      status: status,
+      readiness: null,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: true,
+      settingsAvailable: true,
+    );
+
+    expect(_mapGuidePrimaryAction(guide.primaryAction), profileDecision.type);
+    expect(guide.primaryLabel, profileDecision.label);
+    expect(guide.body, profileDecision.detail);
+  });
+
+  test('error environment keeps same settings primary as profile next action',
+      () {
+    final profile = _profile();
+    final status = _status(
+      phase: ClientConnectionPhase.error,
+      message: 'Runtime environment check failed.',
+      activeProfileId: profile.id,
+      errorCode: 'RUNTIME_BINARY_MISSING',
+      failureFamilyHint: 'environment',
+    );
+    final session = _session();
+    final posture = _posture();
+
+    final guide = _resolveGuide(
+      status: status,
+      selectedProfile: profile,
+      activeProfile: profile,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: true,
+      settingsAvailable: true,
+    );
+
+    final profileDecision = _resolveProfileDecision(
+      status: status,
+      readiness: null,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: true,
+      settingsAvailable: true,
+    );
+
+    expect(_mapGuidePrimaryAction(guide.primaryAction), profileDecision.type);
+    expect(guide.primaryLabel, profileDecision.label);
+    expect(guide.body, profileDecision.detail);
+  });
+
+  test(
+      'error environment without settings uses profile fallback when session needs no evidence revalidation',
+      () {
+    final profile = _profile();
+    final status = _status(
+      phase: ClientConnectionPhase.error,
+      message: 'Runtime environment check failed.',
+      activeProfileId: profile.id,
+      errorCode: 'RUNTIME_BINARY_MISSING',
+      failureFamilyHint: 'environment',
+    );
+    final session = _session();
+    final posture = _posture();
+
+    final guide = _resolveGuide(
+      status: status,
+      selectedProfile: profile,
+      activeProfile: profile,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: true,
+      settingsAvailable: false,
+    );
+
+    expect(_mapGuidePrimaryAction(guide.primaryAction),
+        ProfileNextActionType.openProfiles);
+    expect(guide.primaryLabel, 'Open Profiles');
+  });
+
+  test(
+      'error export_os keeps label/detail parity while dashboard routes to advanced',
+      () {
+    final profile = _profile();
+    final status = _status(
+      phase: ClientConnectionPhase.error,
+      message: 'Diagnostics export failed: permission denied.',
+      activeProfileId: profile.id,
+      errorCode: 'DIAGNOSTICS_EXPORT_FAILED',
+      failureFamilyHint: 'export_os',
+    );
+    final session = _session();
+    final posture = _posture();
+
+    final guide = _resolveGuide(
+      status: status,
+      selectedProfile: profile,
+      activeProfile: profile,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: true,
+      settingsAvailable: true,
+    );
+
+    final profileDecision = _resolveProfileDecision(
+      status: status,
+      readiness: null,
+      posture: posture,
+      session: session,
+      troubleshootingAvailable: true,
+      settingsAvailable: true,
+    );
+
+    expect(guide.primaryAction, DashboardGuideAction.openAdvanced);
+    expect(guide.primaryLabel, profileDecision.label);
+    expect(guide.body, profileDecision.detail);
+  });
+
   test(
       'error unknown without troubleshooting keeps same fallback action as profile',
       () {

--- a/client/test/features/profiles/presentation/next_action_policy_test.dart
+++ b/client/test/features/profiles/presentation/next_action_policy_test.dart
@@ -89,6 +89,130 @@ void main() {
 
       expect(decision.type, ProfileNextActionType.exportSupportBundle);
       expect(decision.label, 'Export Support Bundle');
+      expect(decision.detail, contains('permissions'));
+    });
+
+    test('maps launch failure family to retry action', () {
+      final decision = ProfileNextActionPolicy.resolve(
+        status: ClientConnectionStatus(
+          phase: ClientConnectionPhase.error,
+          message: 'Runtime launch failed before session ready.',
+          updatedAt: DateTime.parse('2026-04-20T01:00:00.000Z'),
+          errorCode: 'RUNTIME_LAUNCH_FAILED',
+          failureFamilyHint: 'launch',
+        ),
+        readinessReport: null,
+        failureFamily: FailureFamily.launch,
+        troubleshootingAvailable: true,
+        settingsAvailable: true,
+      );
+
+      expect(decision.type, ProfileNextActionType.retryConnect);
+      expect(decision.label, 'Retry Connect Test');
+    });
+
+    test('maps config failure family to open profiles action', () {
+      final decision = ProfileNextActionPolicy.resolve(
+        status: ClientConnectionStatus(
+          phase: ClientConnectionPhase.error,
+          message: 'Invalid profile field: server port out of range.',
+          updatedAt: DateTime.parse('2026-04-20T01:00:00.000Z'),
+          errorCode: 'CONFIG_INVALID',
+          failureFamilyHint: 'config',
+        ),
+        readinessReport: null,
+        failureFamily: FailureFamily.config,
+        troubleshootingAvailable: true,
+        settingsAvailable: true,
+      );
+
+      expect(decision.type, ProfileNextActionType.openProfiles);
+      expect(decision.label, 'Open Profiles');
+      expect(decision.detail, contains('config'));
+    });
+
+    test('maps environment failure family to settings as primary', () {
+      final decision = ProfileNextActionPolicy.resolve(
+        status: ClientConnectionStatus(
+          phase: ClientConnectionPhase.error,
+          message: 'Runtime environment check failed.',
+          updatedAt: DateTime.parse('2026-04-20T01:00:00.000Z'),
+          errorCode: 'RUNTIME_BINARY_MISSING',
+          failureFamilyHint: 'environment',
+        ),
+        readinessReport: null,
+        failureFamily: FailureFamily.environment,
+        troubleshootingAvailable: true,
+        settingsAvailable: true,
+      );
+
+      expect(decision.type, ProfileNextActionType.openSettings);
+      expect(decision.label, 'Open Settings');
+      expect(decision.detail, contains('environment'));
+    });
+
+    test(
+        'maps environment failure family to troubleshooting fallback when settings unavailable',
+        () {
+      final decision = ProfileNextActionPolicy.resolve(
+        status: ClientConnectionStatus(
+          phase: ClientConnectionPhase.error,
+          message: 'Runtime environment check failed.',
+          updatedAt: DateTime.parse('2026-04-20T01:00:00.000Z'),
+          errorCode: 'RUNTIME_BINARY_MISSING',
+          failureFamilyHint: 'environment',
+        ),
+        readinessReport: null,
+        failureFamily: FailureFamily.environment,
+        troubleshootingAvailable: true,
+        settingsAvailable: false,
+      );
+
+      expect(decision.type, ProfileNextActionType.openTroubleshooting);
+      expect(decision.label, 'Open Troubleshooting');
+    });
+
+    test('unknown failure defaults to evidence-preserving troubleshooting path',
+        () {
+      final decision = ProfileNextActionPolicy.resolve(
+        status: ClientConnectionStatus(
+          phase: ClientConnectionPhase.error,
+          message: 'Unexpected runtime handshake mismatch.',
+          updatedAt: DateTime.parse('2026-04-20T01:00:00.000Z'),
+          errorCode: 'UNCLASSIFIED_RUNTIME_FAILURE',
+          failureFamilyHint: 'unknown',
+        ),
+        readinessReport: null,
+        failureFamily: FailureFamily.unknown,
+        troubleshootingAvailable: true,
+        settingsAvailable: true,
+      );
+
+      expect(decision.type, ProfileNextActionType.openTroubleshooting);
+      expect(decision.label, 'Open Troubleshooting');
+      expect(decision.detail, contains('capture runtime evidence'));
+    });
+
+    test(
+        'unknown failure falls back to profiles when troubleshooting unavailable',
+        () {
+      final decision = ProfileNextActionPolicy.resolve(
+        status: ClientConnectionStatus(
+          phase: ClientConnectionPhase.error,
+          message: 'Unexpected runtime handshake mismatch.',
+          updatedAt: DateTime.parse('2026-04-20T01:00:00.000Z'),
+          errorCode: 'UNCLASSIFIED_RUNTIME_FAILURE',
+          failureFamilyHint: 'unknown',
+        ),
+        readinessReport: null,
+        failureFamily: FailureFamily.unknown,
+        troubleshootingAvailable: false,
+        settingsAvailable: true,
+      );
+
+      expect(decision.type, ProfileNextActionType.openProfiles);
+      expect(decision.label, 'Open Profiles');
+      expect(decision.detail, contains('capture runtime evidence'));
     });
 
     test('maps user_input failure family to set password action', () {


### PR DESCRIPTION
## Summary
- expand `ProfileNextActionPolicy` test coverage for Top5 failure families: `user_input/config/connect/environment/export_os`
- add explicit unknown-family assertions to enforce evidence-preserving troubleshooting-first default
- expand `DashboardGuidePolicy` parity tests to ensure the same failure-family intent is reflected cross-surface
- codify environment/export edge-path expectations for settings/troubleshooting fallback behavior

## Verification
- `flutter test test/features/profiles/presentation/next_action_policy_test.dart test/features/dashboard/presentation/dashboard_guide_policy_test.dart`
- `flutter analyze`

Closes #36
