### PR TITLE
feat(client): close #38 readiness recommendation one-click closure

### DIFF
--- a/client/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/client/lib/features/dashboard/presentation/dashboard_page.dart
@@ -25,12 +25,14 @@ class DashboardPage extends StatefulWidget {
     this.onOpenProfiles,
     this.onOpenAdvanced,
     this.onOpenSettings,
+    this.onReadinessRecommendationTelemetry,
   });
 
   final ClientServiceRegistry services;
   final VoidCallback? onOpenProfiles;
   final VoidCallback? onOpenAdvanced;
   final VoidCallback? onOpenSettings;
+  final ValueChanged<Map<String, Object?>>? onReadinessRecommendationTelemetry;
 
   @override
   State<DashboardPage> createState() => _DashboardPageState();
@@ -91,11 +93,66 @@ class _DashboardPageState extends State<DashboardPage> {
     );
   }
 
-  VoidCallback? _actionHandlerFor(ReadinessAction action) {
-    return switch (action) {
+  ReadinessRecommendation _resolveRecommendation(
+    ReadinessRecommendation recommendation,
+  ) {
+    switch (recommendation.action) {
+      case ReadinessAction.openProfiles:
+        return recommendation;
+      case ReadinessAction.openTroubleshooting:
+        if (widget.onOpenAdvanced != null) {
+          return recommendation;
+        }
+        return ReadinessRecommendation(
+          action: ReadinessAction.openProfiles,
+          label: 'Open Profiles',
+          detail: recommendation.detail,
+          source: ReadinessRecommendationSource.fallback,
+          domain: recommendation.domain,
+          destination: 'profiles',
+          destinationAvailable: true,
+          fallbackReason: 'Troubleshooting page is unavailable in this surface.',
+        );
+      case ReadinessAction.openSettings:
+        if (widget.onOpenSettings != null) {
+          return recommendation;
+        }
+        return ReadinessRecommendation(
+          action: ReadinessAction.openProfiles,
+          label: 'Open Profiles',
+          detail: recommendation.detail,
+          source: ReadinessRecommendationSource.fallback,
+          domain: recommendation.domain,
+          destination: 'profiles',
+          destinationAvailable: true,
+          fallbackReason: 'Settings page is unavailable in this surface.',
+        );
+    }
+  }
+
+  VoidCallback? _actionHandlerFor(ReadinessRecommendation recommendation) {
+    final telemetry = widget.onReadinessRecommendationTelemetry;
+    final resolved = _resolveRecommendation(recommendation);
+    final actionHandler = switch (resolved.action) {
       ReadinessAction.openProfiles => widget.onOpenProfiles,
       ReadinessAction.openTroubleshooting => widget.onOpenAdvanced,
       ReadinessAction.openSettings => widget.onOpenSettings,
+    };
+    if (actionHandler == null) return null;
+
+    return () {
+      telemetry?.call(<String, Object?>{
+        'eventName': 'recovery_action_executed',
+        'action': resolved.actionId.name,
+        'source': resolved.source.name,
+        'domain': resolved.domain.name,
+        'destination': resolved.destination,
+        'destinationAvailable': resolved.destinationAvailable,
+        'outcome': 'acted',
+        if (resolved.fallbackReason != null)
+          'fallbackReason': resolved.fallbackReason,
+      });
+      actionHandler();
     };
   }
 
@@ -247,6 +304,10 @@ class _DashboardPageState extends State<DashboardPage> {
                     return const Text('Checking readiness…');
                   }
 
+                  final recommendation = report.recommendation == null
+                      ? null
+                      : _resolveRecommendation(report.recommendation!);
+
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
@@ -288,19 +349,34 @@ class _DashboardPageState extends State<DashboardPage> {
                           style: TextStyle(fontWeight: FontWeight.w600),
                         ),
                       ],
-                      if (report.recommendation != null) ...<Widget>[
+                      if (recommendation != null) ...<Widget>[
                         const SizedBox(height: 12),
                         Text(
-                          report.recommendation!.detail,
+                          recommendation.detail,
                           style: const TextStyle(fontWeight: FontWeight.w600),
                         ),
                         const SizedBox(height: 8),
                         FilledButton.icon(
                           onPressed:
-                              _actionHandlerFor(report.recommendation!.action),
+                              _actionHandlerFor(recommendation),
                           icon: const Icon(Icons.play_arrow),
-                          label: Text(report.recommendation!.label),
+                          label: Text(recommendation.label),
                         ),
+                        const SizedBox(height: 4),
+                        Text(
+                          'Destination: ${recommendation.destination}',
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                        Text(
+                          'Destination availability: ${recommendation.destinationAvailable ? 'reachable' : 'unavailable'}',
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                        if (recommendation.source ==
+                            ReadinessRecommendationSource.fallback)
+                          Text(
+                            'Fallback reason: ${recommendation.fallbackReason ?? 'Route unavailable in this surface.'}',
+                            style: const TextStyle(fontSize: 12),
+                          ),
                       ],
                       const SizedBox(height: 12),
                       Wrap(
@@ -562,7 +638,7 @@ class _NextStepGuide extends StatelessWidget {
           children: <Widget>[
             FilledButton(
               onPressed: () => _runAction(context, model.primaryAction),
-              child: Text(model.primaryLabel),
+              child: Text(_displayLabelFor(model.primaryAction, model.primaryLabel)),
             ),
             if (model.secondaryLabel != null)
               OutlinedButton(
@@ -573,6 +649,21 @@ class _NextStepGuide extends StatelessWidget {
         ),
       ],
     );
+  }
+
+  String _displayLabelFor(_GuideAction action, String fallbackLabel) {
+    final posture = describeRuntimePosture(
+      runtimeMode: services.controller.runtimeConfig.mode,
+      backendKind: services.controller.telemetry.backendKind,
+    );
+    return switch (action) {
+      _GuideAction.connectNow => posture.qualifyAction('Connect now'),
+      _GuideAction.retryNow => posture.qualifyAction('Retry now'),
+      _GuideAction.disconnectNow => 'Disconnect now',
+      _GuideAction.openProfiles => 'Open Profiles',
+      _GuideAction.openAdvanced => 'Open Troubleshooting',
+      _GuideAction.openSettings => 'Open Settings',
+    };
   }
 
   Future<void> _runAction(BuildContext context, _GuideAction? action) async {
@@ -598,9 +689,15 @@ class _NextStepGuide extends StatelessWidget {
             .buildReport(profileOverride: currentProfile);
         if (!context.mounted) return;
         if (readinessReport.overallLevel == ReadinessLevel.blocked) {
+          final recommendation = readinessReport.recommendation;
+          final nextStep = recommendation == null
+              ? null
+              : '${recommendation.label} (${recommendation.destination})';
+          final message = nextStep == null
+              ? 'Connect blocked: ${readinessReport.summary}'
+              : 'Connect blocked: ${readinessReport.summary} Next action: $nextStep';
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-                content: Text('Connect blocked: ${readinessReport.summary}')),
+            SnackBar(content: Text(message)),
           );
           return;
         }

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -348,40 +348,93 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
     );
   }
 
-  void _runReadinessAction(BuildContext context, ReadinessAction action) {
-    switch (action) {
+  ReadinessRecommendation _resolveRecommendation(
+    ReadinessRecommendation recommendation,
+  ) {
+    switch (recommendation.action) {
+      case ReadinessAction.openProfiles:
+        return recommendation;
+      case ReadinessAction.openTroubleshooting:
+        if (widget.onOpenAdvanced != null) {
+          return recommendation;
+        }
+        return ReadinessRecommendation(
+          action: ReadinessAction.openProfiles,
+          label: 'Open Profiles',
+          detail: recommendation.detail,
+          source: ReadinessRecommendationSource.fallback,
+          domain: recommendation.domain,
+          destination: 'profiles',
+          destinationAvailable: true,
+          fallbackReason: 'Troubleshooting page is unavailable in this surface.',
+        );
+      case ReadinessAction.openSettings:
+        if (widget.onOpenSettings != null) {
+          return recommendation;
+        }
+        return ReadinessRecommendation(
+          action: ReadinessAction.openProfiles,
+          label: 'Open Profiles',
+          detail: recommendation.detail,
+          source: ReadinessRecommendationSource.fallback,
+          domain: recommendation.domain,
+          destination: 'profiles',
+          destinationAvailable: true,
+          fallbackReason: 'Settings page is unavailable in this surface.',
+        );
+    }
+  }
+
+  void _runReadinessAction(
+    BuildContext context,
+    ReadinessRecommendation recommendation,
+  ) {
+    final resolved = _resolveRecommendation(recommendation);
+    _recordReadinessRecommendationTelemetry(
+      source: recommendation.source,
+      recommendation: resolved,
+      outcome: 'acted',
+    );
+
+    switch (resolved.action) {
       case ReadinessAction.openProfiles:
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
+          SnackBar(
             content: Text(
-                'You are already in Profiles. Update this profile directly.'),
+              resolved.fallbackReason ??
+                  'You are already in Profiles. Update this profile directly.',
+            ),
           ),
         );
         return;
       case ReadinessAction.openTroubleshooting:
-        if (widget.onOpenAdvanced != null) {
-          widget.onOpenAdvanced!.call(action);
-          return;
-        }
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content:
-                Text('Troubleshooting page is unavailable in this surface.'),
-          ),
-        );
+        widget.onOpenAdvanced!.call(resolved.action);
         return;
       case ReadinessAction.openSettings:
-        if (widget.onOpenSettings != null) {
-          widget.onOpenSettings!.call();
-          return;
-        }
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Settings page is unavailable in this surface.'),
-          ),
-        );
+        widget.onOpenSettings!.call();
         return;
     }
