### PR TITLE
feat(analytics): close #39 recovery telemetry closure

### DIFF
--- a/client/lib/features/analytics/application/ux_metric_event_mapper.dart
+++ b/client/lib/features/analytics/application/ux_metric_event_mapper.dart
@@ -20,7 +20,7 @@ class UxMetricEventMapper {
           name: 'first_connect_attempted',
           at: now,
           fields: <String, Object?>{
-            'runtimePosture': runtimePosture,
+            'runtimePosture': _normalizeRuntimePosture(runtimePosture),
           },
         ),
       );
@@ -48,7 +48,7 @@ class UxMetricEventMapper {
           name: 'connect_failed_$failureFamily',
           at: now,
           fields: <String, Object?>{
-            'runtimePosture': runtimePosture,
+            'runtimePosture': _normalizeRuntimePosture(runtimePosture),
             'failureFamily': failureFamily,
           },
         ),
@@ -67,5 +67,62 @@ class UxMetricEventMapper {
     }
 
     return output;
+  }
+
+  UxEvent recoveryActionExecuted({
+    required String userId,
+    required String sessionId,
+    required String action,
+    required String source,
+    required String failureFamily,
+    required String runtimePosture,
+    DateTime? at,
+  }) {
+    return UxEvent(
+      userId: userId,
+      sessionId: sessionId,
+      name: 'recovery_action_executed',
+      at: at ?? DateTime.now(),
+      fields: <String, Object?>{
+        'action': action,
+        'source': source,
+        'failureFamily': failureFamily,
+        'runtimePosture': _normalizeRuntimePosture(runtimePosture),
+      },
+    );
+  }
+
+  UxEvent recoveryOutcome({
+    required String userId,
+    required String sessionId,
+    required String action,
+    required String source,
+    required String failureFamily,
+    required String runtimePosture,
+    required String outcome,
+    DateTime? at,
+  }) {
+    return UxEvent(
+      userId: userId,
+      sessionId: sessionId,
+      name: 'recovery_outcome',
+      at: at ?? DateTime.now(),
+      fields: <String, Object?>{
+        'action': action,
+        'source': source,
+        'failureFamily': failureFamily,
+        'runtimePosture': _normalizeRuntimePosture(runtimePosture),
+        'outcome': outcome,
+      },
+    );
+  }
+
+  String _normalizeRuntimePosture(String runtimePosture) {
+    return switch (runtimePosture) {
+      'runtimeTrue' || 'runtime_true' => 'runtime_true',
+      'fallbackStub' || 'fallback_stub' => 'fallback',
+      'explicitStub' || 'nonDesktopStub' || 'stub' => 'stub',
+      _ => runtimePosture,
+    };
   }
 }

--- a/client/lib/features/analytics/application/ux_metric_service.dart
+++ b/client/lib/features/analytics/application/ux_metric_service.dart
@@ -83,7 +83,8 @@ class UxMetricService {
         .toSet();
 
     final successSessions = events
-        .where((event) => event.name == 'recovery_succeeded')
+        .where((event) => event.name == 'recovery_outcome')
+        .where((event) => event.fields['outcome'] == 'success')
         .map((event) => event.sessionId)
         .whereType<String>()
         .where(suggestedSessions.contains)

--- a/client/test/features/analytics/application/ux_metric_event_mapper_test.dart
+++ b/client/test/features/analytics/application/ux_metric_event_mapper_test.dart
@@ -56,4 +56,64 @@ void main() {
       isTrue,
     );
   });
