### PR TITLE
chore(release): block prerelease tags (alpha/beta/rc)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,35 @@ env:
 
 jobs:
   # ============================================
+  # Release policy guard
+  # ============================================
+  release-policy-guard:
+    name: Release policy guard (block prerelease tags)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enforce no prerelease tags (alpha/beta/rc)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+          TAG_NAME="${GITHUB_REF_NAME}"
+          echo "release policy: validating tag '${TAG_NAME}'"
+
+          # Policy: we are fully stopping prerelease cuts.
+          # Block alpha/beta/rc tags explicitly.
+          if echo "${TAG_NAME}" | grep -Eiq '(alpha|beta|rc)'; then
+            echo "ERROR: prerelease tags are blocked by policy (found alpha/beta/rc in '${TAG_NAME}')."
+            echo "If you intended a stable release, use a stable tag like: v1.5.0"
+            exit 1
+          fi
+
+          echo "OK: stable tag detected."
+
+  # ============================================
   # Linux Builds (x86_64 and aarch64)
   # ============================================
   build-linux:
+    needs: [release-policy-guard]
     strategy:
       fail-fast: false
       matrix:
@@ -121,6 +147,7 @@ jobs:
   # macOS Builds (x86_64 and arm64)
   # ============================================
   build-macos:
+    needs: [release-policy-guard]
     strategy:
       fail-fast: false
       matrix:
@@ -231,6 +258,7 @@ jobs:
   # Windows Build (x86_64 via MSYS2/MinGW)
   # ============================================
   build-windows:
+    needs: [release-policy-guard]
     runs-on: windows-latest
     name: Windows x86_64
 


### PR DESCRIPTION
### What\n- Add a release policy guard job that fails on tag names containing alpha/beta/rc.\n- Wire build jobs to depend on the guard.\n\n### Why\nWe are fully stopping beta/prerelease cuts; this prevents accidental prerelease tagging from producing artifacts/releases.\n\n### Evidence\n- Local YAML parse OK (python3 yaml.safe_load).\n- ./scripts/validate_iter2_recovery_ladder.sh ✅\n- ./scripts/validate_iter1_first_connect.sh ✅\n- python3 -m pytest scripts/tests/test_validate_client_release_truth.py -q ✅