+  }
+
+  void _recordReadinessRecommendationTelemetry({
+    required ReadinessRecommendationSource source,
+    required ReadinessRecommendation recommendation,
+    required String outcome,
+  }) {
+    final fields = <String, Object?>{
+      'action': recommendation.actionId.name,
+      'source': source.name,
+      'domain': recommendation.domain.name,
+      'destination': recommendation.destination,
+      'destinationAvailable': recommendation.destinationAvailable,
+      'outcome': outcome,
+      if (recommendation.fallbackReason != null)
+        'fallbackReason': recommendation.fallbackReason,
+    };
+    debugPrint(
+      '[telemetry] readiness_recommendation '
+      '${fields.entries.map((entry) => '${entry.key}=${entry.value}').join(' ')}',
+    );
   }
 
   @override
@@ -591,15 +644,18 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
                   AsyncSnapshot<ReadinessReport> snapshot) {
                 final report =
                     snapshot.data ?? _readinessController.latestReport;
+                final recommendation = report?.recommendation;
+                final resolvedRecommendation = recommendation == null
+                    ? null
+                    : _resolveRecommendation(recommendation);
                 return _ProfileReadinessNotice(
                   report: report,
+                  recommendation: resolvedRecommendation,
                   showCachedRefreshHint: report?.isCachedSnapshot == true &&
                       snapshot.connectionState != ConnectionState.done,
-                  onRecommendation: nextActionDecision.isActionable
-                      ? () => _runNextActionDecision(context, nextActionDecision)
-                      : null,
-                  recommendationLabel:
-                      nextActionDecision.isActionable ? nextActionDecision.label : null,
+                  onRecommendation: resolvedRecommendation == null
+                      ? null
+                      : () => _runReadinessAction(context, resolvedRecommendation),
                 );
               },
             ),