+
+  test('maps recovery action executed event with action/source/family/posture', () {
+    final mapper = UxMetricEventMapper();
+
+    final event = mapper.recoveryActionExecuted(
+      userId: 'u1',
+      sessionId: 's1',
+      action: 'open_troubleshooting',
+      source: 'readiness_recommendation',
+      failureFamily: 'connect',
+      runtimePosture: 'runtime_true',
+      at: DateTime.parse('2026-04-21T00:00:00Z'),
+    );
+
+    expect(event.name, 'recovery_action_executed');
+    expect(event.fields['action'], 'open_troubleshooting');
+    expect(event.fields['source'], 'readiness_recommendation');
+    expect(event.fields['failureFamily'], 'connect');
+    expect(event.fields['runtimePosture'], 'runtime_true');
+  });
+
+  test('maps recovery outcome event for success/fail/abandon', () {
+    final mapper = UxMetricEventMapper();
+
+    final success = mapper.recoveryOutcome(
+      userId: 'u1',
+      sessionId: 's1',
+      action: 'retry_connect',
+      source: 'readiness_recommendation',
+      failureFamily: 'connect',
+      runtimePosture: 'runtime_true',
+      outcome: 'success',
+      at: DateTime.parse('2026-04-21T00:01:00Z'),
+    );
+    final fail = mapper.recoveryOutcome(
+      userId: 'u1',
+      sessionId: 's1',
+      action: 'retry_connect',
+      source: 'readiness_recommendation',
+      failureFamily: 'connect',
+      runtimePosture: 'runtime_true',
+      outcome: 'fail',
+      at: DateTime.parse('2026-04-21T00:02:00Z'),
+    );
+    final abandon = mapper.recoveryOutcome(
+      userId: 'u1',
+      sessionId: 's1',
+      action: 'retry_connect',
+      source: 'readiness_recommendation',
+      failureFamily: 'connect',
+      runtimePosture: 'runtime_true',
+      outcome: 'abandon',
+      at: DateTime.parse('2026-04-21T00:03:00Z'),
+    );
+
+    expect(success.name, 'recovery_outcome');
+    expect(success.fields['outcome'], 'success');
+    expect(fail.fields['outcome'], 'fail');
+    expect(abandon.fields['outcome'], 'abandon');
+  });
 }

--- a/client/test/features/analytics/application/ux_metric_service_test.dart
+++ b/client/test/features/analytics/application/ux_metric_service_test.dart
@@ -86,7 +86,7 @@ void main() {
     expect(result.index, closeTo(0.575, 1e-9));
   });
 
