### PR TITLE
fix(iter2): enforce evidence-first recovery for stop-pending/stale/residual

### DIFF
--- a/client/lib/features/profiles/presentation/profile_connection_action_policy.dart
+++ b/client/lib/features/profiles/presentation/profile_connection_action_policy.dart
@@ -108,10 +108,10 @@ class ProfileConnectionActionPolicy {
           canToggleConnection: false,
           buttonEnabled: actionMatrix.primaryActionContract ==
               RuntimePrimaryActionContract.preferTroubleshooting,
-          buttonLabel:
-              operatorAdvice.kind == RuntimeOperatorAdviceKind.revalidateInTroubleshooting
-                  ? 'Revalidate in Troubleshooting'
-                  : (operatorAdvice.primaryLabel ?? 'Open Troubleshooting'),
+          buttonLabel: operatorAdvice.kind ==
+                  RuntimeOperatorAdviceKind.revalidateInTroubleshooting
+              ? 'Revalidate in Troubleshooting'
+              : (operatorAdvice.primaryLabel ?? 'Open Troubleshooting'),
           statusHint: operatorAdvice.message ??
               '${runtimeSession.truthNote} ${runtimeSession.recoveryGuidance}',
           primaryAction: actionMatrix.preferredOperatorAction ==
@@ -162,6 +162,42 @@ class ProfileConnectionActionPolicy {
                 RuntimePreferredOperatorAction.openTroubleshooting
             ? ProfileConnectionPrimaryAction.openTroubleshooting
             : ProfileConnectionPrimaryAction.none,
+        actionableSessionTruth: actionableSessionTruth,
+        actionSafety: actionSafety,
+      );
+    }
+
+    if (active && status.phase == ClientConnectionPhase.error) {
+      final shouldBlockRetryShortcut =
+          actionMatrix.retryContract == RuntimeRetryContract.blockShortcut;
+      if (shouldBlockRetryShortcut) {
+        final canOpenTroubleshooting = actionMatrix.primaryActionContract ==
+                RuntimePrimaryActionContract.preferTroubleshooting &&
+            actionMatrix.preferredOperatorAction ==
+                RuntimePreferredOperatorAction.openTroubleshooting;
+
+        return ProfileConnectionActionPolicy(
+          canToggleConnection: false,
+          buttonEnabled: canOpenTroubleshooting,
+          buttonLabel: canOpenTroubleshooting
+              ? (operatorAdvice.primaryLabel ?? 'Open Troubleshooting')
+              : 'Retry blocked: capture evidence',
+          statusHint: operatorAdvice.message ??
+              'Capture runtime evidence before retrying. Immediate retry is blocked for the current session truth.',
+          primaryAction: canOpenTroubleshooting
+              ? ProfileConnectionPrimaryAction.openTroubleshooting
+              : ProfileConnectionPrimaryAction.none,
+          actionableSessionTruth: actionableSessionTruth,
+          actionSafety: actionSafety,
+        );
+      }
+
+      return ProfileConnectionActionPolicy(
+        canToggleConnection: true,
+        buttonEnabled: true,
+        buttonLabel: runtimePosture.qualifyAction('Retry Connect Test'),
+        statusHint: status.message,
+        primaryAction: ProfileConnectionPrimaryAction.connect,
         actionableSessionTruth: actionableSessionTruth,
         actionSafety: actionSafety,
       );

--- a/client/test/features/controller/domain/runtime_action_safety_test.dart
+++ b/client/test/features/controller/domain/runtime_action_safety_test.dart
@@ -5,7 +5,9 @@ import 'package:trojan_pro_client/features/controller/domain/runtime_action_safe
 import 'package:trojan_pro_client/features/controller/domain/runtime_posture.dart';
 
 void main() {
-  test('disconnecting stop-pending runtime blocks retry until exit confirmation', () {
+  test(
+      'disconnecting stop-pending runtime blocks retry until exit confirmation',
+      () {
     final safety = RuntimeActionSafety.resolve(
       status: ClientConnectionStatus(
         phase: ClientConnectionPhase.disconnecting,
@@ -29,9 +31,11 @@ void main() {
     expect(safety.state, RuntimeActionSafetyState.waitForExitConfirmation);
     expect(safety.blocksRetry, isTrue);
     expect(safety.recommendsSnapshotFirst, isTrue);
+    expect(safety.detail, contains('Capture support evidence first'));
   });
 
-  test('stale connected runtime requires revalidation before state changes', () {
+  test('stale connected runtime requires revalidation before state changes',
+      () {
     final safety = RuntimeActionSafety.resolve(
       status: ClientConnectionStatus(
         phase: ClientConnectionPhase.connected,
@@ -53,5 +57,55 @@ void main() {
     expect(safety.state, RuntimeActionSafetyState.revalidateFirst);
     expect(safety.blocksRetry, isTrue);
     expect(safety.recommendsSnapshotFirst, isFalse);
+  });
+
+  test('error residual runtime enforces evidence capture before retry', () {
+    final safety = RuntimeActionSafety.resolve(
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.error,
+        message: 'Runtime session exited unexpectedly.',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: false,
+        updatedAt: DateTime.now().subtract(const Duration(seconds: 45)),
+        phase: ControllerRuntimePhase.failed,
+        lastExitCode: 13,
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+    );
+
+    expect(safety.state, RuntimeActionSafetyState.captureSnapshotFirst);
+    expect(safety.blocksRetry, isTrue);
+    expect(safety.recommendsSnapshotFirst, isTrue);
+    expect(safety.detail, contains('Preserve the current runtime evidence'));
+  });
+
+  test('connecting with stale session truth still blocks retry shortcut', () {
+    final safety = RuntimeActionSafety.resolve(
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.connecting,
+        message: 'Connecting current profile...',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: DateTime.now().subtract(const Duration(minutes: 4)),
+        phase: ControllerRuntimePhase.alive,
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+    );
+
+    expect(safety.state, RuntimeActionSafetyState.captureSnapshotFirst);
+    expect(safety.blocksRetry, isTrue);
+    expect(safety.recommendsSnapshotFirst, isTrue);
   });
 }

--- a/client/test/features/controller/domain/runtime_operator_advice_test.dart
+++ b/client/test/features/controller/domain/runtime_operator_advice_test.dart
@@ -30,7 +30,9 @@ void main() {
     expect(advice.primaryEnabled, isTrue);
   });
 
-  test('disconnecting stop-pending runtime recommends waiting for exit confirmation', () {
+  test(
+      'disconnecting stop-pending runtime recommends waiting for exit confirmation',
+      () {
     final advice = RuntimeOperatorAdvice.resolve(
       status: ClientConnectionStatus(
         phase: ClientConnectionPhase.disconnecting,
@@ -55,6 +57,61 @@ void main() {
     expect(advice.kind, RuntimeOperatorAdviceKind.waitForExitConfirmation);
     expect(advice.headline, 'Exit confirmation pending');
     expect(advice.message, contains('fully closed yet'));
+  });
+
+  test(
+      'error residual session recommends troubleshooting evidence-first guidance',
+      () {
+    final advice = RuntimeOperatorAdvice.resolve(
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.error,
+        message: 'Runtime process exited unexpectedly.',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: false,
+        updatedAt: DateTime.now().subtract(const Duration(seconds: 40)),
+        phase: ControllerRuntimePhase.failed,
+        lastExitCode: 7,
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+      troubleshootingAvailable: true,
+    );
+
+    expect(advice.kind, RuntimeOperatorAdviceKind.revalidateInTroubleshooting);
+    expect(advice.primaryEnabled, isTrue);
+    expect(advice.primaryLabel, 'Open Troubleshooting');
+    expect(advice.message, contains('leftover session state'));
+  });
+
+  test('error stale running session still advises troubleshooting before retry',
+      () {
+    final advice = RuntimeOperatorAdvice.resolve(
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.error,
+        message: 'Handshake timed out.',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      session: ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: DateTime.now().subtract(const Duration(minutes: 5)),
+        phase: ControllerRuntimePhase.alive,
+      ),
+      posture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+      troubleshootingAvailable: true,
+    );
+
+    expect(advice.kind, RuntimeOperatorAdviceKind.revalidateInTroubleshooting);
+    expect(advice.primaryEnabled, isTrue);
+    expect(advice.message, contains('Open Troubleshooting'));
   });
 
   test('stub residual state does not create actionable advice by itself', () {

--- a/client/test/features/profiles/presentation/profile_connection_action_policy_test.dart
+++ b/client/test/features/profiles/presentation/profile_connection_action_policy_test.dart
@@ -37,7 +37,8 @@ void main() {
         ProfileConnectionPrimaryAction.openTroubleshooting);
   });
 
-  test('disconnecting session surfaces recovery guidance instead of idle hint', () {
+  test('disconnecting session surfaces recovery guidance instead of idle hint',
+      () {
     final policy = ProfileConnectionActionPolicy.resolve(
       hasStoredPassword: true,
       active: true,
@@ -71,6 +72,41 @@ void main() {
     expect(policy.actionSafety.state,
         RuntimeActionSafetyState.waitForExitConfirmation);
     expect(policy.actionSafety.recommendsSnapshotFirst, isTrue);
+  });
+
+  test('error residual session keeps troubleshooting evidence-first CTA', () {
+    final policy = ProfileConnectionActionPolicy.resolve(
+      hasStoredPassword: true,
+      active: true,
+      status: ClientConnectionStatus(
+        phase: ClientConnectionPhase.error,
+        message: 'Runtime exited unexpectedly after connect failure.',
+        updatedAt: DateTime.now(),
+        activeProfileId: 'sample-hk-1',
+      ),
+      runtimePosture: describeRuntimePosture(
+        runtimeMode: 'real-runtime-boundary',
+        backendKind: 'real-shell-controller',
+      ),
+      runtimeSession: ControllerRuntimeSession(
+        isRunning: false,
+        updatedAt: DateTime.now().subtract(const Duration(seconds: 50)),
+        phase: ControllerRuntimePhase.failed,
+        lastExitCode: 13,
+      ),
+      readinessReport: null,
+      hasConnectedElsewhere: false,
+      onOpenAdvancedAvailable: true,
+    );
+
+    expect(policy.buttonEnabled, isTrue);
+    expect(policy.buttonLabel, 'Open Troubleshooting');
+    expect(policy.primaryAction,
+        ProfileConnectionPrimaryAction.openTroubleshooting);
+    expect(policy.statusHint, contains('leftover session state'));
+    expect(policy.actionSafety.state,
+        RuntimeActionSafetyState.captureSnapshotFirst);
+    expect(policy.actionSafety.blocksRetry, isTrue);
   });
 
   test('readiness blocked connect returns blocked policy', () {


### PR DESCRIPTION
## Summary
- enforce evidence-first behavior for stop-pending / stale / residual runtime truth paths in profile connection CTA policy
- keep retry shortcut blocked when runtime safety marks `captureSnapshotFirst` / `waitForExitConfirmation`
- expand `runtime_action_safety` and `runtime_operator_advice` tests for stale/residual evidence-preservation assertions
- expand `profile_connection_action_policy` tests to ensure troubleshooting-first CTA on residual error sessions

## Verification
- `flutter test test/features/controller/domain/runtime_action_safety_test.dart test/features/controller/domain/runtime_operator_advice_test.dart test/features/profiles/presentation/profile_connection_action_policy_test.dart test/features/profiles/presentation/profiles_page_action_gating_test.dart`
- `flutter analyze`

Closes #37