@@ -745,13 +801,46 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
   ) {
     switch (decision.type) {
       case ProfileNextActionType.openProfiles:
-        _runReadinessAction(context, ReadinessAction.openProfiles);
+        _runReadinessAction(
+          context,
+          const ReadinessRecommendation(
+            action: ReadinessAction.openProfiles,
+            label: 'Open Profiles',
+            detail: 'Review and update profile details directly.',
+            source: ReadinessRecommendationSource.fallback,
+            domain: ReadinessDomain.profile,
+            destination: 'profiles',
+            destinationAvailable: true,
+          ),
+        );
         return;
       case ProfileNextActionType.openTroubleshooting:
-        _runReadinessAction(context, ReadinessAction.openTroubleshooting);
+        _runReadinessAction(
+          context,
+          const ReadinessRecommendation(
+            action: ReadinessAction.openTroubleshooting,
+            label: 'Open Troubleshooting',
+            detail: 'Open Troubleshooting to capture runtime evidence.',
+            source: ReadinessRecommendationSource.fallback,
+            domain: ReadinessDomain.runtimeBinary,
+            destination: 'advanced.troubleshooting',
+            destinationAvailable: true,
+          ),
+        );
         return;
       case ProfileNextActionType.openSettings:
-        _runReadinessAction(context, ReadinessAction.openSettings);
+        _runReadinessAction(
+          context,
+          const ReadinessRecommendation(
+            action: ReadinessAction.openSettings,
+            label: 'Open Settings',
+            detail: 'Open Settings to fix environment-level blockers.',
+            source: ReadinessRecommendationSource.fallback,
+            domain: ReadinessDomain.environment,
+            destination: 'settings',
+            destinationAvailable: true,
+          ),
+        );
         return;
       case ProfileNextActionType.retryConnect:
         ScaffoldMessenger.of(context).showSnackBar(
@@ -1112,14 +1201,14 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
 class _ProfileReadinessNotice extends StatelessWidget {
   const _ProfileReadinessNotice({
     required this.report,
+    this.recommendation,
     this.showCachedRefreshHint = false,
-    this.recommendationLabel,
     this.onRecommendation,
   });
 
   final ReadinessReport? report;
+  final ReadinessRecommendation? recommendation;
   final bool showCachedRefreshHint;
-  final String? recommendationLabel;
   final VoidCallback? onRecommendation;
 
   Color _tone(ReadinessLevel level) {
@@ -1145,9 +1234,8 @@ class _ProfileReadinessNotice extends StatelessWidget {
     }
 
     final tone = _tone(report!.overallLevel);
-    final recommendation = report!.recommendation;
-    final effectiveRecommendationLabel =
-        recommendationLabel ?? recommendation?.label;
+    final effectiveRecommendation = recommendation ?? report!.recommendation;
+    final effectiveRecommendationLabel = effectiveRecommendation?.label;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(12),
@@ -1185,12 +1273,29 @@ class _ProfileReadinessNotice extends StatelessWidget {
               'Recommended next step: $effectiveRecommendationLabel',
               style: const TextStyle(fontWeight: FontWeight.w600),
             ),
+            if (effectiveRecommendation != null) ...<Widget>[
+              const SizedBox(height: 4),
+              Text(
+                'Destination: ${effectiveRecommendation.destination}',
+                style: const TextStyle(fontSize: 12),
+              ),
+              Text(
+                'Destination availability: ${effectiveRecommendation.destinationAvailable ? 'reachable' : 'unavailable'}',
+                style: const TextStyle(fontSize: 12),
+              ),
+              if (effectiveRecommendation.source ==
+                  ReadinessRecommendationSource.fallback)
+                Text(
+                  'Fallback reason: ${effectiveRecommendation.fallbackReason ?? 'Route unavailable in this surface.'}',
+                  style: const TextStyle(fontSize: 12),
+                ),
+            ],
             if (onRecommendation != null) ...<Widget>[
               const SizedBox(height: 8),
               OutlinedButton.icon(
                 onPressed: onRecommendation,
                 icon: Icon(_recommendationIcon(
-                  recommendation?.action ?? ReadinessAction.openProfiles,
+                  effectiveRecommendation?.action ?? ReadinessAction.openProfiles,
                 )),
                 label: Text(effectiveRecommendationLabel),
               ),

--- a/client/lib/features/readiness/application/readiness_service.dart
+++ b/client/lib/features/readiness/application/readiness_service.dart
@@ -141,8 +141,8 @@ class ReadinessService {
         summary: status.userFacingSummary,
         detail:
             'Storage is session-only. Restarting the app may require re-entering passwords.',
-        action: ReadinessAction.openTroubleshooting,
-        actionLabel: 'Open Troubleshooting',
+        action: ReadinessAction.openSettings,
+        actionLabel: 'Open Settings',
       );
     }
 
@@ -152,8 +152,8 @@ class ReadinessService {
         level: ReadinessLevel.degraded,
         summary: status.userFacingSummary,
         detail: status.lastPrimaryError,
-        action: ReadinessAction.openTroubleshooting,
-        actionLabel: 'Open Troubleshooting',
+        action: ReadinessAction.openSettings,
+        actionLabel: 'Open Settings',
       );
     }
 

--- a/client/lib/features/readiness/domain/readiness_report.dart
+++ b/client/lib/features/readiness/domain/readiness_report.dart
@@ -29,6 +29,17 @@ enum ReadinessAction {
   openSettings,
 }
 
+enum ReadinessRecommendationSource {
+  report,
+  fallback,
+}
+
+enum ReadinessRecommendationActionId {
+  openProfiles,
+  openTroubleshooting,
+  openSettings,
+}
+
 enum ReadinessFreshness {
   fresh,
   aging,
@@ -97,17 +108,44 @@ class ReadinessRecommendation {
     required this.action,
     required this.label,
     required this.detail,
+    required this.source,
+    required this.domain,
+    required this.destination,
+    required this.destinationAvailable,
+    this.fallbackReason,
   });
 
   final ReadinessAction action;
   final String label;
   final String detail;
+  final ReadinessRecommendationSource source;
+  final ReadinessDomain domain;
+  final String destination;
+  final bool destinationAvailable;
+  final String? fallbackReason;
+
+  ReadinessRecommendationActionId get actionId {
+    return switch (action) {
+      ReadinessAction.openProfiles =>
+        ReadinessRecommendationActionId.openProfiles,
+      ReadinessAction.openTroubleshooting =>
+        ReadinessRecommendationActionId.openTroubleshooting,
+      ReadinessAction.openSettings =>
+        ReadinessRecommendationActionId.openSettings,
+    };
+  }
 
   Map<String, Object?> toJson() {
     return <String, Object?>{
       'action': action.name,
+      'actionId': actionId.name,
       'label': label,
       'detail': detail,
+      'source': source.name,
+      'domain': domain.name,
+      'destination': destination,
+      'destinationAvailable': destinationAvailable,
+      'fallbackReason': fallbackReason,
     };
   }
 }
@@ -185,10 +223,20 @@ class ReadinessReport {
     }
 
     final candidate = candidates.first;
+    final action = candidate.action!;
+    final destination = switch (action) {
+      ReadinessAction.openProfiles => 'profiles',
+      ReadinessAction.openTroubleshooting => 'advanced.troubleshooting',
+      ReadinessAction.openSettings => 'settings',
+    };
     return ReadinessRecommendation(
-      action: candidate.action!,
+      action: action,
       label: candidate.actionLabel!,
       detail: candidate.detail ?? candidate.summary,
+      source: ReadinessRecommendationSource.report,
+      domain: candidate.domain,
+      destination: destination,
+      destinationAvailable: true,
     );
   }
 

--- a/client/test/features/dashboard/presentation/dashboard_page_test.dart
+++ b/client/test/features/dashboard/presentation/dashboard_page_test.dart
@@ -142,6 +142,32 @@ class _TestLifecycleController extends ClientControllerApi {
   }
 }
 
+class _UnavailableRuntimeLifecycleController extends _TestLifecycleController {
+  @override
+  Future<ControllerRuntimeHealth> checkHealth() async {
+    return ControllerRuntimeHealth(
+      level: ControllerRuntimeHealthLevel.unavailable,
+      summary: 'runtime binary missing for this test',
+      updatedAt: DateTime.parse('2026-03-13T00:00:00.000Z'),
+    );
+  }
+
+  @override
+  ControllerRuntimeConfig get runtimeConfig => const ControllerRuntimeConfig(
+        mode: 'real-runtime-boundary',
+        endpointHint: 'local-controller://unavailable-runtime-test',
+        enableVerboseTelemetry: true,
+      );
+
+  @override
+  ControllerTelemetrySnapshot get telemetry => ControllerTelemetrySnapshot(
+        backendKind: 'real-shell-controller',
+        backendVersion: 'test-unavailable-runtime',
+        capabilities: const <String>['connect', 'disconnect', 'healthCheck'],
+        lastUpdatedAt: DateTime.parse('2026-03-13T00:00:00.000Z'),
+      );
+}
+
 class _RuntimeTrueLifecycleController extends _TestLifecycleController {
   @override
   ControllerTelemetrySnapshot get telemetry => ControllerTelemetrySnapshot(
@@ -347,7 +373,10 @@ void main() {
     final services = _buildServices();
 
     await _showDashboard(tester, services: services);
-    await tester.tap(find.text('Advanced runtime session'));
+    final advancedTile = find.text('Advanced runtime session');
+    await tester.ensureVisible(advancedTile);
+    await tester.pump();
+    await tester.tap(advancedTile);
     await tester.pumpAndSettle();
 
     expect(find.textContaining('Session Truth:'), findsOneWidget);
@@ -412,6 +441,36 @@ void main() {
       findsNothing,
     );
     expect(find.widgetWithText(FilledButton, 'Open Profiles'), findsWidgets);
+    expect(find.text('Destination: profiles'), findsWidgets);
+    expect(find.text('Destination availability: reachable'), findsWidgets);
+  });
+
+  testWidgets('dashboard shows fallback recommendation metadata when destination is unavailable',
+      (WidgetTester tester) async {
+    final services = _buildServices(
+      controller: _UnavailableRuntimeLifecycleController(),
+    );
+    final profile = services.profileStore.selectedProfile!;
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: profile.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      profile.copyWith(hasStoredPassword: true),
+    );
+
+    await _showDashboard(tester, services: services);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Connect blocked'), findsWidgets);
+    expect(find.widgetWithText(FilledButton, 'Open Profiles'), findsWidgets);
+    expect(find.text('Destination: profiles'), findsWidgets);
+    expect(find.text('Destination availability: reachable'), findsWidgets);
+    expect(
+      find.text(
+          'Fallback reason: Troubleshooting page is unavailable in this surface.'),
+      findsWidgets,
+    );
   });
 
   testWidgets(

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -26,6 +26,7 @@ import 'package:trojan_pro_client/platform/services/memory_diagnostics_file_expo
 import 'package:trojan_pro_client/platform/services/memory_local_state_store.dart';
 import 'package:trojan_pro_client/platform/services/service_registry.dart';
 import 'package:trojan_pro_client/platform/secure_storage/memory_secure_storage.dart';
+import 'package:trojan_pro_client/platform/secure_storage/secure_storage.dart';
 
 Future<void> _setDesktopSurface(WidgetTester tester) async {
   await tester.binding.setSurfaceSize(const Size(1800, 1600));
@@ -70,6 +71,57 @@ class _UnavailableRuntimeController extends FakeClientController {
       summary: 'runtime binary missing for this test',
       updatedAt: DateTime.parse('2026-03-20T00:00:00.000Z'),
     );
+  }
+
+  @override
+  ControllerRuntimeConfig get runtimeConfig => const ControllerRuntimeConfig(
+        mode: 'real-runtime-boundary',
+        endpointHint: 'local-controller://unavailable-runtime-test',
+        enableVerboseTelemetry: true,
+      );
+
+  @override
+  ControllerTelemetrySnapshot get telemetry => ControllerTelemetrySnapshot(
+        backendKind: 'real-shell-controller',
+        backendVersion: 'test-unavailable-runtime',
+        capabilities: const <String>[
+          'connect',
+          'disconnect',
+          'healthCheck',
+        ],
+        lastUpdatedAt: DateTime.now(),
+      );
+}
+
+class _PersistentSecureStorage extends MemorySecureStorage {
+  final Map<String, String> _backingStore = <String, String>{};
+
+  @override
+  SecureStorageStatus get status => const SecureStorageStatus(
+        backendName: 'keychain',
+        activeBackendName: 'keychain',
+        isSecure: true,
+        isPersistent: true,
+      );
+
+  @override
+  Future<void> writeSecret(String key, String value) async {
+    _backingStore[key] = value;
+  }
+
+  @override
+  Future<String?> readSecret(String key) async {
+    return _backingStore[key];
+  }
+
+  @override
+  Future<void> deleteSecret(String key) async {
+    _backingStore.remove(key);
+  }
+
+  @override
+  Future<List<String>> listKeys() async {
+    return _backingStore.keys.toList()..sort();
   }
 }
 
@@ -149,9 +201,10 @@ class _SafeModeController extends FakeClientController {
 ClientServiceRegistry _buildServices({
   ClientControllerApi? controllerOverride,
   LocalStateStore? localStateOverride,
+  MemorySecureStorage? secureStorageOverride,
 }) {
   final localState = localStateOverride ?? MemoryLocalStateStore();
-  final secureStorage = MemorySecureStorage();
+  final secureStorage = secureStorageOverride ?? MemorySecureStorage();
   final diagnosticsExporter = MemoryDiagnosticsFileExporter();
   final profileStore = ProfileStore.withSampleProfiles(
     localStateStore: localState,
@@ -559,6 +612,8 @@ void main() {
 
     expect(find.textContaining('Recommended next step: Open Troubleshooting'),
         findsOneWidget);
+    expect(find.text('Destination: advanced.troubleshooting'), findsOneWidget);
+    expect(find.text('Destination availability: reachable'), findsOneWidget);
 
     final troubleshootingButtons = find.widgetWithText(
       OutlinedButton,
@@ -570,6 +625,67 @@ void main() {
     await tester.pump();
 
     expect(openedAdvanced, isTrue);
+  });
+
+  testWidgets('readiness recommendation falls back to profiles when settings route is unavailable',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    final services = _buildServices(
+      controllerOverride: _UnavailableRuntimeController(),
+      secureStorageOverride: _PersistentSecureStorage(),
+    );
+    final selected = services.profileStore.selectedProfile!;
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: selected.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      selected.copyWith(hasStoredPassword: true),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ProfilesPage(
+            services: services,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final nextStepText = tester
+        .widgetList<Text>(find.byType(Text))
+        .map((widget) => widget.data)
+        .whereType<String>()
+        .where((value) => value.contains('Recommended next step:'))
+        .toList();
+    expect(
+      nextStepText,
+      contains('Recommended next step: Open Profiles'),
+      reason:
+          'Settings route is unavailable in this surface, so recommendation must fall back to profiles.',
+    );
+    expect(find.text('Destination: profiles'), findsOneWidget);
+    expect(find.text('Destination availability: reachable'), findsOneWidget);
+    expect(
+      find.textContaining(
+          'Fallback reason: Troubleshooting page is unavailable in this surface.'),
+      findsOneWidget,
+      reason:
+          'Environment recommendation falls back from troubleshooting when advanced route is unavailable.',
+    );
+
+    await tester.ensureVisible(find.text('Open Profiles').last);
+    await tester.tap(find.text('Open Profiles').last);
+    await tester.pump();
+
+    expect(
+      find.text('Troubleshooting page is unavailable in this surface.'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('stale connected profile steers primary CTA to troubleshooting',

--- a/client/test/features/readiness/application/readiness_service_test.dart
+++ b/client/test/features/readiness/application/readiness_service_test.dart
@@ -64,6 +64,32 @@ void main() {
     );
   });
 
+  test('readiness recommendation metadata includes source/domain/destination',
+      () {
+    final report = ReadinessReport.fromChecks(
+      const <ReadinessCheck>[
+        ReadinessCheck(
+          domain: ReadinessDomain.runtimeBinary,
+          level: ReadinessLevel.blocked,
+          summary: 'runtime binary missing',
+          detail: 'Install runtime binary before connecting.',
+          action: ReadinessAction.openTroubleshooting,
+          actionLabel: 'Open Troubleshooting',
+        ),
+      ],
+    );
+
+    final recommendation = report.recommendation;
+    expect(recommendation, isNotNull);
+    expect(recommendation!.source, ReadinessRecommendationSource.report);
+    expect(recommendation.domain, ReadinessDomain.runtimeBinary);
+    expect(recommendation.destination, 'advanced.troubleshooting');
+    expect(recommendation.destinationAvailable, isTrue);
+    expect(recommendation.fallbackReason, isNull);
+    expect(recommendation.actionId,
+        ReadinessRecommendationActionId.openTroubleshooting);
+  });
+
   test('readiness is degraded when secure storage is session-only', () async {
     final localState = MemoryLocalStateStore();
     final profileStore = ProfileStore.withSampleProfiles(
@@ -95,7 +121,8 @@ void main() {
       isTrue,
     );
     expect(report.recommendation, isNotNull);
-    expect(report.recommendation!.action, ReadinessAction.openTroubleshooting);
+    expect(report.recommendation!.action, ReadinessAction.openSettings);
+    expect(report.recommendation!.destination, 'settings');
   });
 
   test('recommendation prefers blocked fixes over degraded warnings', () {
@@ -105,8 +132,8 @@ void main() {
           domain: ReadinessDomain.secureStorage,
           level: ReadinessLevel.degraded,
           summary: 'secure storage fallback',
-          action: ReadinessAction.openTroubleshooting,
-          actionLabel: 'Open Troubleshooting',
+          action: ReadinessAction.openSettings,
+          actionLabel: 'Open Settings',
         ),
         ReadinessCheck(
           domain: ReadinessDomain.password,
@@ -120,6 +147,11 @@ void main() {
 
     expect(report.recommendation, isNotNull);
     expect(report.recommendation!.action, ReadinessAction.openProfiles);
+    expect(report.recommendation!.domain, ReadinessDomain.password);
+    expect(report.recommendation!.destination, 'profiles');
+    expect(report.recommendation!.destinationAvailable, isTrue);
+    expect(report.recommendation!.source, ReadinessRecommendationSource.report);
+    expect(report.recommendation!.fallbackReason, isNull);
   });
 
   test('recommendation ordering stays stable across degraded domains', () {
@@ -136,14 +168,15 @@ void main() {
           domain: ReadinessDomain.secureStorage,
           level: ReadinessLevel.degraded,
           summary: 'secure storage fallback',
-          action: ReadinessAction.openTroubleshooting,
-          actionLabel: 'Open Troubleshooting',
+          action: ReadinessAction.openSettings,
+          actionLabel: 'Open Settings',
         ),
       ],
     );
 
     expect(report.recommendation, isNotNull);
     expect(report.recommendation!.detail, 'secure storage fallback');
+    expect(report.recommendation!.action, ReadinessAction.openSettings);
   });
 
   test('readiness persists and restores last-known snapshot', () async {


### PR DESCRIPTION
## Summary\n- add structured readiness recommendation metadata (source/domain/destination/fallback) to the readiness domain model\n- resolve unavailable recommendation routes to a reachable fallback and surface destination availability in Dashboard/Profiles\n- keep recommendation action telemetry minimal and deterministic for acted paths\n\n## Testing\n- flutter analyze\n- flutter test test/features/readiness/application/readiness_service_test.dart test/features/profiles/presentation/profiles_page_action_gating_test.dart test/features/dashboard/presentation/dashboard_page_test.dart\n- ./scripts/validate_iter2_recovery_ladder.sh\n\nCloses #38