-  test('SSR counts recovery succeeded over suggested sessions', () {
+  test('SSR counts recovery outcome success over suggested sessions', () {
     final service = UxMetricService();
     final events = <UxEvent>[
       UxEvent(
@@ -98,14 +98,26 @@ void main() {
       UxEvent(
         userId: 'u1',
         sessionId: 's1',
-        name: 'recovery_succeeded',
+        name: 'recovery_outcome',
         at: DateTime.parse('2026-04-17T10:01:00Z'),
+        fields: const <String, Object?>{
+          'outcome': 'success',
+        },
       ),
       UxEvent(
         userId: 'u2',
         sessionId: 's2',
         name: 'recovery_suggested',
         at: DateTime.parse('2026-04-17T10:05:00Z'),
+      ),
+      UxEvent(
+        userId: 'u2',
+        sessionId: 's2',
+        name: 'recovery_outcome',
+        at: DateTime.parse('2026-04-17T10:06:00Z'),
+        fields: const <String, Object?>{
+          'outcome': 'fail',
+        },
       ),
     ];
 
@@ -114,6 +126,27 @@ void main() {
     expect(result.numerator, 1);
     expect(result.denominator, 2);
     expect(result.value, 0.5);
+  });
+
+  test('SSR ignores recovery outcome success without suggested session', () {
+    final service = UxMetricService();
+    final events = <UxEvent>[
+      UxEvent(
+        userId: 'u1',
+        sessionId: 's1',
+        name: 'recovery_outcome',
+        at: DateTime.parse('2026-04-17T10:01:00Z'),
+        fields: const <String, Object?>{
+          'outcome': 'success',
+        },
+      ),
+    ];
+
+    final result = service.computeSsr(events);
+
+    expect(result.numerator, 0);
+    expect(result.denominator, 0);
+    expect(result.value, 0.0);
   });
 
   test('STE requires posture + recovery evidence fields in export completion', () {

--- a/docs/metrics/v1.5.0-ux-event-dictionary.md
+++ b/docs/metrics/v1.5.0-ux-event-dictionary.md
@@ -81,18 +81,30 @@
 ## 4. 护栏（Guardrail）相关事件
 
 ### `recovery_suggested`
-表示系统给出异常恢复建议。
+表示系统给出异常恢复建议（建议阶段）。
 
 必填附加字段：
-- `failure_family`: `readiness_blocked` | `launch_failed` | `connect_failed` | `unknown`
-- `suggested_action`: `retry` | `rollback` | `open_readiness`
+- `failureFamily`: `launch` | `config` | `environment` | `connect` | `user_input` | `export_os` | `unknown`
+- `runtimePosture`: `runtime_true` | `fallback` | `stub` | `unknown`
 
-### `recovery_succeeded`
-表示用户按建议完成恢复。
+### `recovery_action_executed`
+表示用户执行了恢复动作（执行阶段）。
 
 必填附加字段：
-- `failure_family`
-- `resolved_by`: `retry` | `rollback` | `manual_fix`
+- `action`: `openProfiles` | `openTroubleshooting` | `openSettings` | `retry_connect` | `rollback` | `other`
+- `source`: `report` | `fallback` | `readiness_recommendation` | `other`
+- `failureFamily`: `launch` | `config` | `environment` | `connect` | `user_input` | `export_os` | `unknown`
+- `runtimePosture`: `runtime_true` | `fallback` | `stub` | `unknown`
+
+### `recovery_outcome`
+表示恢复动作的最终结果（结果阶段）。
+
+必填附加字段：
+- `action`
+- `source`
+- `failureFamily`
+- `runtimePosture`
+- `outcome`: `success` | `fail` | `abandon`
 
 ### `diagnostics_export_started`
 表示用户开始导出诊断包。
@@ -112,4 +124,8 @@
 1. FCSR 只把 `runtime_session_ready_runtime_true` 计入成功，`fallback/stub` 不计入。
 2. FCSR 首会话窗口固定为 `first_session_started` 起 30 分钟。
 3. HFE 统计仅纳入 `action_completed` 完整链路，不完整动作仅用于辅助诊断。
-4. SSR/STE 作为护栏指标，不能因主指标优化而退化。
+4. SSR 以 `recovery_suggested -> recovery_outcome(outcome=success)` 计算，不再使用 `recovery_succeeded`。
+5. Guardrail 需同时观察建议、执行、结果三段：
+   - `recovery_acted_rate = recovery_action_executed / recovery_suggested`
+   - `recovery_outcome.success|fail|abandon` 分布
+6. SSR/STE 作为护栏指标，不能因主指标优化而退化。

--- a/docs/metrics/v1.5.0-ux-metric-computation-spec.md
+++ b/docs/metrics/v1.5.0-ux-metric-computation-spec.md
@@ -44,9 +44,16 @@
 用户在无需人工支持介入情况下完成异常恢复的比例。
 
 ### 3.2 计算
-- `numerator`：发生 `recovery_succeeded` 的去重 `session_id`
+- `numerator`：发生 `recovery_outcome` 且 `outcome == success` 的去重 `session_id`
 - `denominator`：发生 `recovery_suggested` 的去重 `session_id`
 - `ssr = numerator / denominator`（denominator 为 0 时记为 0）
+
+### 3.3 acted/outcome 闭环护栏
+除 SSR 外，Iter-2 需要附加闭环护栏：
+- `recovery_acted_rate = count(recovery_action_executed) / count(recovery_suggested)`
+- `recovery_outcome_breakdown = {success, fail, abandon}`（按事件数统计）
+
+该闭环用于回答“系统有建议，用户是否执行，执行后是否有效”。
 
 ## 4. STE（Support Triage Efficiency）
 

--- a/scripts/tests/test_compute_ux_metrics_snapshot.py
+++ b/scripts/tests/test_compute_ux_metrics_snapshot.py
@@ -35,3 +35,46 @@ def test_snapshot_fcsr_counts_runtime_true_only():
     assert result["fcsr"]["numerator"] == 1
     assert result["fcsr"]["denominator"] == 2
     assert result["fcsr"]["value"] == 0.5
+
+
+def test_snapshot_recovery_outcome_and_acted_closure():
+    events = [
+        {
+            "userId": "u1",
+            "sessionId": "s1",
+            "name": "recovery_suggested",
+            "at": "2026-04-21T00:00:00Z",
+        },
+        {
+            "userId": "u1",
+            "sessionId": "s1",
+            "name": "recovery_action_executed",
+            "at": "2026-04-21T00:00:05Z",
+            "fields": {
+                "action": "open_profiles",
+                "source": "readiness_recommendation",
+                "failureFamily": "connect",
+                "runtimePosture": "runtime_true",
+            },
+        },
+        {
+            "userId": "u1",
+            "sessionId": "s1",
+            "name": "recovery_outcome",
+            "at": "2026-04-21T00:01:00Z",
+            "fields": {
+                "action": "open_profiles",
+                "source": "readiness_recommendation",
+                "failureFamily": "connect",
+                "runtimePosture": "runtime_true",
+                "outcome": "success",
+            },
+        },
+    ]
+
+    result = compute_snapshot(events=events)
+    assert result["guardrails"]["ssr"] == 1.0
+    assert result["guardrails"]["recovery_acted_rate"] == 1.0
+    assert result["guardrails"]["recovery_outcome"]["success"] == 1
+    assert result["guardrails"]["recovery_outcome"]["fail"] == 0
+    assert result["guardrails"]["recovery_outcome"]["abandon"] == 0

--- a/scripts/ux/compute_ux_metrics_snapshot.py
+++ b/scripts/ux/compute_ux_metrics_snapshot.py
@@ -15,6 +15,13 @@ def _safe_div(numerator: int, denominator: int) -> float:
     return numerator / denominator
 
 
+def _event_fields(event: dict[str, Any]) -> dict[str, Any]:
+    fields = event.get("fields")
+    if isinstance(fields, dict):
+        return fields
+    return event
+
+
 def compute_snapshot(events: list[dict[str, Any]]) -> dict[str, Any]:
     started_users = {
         str(event.get("userId"))
@@ -38,8 +45,27 @@ def compute_snapshot(events: list[dict[str, Any]]) -> dict[str, Any]:
     recovery_suggested = [
         event for event in events if event.get("name") == "recovery_suggested"
     ]
-    recovery_succeeded = [
-        event for event in events if event.get("name") == "recovery_succeeded"
+    recovery_action_executed = [
+        event for event in events if event.get("name") == "recovery_action_executed"
+    ]
+    recovery_outcome = [
+        event for event in events if event.get("name") == "recovery_outcome"
+    ]
+
+    recovery_success = [
+        event
+        for event in recovery_outcome
+        if str(_event_fields(event).get("outcome", "")).lower() == "success"
+    ]
+    recovery_fail = [
+        event
+        for event in recovery_outcome
+        if str(_event_fields(event).get("outcome", "")).lower() == "fail"
+    ]
+    recovery_abandon = [
+        event
+        for event in recovery_outcome
+        if str(_event_fields(event).get("outcome", "")).lower() == "abandon"
     ]
 
     diagnostics_started = [
@@ -71,8 +97,17 @@ def compute_snapshot(events: list[dict[str, Any]]) -> dict[str, Any]:
             "index": hfe_index,
         },
         "guardrails": {
-            "ssr": _safe_div(len(recovery_succeeded), len(recovery_suggested)),
+            "ssr": _safe_div(len(recovery_success), len(recovery_suggested)),
             "ste": _safe_div(len(diagnostics_completed), len(diagnostics_started)),
+            "recovery_acted_rate": _safe_div(
+                len(recovery_action_executed),
+                len(recovery_suggested),
+            ),
+            "recovery_outcome": {
+                "success": len(recovery_success),
+                "fail": len(recovery_fail),
+                "abandon": len(recovery_abandon),
+            },
         },
     }
 


### PR DESCRIPTION
## Summary\n- add recovery telemetry events for acted/outcome closure (, )\n- switch SSR computation to  over  sessions\n- extend metrics snapshot script with acted rate and outcome breakdown\n- sync metrics docs with Iter-2 suggested->acted->outcome semantics\n\n## Linked issue\n- closes #39\n\n## Verification\n- Analyzing trojan-obfuscation...                                 
No issues found! (ran in 3.9s) (client)\n- \n- ...                                                                      [100%]
3 passed in 0.01s\n- == validate_iter2_recovery_ladder ==
project_root=/root/.openclaw/workspace/trojan-obfuscation
branch=feature/iter-2-i2-05-recovery-telemetry-closure
commit=a76937a
started_at_utc=2026-04-21T01:22:23Z

[1/4] python tests (ux metrics snapshot)
...                                                                      [100%]
3 passed in 0.01s
✅ [1/4] pass

[2/4] flutter analyze (client)
Resolving dependencies...
Downloading packages...
  async 2.13.0 (2.13.1 available)
  flutter_lints 3.0.2 (6.0.0 available)
  lints 3.0.0 (6.1.0 available)
  meta 1.17.0 (1.18.2 available)
  native_toolchain_c 0.17.5 (0.17.6 available)
  path_provider_android 2.2.22 (2.3.1 available)
  test_api 0.7.10 (0.7.11 available)
  vector_math 2.2.0 (2.3.0 available)
  vm_service 15.0.2 (15.1.0 available)
  win32 5.15.0 (6.0.1 available)
Got dependencies!
10 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
Analyzing client...                                             
No issues found! (ran in 3.5s)
✅ [2/4] pass

[3/4] flutter test (Iter-2 recovery ladder key suite)
Resolving dependencies...
Downloading packages...
  async 2.13.0 (2.13.1 available)
  flutter_lints 3.0.2 (6.0.0 available)
  lints 3.0.0 (6.1.0 available)
  meta 1.17.0 (1.18.2 available)
  native_toolchain_c 0.17.5 (0.17.6 available)
  path_provider_android 2.2.22 (2.3.1 available)
  test_api 0.7.10 (0.7.11 available)
  vector_math 2.2.0 (2.3.0 available)
  vm_service 15.0.2 (15.1.0 available)
  win32 5.15.0 (6.0.1 available)
Got dependencies!
10 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
00:00 +0: loading /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart
00:00 +0: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy blocked readiness openProfiles recommendation keeps profiles action
00:00 +1: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy blocked readiness openTroubleshooting recommendation uses troubleshooting when available
00:00 +2: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy blocked readiness openTroubleshooting recommendation falls back to profiles when unavailable
00:00 +3: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy blocked readiness openSettings recommendation uses settings when available
00:00 +4: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy blocked readiness openSettings recommendation falls back to profiles when unavailable
00:00 +5: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy blocked readiness password domain maps to Set Password on profiles
00:00 +6: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy blocked readiness secureStorage domain falls back to profiles when settings unavailable
00:00 +7: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy blocked readiness runtime domain maps to troubleshooting when available
00:00 +8: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy error user_input maps to set password action
00:00 +9: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy error config maps to open profiles action
00:00 +10: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy error connect maps to retry connect when no evidence-first guard is active
00:00 +11: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy error launch maps to retry connect when no evidence-first guard is active
00:00 +12: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy error connect with stale runtime prioritizes troubleshooting evidence capture
00:00 +13: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy error environment prefers settings when available
00:00 +14: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy error environment falls back to troubleshooting when settings unavailable
00:00 +15: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy error environment falls back to profiles when no entrypoint is available
00:00 +16: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy error export_os maps to support bundle export action
00:00 +17: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy error unknown defaults to troubleshooting when available
00:00 +18: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy error unknown falls back to profiles when troubleshooting unavailable
00:00 +19: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy disconnecting state recommends troubleshooting when available
00:00 +20: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy disconnecting state falls back to profiles when troubleshooting unavailable
00:00 +21: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy connected stale runtime recommends revalidate in troubleshooting
00:00 +22: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy connected stub residual state does not force action by itself
00:00 +23: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/recovery_ladder_policy_test.dart: RecoveryLadderPolicy connecting state with stale runtime recommends troubleshooting
00:00 +24: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/next_action_policy_test.dart: ProfileNextActionPolicy maps readiness blocked password to set password action
00:00 +25: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/next_action_policy_test.dart: ProfileNextActionPolicy maps readiness blocked environment to troubleshooting
00:00 +26: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/next_action_policy_test.dart: ProfileNextActionPolicy maps connect failure family to retry action
00:00 +27: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/next_action_policy_test.dart: ProfileNextActionPolicy maps export_os failure family to export support bundle action
00:00 +28: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/next_action_policy_test.dart: ProfileNextActionPolicy maps launch failure family to retry action
00:00 +29: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/next_action_policy_test.dart: ProfileNextActionPolicy maps config failure family to open profiles action
00:00 +30: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/next_action_policy_test.dart: ProfileNextActionPolicy maps environment failure family to settings as primary
00:00 +31: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/next_action_policy_test.dart: ProfileNextActionPolicy maps environment failure family to troubleshooting fallback when settings unavailable
00:00 +32: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/next_action_policy_test.dart: ProfileNextActionPolicy unknown failure defaults to evidence-preserving troubleshooting path
00:00 +33: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/next_action_policy_test.dart: ProfileNextActionPolicy unknown failure falls back to profiles when troubleshooting unavailable
00:00 +34: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/next_action_policy_test.dart: ProfileNextActionPolicy maps user_input failure family to set password action
00:00 +35: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/next_action_policy_test.dart: ProfileNextActionPolicy disconnecting prefers troubleshooting by default
00:01 +36: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart: stale connected runtime produces revalidation guide
00:01 +37: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart: idle missing-password state still routes to profiles
00:01 +38: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart: error runtime with residual evidence prefers troubleshooting over retry shortcut
00:01 +39: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart: disconnecting stop-pending runtime uses exit confirmation headline
00:01 +40: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart: error config keeps same action label and detail as profile next action
00:01 +41: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart: error launch keeps same retry action as profile next action
00:01 +42: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart: error user_input keeps same password action as profile next action
00:01 +43: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart: error environment keeps same settings primary as profile next action
00:01 +44: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart: error environment without settings uses profile fallback when session needs no evidence revalidation
00:01 +45: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart: error export_os keeps label/detail parity while dashboard routes to advanced
00:01 +46: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart: error unknown without troubleshooting keeps same fallback action as profile
00:01 +47: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/dashboard/presentation/dashboard_guide_policy_test.dart: blocked readiness openSettings recommendation falls back consistently when settings are unavailable
00:01 +48: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/profile_connection_action_policy_test.dart: stale connected session routes to troubleshooting when available
00:01 +49: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/profile_connection_action_policy_test.dart: disconnecting session surfaces recovery guidance instead of idle hint
00:01 +50: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/profile_connection_action_policy_test.dart: error residual session keeps troubleshooting evidence-first CTA
00:01 +51: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/profiles/presentation/profile_connection_action_policy_test.dart: readiness blocked connect returns blocked policy
00:02 +52: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/runtime_action_safety_test.dart: disconnecting stop-pending runtime blocks retry until exit confirmation
00:02 +53: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/runtime_action_safety_test.dart: stale connected runtime requires revalidation before state changes
00:02 +54: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/runtime_action_safety_test.dart: error residual runtime enforces evidence capture before retry
00:02 +55: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/runtime_action_safety_test.dart: connecting with stale session truth still blocks retry shortcut
00:02 +56: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/runtime_operator_advice_test.dart: connected stale runtime recommends revalidation
00:02 +57: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/runtime_operator_advice_test.dart: disconnecting stop-pending runtime recommends waiting for exit confirmation
00:02 +58: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/runtime_operator_advice_test.dart: error residual session recommends troubleshooting evidence-first guidance
00:02 +59: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/runtime_operator_advice_test.dart: error stale running session still advises troubleshooting before retry
00:02 +60: /root/.openclaw/workspace/trojan-obfuscation/client/test/features/controller/domain/runtime_operator_advice_test.dart: stub residual state does not create actionable advice by itself
00:02 +61: All tests passed!
✅ [3/4] pass

[4/4] done
finished_at_utc=2026-04-21T01:22:40Z

---
Recovery Ladder validation evidence
- Script: ./scripts/validate_iter2_recovery_ladder.sh
- Branch: feature/iter-2-i2-05-recovery-telemetry-closure
- Commit: a76937a
- Started: 2026-04-21T01:22:23Z
- Finished: 2026-04-21T01:22:40Z\n