### PR TITLE
fix(client): disable quick connect when already connected

### DIFF
--- a/client/lib/features/profiles/presentation/high_frequency_actions_strip.dart
+++ b/client/lib/features/profiles/presentation/high_frequency_actions_strip.dart
@@ -10,9 +10,9 @@ class HighFrequencyActionsStrip extends StatelessWidget {
   });
 
   final bool enabled;
-  final VoidCallback onQuickConnect;
-  final VoidCallback onQuickDisconnect;
-  final VoidCallback onSwitchProfile;
+  final VoidCallback? onQuickConnect;
+  final VoidCallback? onQuickDisconnect;
+  final VoidCallback? onSwitchProfile;
 
   @override
   Widget build(BuildContext context) {

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -669,44 +669,31 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
             const SizedBox(height: 12),
             HighFrequencyActionsStrip(
               enabled: connectionPolicy.canToggleConnection,
-              onQuickConnect: () async {
-                final messenger = ScaffoldMessenger.of(context);
-                if (status.phase == ClientConnectionPhase.connected) {
-                  final result = await services.controller.disconnect();
-                  if (!mounted) return;
-                  final feedback = buildRuntimeActionFeedback(
-                    action: RuntimeActionKind.disconnect,
-                    result: result,
-                    status: services.controller.status,
-                    session: services.controller.session,
-                    posture: _runtimePosture,
-                  );
-                  messenger.showSnackBar(
-                    SnackBar(content: Text(feedback)),
-                  );
-                  return;
-                }
+              onQuickConnect:
+                  status.phase == ClientConnectionPhase.connected
+                      ? null
+                      : () async {
+                          final messenger = ScaffoldMessenger.of(context);
+                          final allowed = await _runConnectReadinessPreflight(
+                            messenger: messenger,
+                          );
+                          if (!mounted || !allowed) {
+                            return;
+                          }
 
-                final allowed = await _runConnectReadinessPreflight(
-                  messenger: messenger,
-                );
-                if (!mounted || !allowed) {
-                  return;
-                }
-
-                final result = await services.controller.connect(selected);
-                if (!mounted) return;
-                final feedback = buildRuntimeActionFeedback(
-                  action: RuntimeActionKind.connect,
-                  result: result,
-                  status: services.controller.status,
-                  session: services.controller.session,
-                  posture: _runtimePosture,
-                );
-                messenger.showSnackBar(
-                  SnackBar(content: Text(feedback)),
-                );
-              },
+                          final result = await services.controller.connect(selected);
+                          if (!mounted) return;
+                          final feedback = buildRuntimeActionFeedback(
+                            action: RuntimeActionKind.connect,
+                            result: result,
+                            status: services.controller.status,
+                            session: services.controller.session,
+                            posture: _runtimePosture,
+                          );
+                          messenger.showSnackBar(
+                            SnackBar(content: Text(feedback)),
+                          );
+                        },
               onQuickDisconnect: () async {
                 final messenger = ScaffoldMessenger.of(context);
                 final result = await services.controller.disconnect();

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -535,6 +535,42 @@ void main() {
     expect(services.controller.status.phase, ClientConnectionPhase.disconnected);
   });
 
+  testWidgets('quick connect stays disabled while already connected',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+    final services = _buildServices();
+    final selected = services.profileStore.selectedProfile!;
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: selected.id,
+      password: 'secret',
+    );
+    services.profileStore.upsertProfile(
+      selected.copyWith(hasStoredPassword: true),
+    );
+
+    await tester.runAsync(() => services.controller.connect(selected));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ProfilesPage(services: services)),
+      ),
+    );
+    await tester.pump();
+
+    final quickConnectButton = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'Quick Connect'),
+    );
+    final quickDisconnectButton = tester.widget<OutlinedButton>(
+      find.widgetWithText(OutlinedButton, 'Quick Disconnect'),
+    );
+
+    expect(services.controller.status.phase, ClientConnectionPhase.connected);
+    expect(quickConnectButton.onPressed, isNull,
+        reason: 'Quick Connect must not behave like a toggle when connected.');
+    expect(quickDisconnectButton.onPressed, isNotNull);
+  });
+
   testWidgets(
       'readiness notice refreshes when selected profile changes in place',
       (WidgetTester tester) async {


### PR DESCRIPTION
### What\n- Make Quick Connect non-toggle: when already connected, the **Quick Connect** button is disabled and no longer triggers disconnect.\n- Keep disconnect semantics explicit via **Quick Disconnect**.\n\n### Why\nAvoid misleading HF action behavior and keep runtime-truth UX consistent (connect != disconnect).\n\n### Tests\n- ./scripts/validate_iter2_recovery_ladder.sh\n\n### Notes\n- Includes a widget test covering the connected-state gating.