### PR TITLE
feat(client): Profiles HF quick retry (last known good)

### DIFF
--- a/client/lib/features/controller/application/adapter_backed_client_controller.dart
+++ b/client/lib/features/controller/application/adapter_backed_client_controller.dart
@@ -127,6 +127,9 @@ class AdapterBackedClientController extends ClientControllerApi {
   LastRuntimeFailureSummary? get lastRuntimeFailure => _lastRuntimeFailure;
 
   @override
+  String? get lastKnownGoodProfileId => _lastKnownGoodProfileId;
+
+  @override
   List<RoutingProbeEvidenceRecord> get latestRoutingProbeEvidence =>
       List<RoutingProbeEvidenceRecord>.unmodifiable(
         _latestRoutingProbeEvidence,

--- a/client/lib/features/controller/application/client_controller_api.dart
+++ b/client/lib/features/controller/application/client_controller_api.dart
@@ -24,6 +24,8 @@ abstract class ClientControllerApi extends ChangeNotifier {
   ControllerRuntimeSession get session;
   LastRuntimeFailureSummary? get lastRuntimeFailure;
 
+  String? get lastKnownGoodProfileId => null;
+
   List<RoutingProbeEvidenceRecord> get latestRoutingProbeEvidence =>
       const <RoutingProbeEvidenceRecord>[];
 

--- a/client/lib/features/controller/application/fake_client_controller.dart
+++ b/client/lib/features/controller/application/fake_client_controller.dart
@@ -51,6 +51,9 @@ class FakeClientController extends ClientControllerApi {
   LastRuntimeFailureSummary? get lastRuntimeFailure => null;
 
   @override
+  String? get lastKnownGoodProfileId => null;
+
+  @override
   List<RoutingProbeEvidenceRecord> get latestRoutingProbeEvidence =>
       const <RoutingProbeEvidenceRecord>[];
 

--- a/client/lib/features/profiles/presentation/high_frequency_actions_strip.dart
+++ b/client/lib/features/profiles/presentation/high_frequency_actions_strip.dart
@@ -7,17 +7,20 @@ class HighFrequencyActionsStrip extends StatelessWidget {
     required this.onQuickConnect,
     required this.onQuickDisconnect,
     required this.onSwitchProfile,
+    this.onQuickRetryLastGood,
   });
 
   final bool enabled;
   final VoidCallback? onQuickConnect;
   final VoidCallback? onQuickDisconnect;
   final VoidCallback? onSwitchProfile;
+  final VoidCallback? onQuickRetryLastGood;
 
   @override
   Widget build(BuildContext context) {
     final connectHandler = enabled ? onQuickConnect : null;
     final disconnectHandler = enabled ? onQuickDisconnect : null;
+    final retryHandler = enabled ? onQuickRetryLastGood : null;
     final switchHandler = enabled ? onSwitchProfile : null;
 
     return Wrap(
@@ -32,6 +35,11 @@ class HighFrequencyActionsStrip extends StatelessWidget {
           onPressed: disconnectHandler,
           child: const Text('Quick Disconnect'),
         ),
+        if (onQuickRetryLastGood != null)
+          OutlinedButton(
+            onPressed: retryHandler,
+            child: const Text('Quick Retry (Last Good)'),
+          ),
         TextButton(
           onPressed: switchHandler,
           child: const Text('Switch Profile'),

--- a/client/lib/features/profiles/presentation/profiles_page.dart
+++ b/client/lib/features/profiles/presentation/profiles_page.dart
@@ -366,7 +366,8 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
           domain: recommendation.domain,
           destination: 'profiles',
           destinationAvailable: true,
-          fallbackReason: 'Troubleshooting page is unavailable in this surface.',
+          fallbackReason:
+              'Troubleshooting page is unavailable in this surface.',
         );
       case ReadinessAction.openSettings:
         if (widget.onOpenSettings != null) {
@@ -442,15 +443,15 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
     final posture = _runtimePosture;
     final connectionPolicy = _connectionPolicy;
 
-    final failureFamily = parseFailureFamily(status.failureFamilyHint) ==
-            FailureFamily.unknown
-        ? classifyFailureFamily(
-            errorCode: status.errorCode,
-            summary: status.message,
-            detail: status.message,
-            phase: status.phase.name,
-          )
-        : parseFailureFamily(status.failureFamilyHint);
+    final failureFamily =
+        parseFailureFamily(status.failureFamilyHint) == FailureFamily.unknown
+            ? classifyFailureFamily(
+                errorCode: status.errorCode,
+                summary: status.message,
+                detail: status.message,
+                phase: status.phase.name,
+              )
+            : parseFailureFamily(status.failureFamilyHint);
 
     final nextActionDecision = ProfileNextActionPolicy.resolve(
       status: status,
@@ -632,7 +633,8 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
                       ? nextActionDecision.label
                       : null,
                   onAction: nextActionDecision.isActionable
-                      ? () => _runNextActionDecision(context, nextActionDecision)
+                      ? () =>
+                          _runNextActionDecision(context, nextActionDecision)
                       : null,
                 );
               },
@@ -655,7 +657,8 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
                       snapshot.connectionState != ConnectionState.done,
                   onRecommendation: resolvedRecommendation == null
                       ? null
-                      : () => _runReadinessAction(context, resolvedRecommendation),
+                      : () =>
+                          _runReadinessAction(context, resolvedRecommendation),
                 );
               },
             ),
@@ -667,10 +670,20 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
               nextAction: nextActionDecision,
             ),
             const SizedBox(height: 12),
-            HighFrequencyActionsStrip(
-              enabled: connectionPolicy.canToggleConnection,
-              onQuickConnect:
-                  status.phase == ClientConnectionPhase.connected
+            Builder(
+              builder: (BuildContext context) {
+                final lastGoodId = services.controller.lastKnownGoodProfileId;
+                final lastGoodProfile = lastGoodId == null
+                    ? null
+                    : services.profileStore.profileById(lastGoodId);
+                final canQuickRetryLastGood = lastGoodProfile != null &&
+                    lastGoodProfile.id != selected.id &&
+                    status.phase != ClientConnectionPhase.connected;
+
+                return HighFrequencyActionsStrip(
+                  enabled: connectionPolicy.canToggleConnection,
+                  onQuickConnect: status.phase ==
+                          ClientConnectionPhase.connected
                       ? null
                       : () async {
                           final messenger = ScaffoldMessenger.of(context);
@@ -681,7 +694,8 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
                             return;
                           }
 
-                          final result = await services.controller.connect(selected);
+                          final result =
+                              await services.controller.connect(selected);
                           if (!mounted) return;
                           final feedback = buildRuntimeActionFeedback(
                             action: RuntimeActionKind.connect,
@@ -694,40 +708,77 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
                             SnackBar(content: Text(feedback)),
                           );
                         },
-              onQuickDisconnect: () async {
-                final messenger = ScaffoldMessenger.of(context);
-                final result = await services.controller.disconnect();
-                if (!mounted) return;
-                final feedback = buildRuntimeActionFeedback(
-                  action: RuntimeActionKind.disconnect,
-                  result: result,
-                  status: services.controller.status,
-                  session: services.controller.session,
-                  posture: _runtimePosture,
-                );
-                messenger.showSnackBar(
-                  SnackBar(content: Text(feedback)),
-                );
-              },
-              onSwitchProfile: () {
-                final profiles = services.profileStore.profiles;
-                if (profiles.length < 2) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Need at least 2 profiles to switch quickly.'),
-                    ),
-                  );
-                  return;
-                }
-                final currentIndex = profiles.indexWhere((p) => p.id == selected.id);
-                final nextIndex = currentIndex < 0
-                    ? 0
-                    : (currentIndex + 1) % profiles.length;
-                services.profileStore.selectProfile(profiles[nextIndex].id);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text('Switched to profile: ${profiles[nextIndex].name}'),
-                  ),
+                  onQuickDisconnect: () async {
+                    final messenger = ScaffoldMessenger.of(context);
+                    final result = await services.controller.disconnect();
+                    if (!mounted) return;
+                    final feedback = buildRuntimeActionFeedback(
+                      action: RuntimeActionKind.disconnect,
+                      result: result,
+                      status: services.controller.status,
+                      session: services.controller.session,
+                      posture: _runtimePosture,
+                    );
+                    messenger.showSnackBar(
+                      SnackBar(content: Text(feedback)),
+                    );
+                  },
+                  onQuickRetryLastGood: !canQuickRetryLastGood
+                      ? null
+                      : () async {
+                          final messenger = ScaffoldMessenger.of(context);
+
+                          services.profileStore
+                              .selectProfile(lastGoodProfile.id);
+
+                          final allowed = await _runConnectReadinessPreflight(
+                            messenger: messenger,
+                            profileOverride: lastGoodProfile,
+                          );
+                          if (!mounted || !allowed) {
+                            return;
+                          }
+
+                          final result = await services.controller
+                              .connect(lastGoodProfile);
+                          if (!mounted) return;
+                          final feedback = buildRuntimeActionFeedback(
+                            action: RuntimeActionKind.retry,
+                            result: result,
+                            status: services.controller.status,
+                            session: services.controller.session,
+                            posture: _runtimePosture,
+                          );
+                          messenger.showSnackBar(
+                            SnackBar(content: Text(feedback)),
+                          );
+                        },
+                  onSwitchProfile: () {
+                    final profiles = services.profileStore.profiles;
+                    if (profiles.length < 2) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text(
+                            'Need at least 2 profiles to switch quickly.',
+                          ),
+                        ),
+                      );
+                      return;
+                    }
+                    final currentIndex =
+                        profiles.indexWhere((p) => p.id == selected.id);
+                    final nextIndex = currentIndex < 0
+                        ? 0
+                        : (currentIndex + 1) % profiles.length;
+                    services.profileStore.selectProfile(profiles[nextIndex].id);
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(
+                          'Switched to profile: ${profiles[nextIndex].name}',
+                        ),
+                      ),
+                    );
+                  },
                 );
               },
             ),
@@ -871,9 +922,11 @@ class _SelectedProfileCardState extends State<_SelectedProfileCard> {
 
   Future<bool> _runConnectReadinessPreflight({
     required ScaffoldMessengerState messenger,
+    ClientProfile? profileOverride,
   }) async {
+    final targetProfile = profileOverride ?? selected;
     final readinessReport = await services.readiness.buildReport(
-      profileOverride: selected,
+      profileOverride: targetProfile,
     );
     if (!mounted) return false;
     _readinessController.replaceLatestReport(readinessReport);
@@ -1282,7 +1335,8 @@ class _ProfileReadinessNotice extends StatelessWidget {
               OutlinedButton.icon(
                 onPressed: onRecommendation,
                 icon: Icon(_recommendationIcon(
-                  effectiveRecommendation?.action ?? ReadinessAction.openProfiles,
+                  effectiveRecommendation?.action ??
+                      ReadinessAction.openProfiles,
                 )),
                 label: Text(effectiveRecommendationLabel),
               ),

--- a/client/test/features/profiles/presentation/high_frequency_actions_strip_test.dart
+++ b/client/test/features/profiles/presentation/high_frequency_actions_strip_test.dart
@@ -51,4 +51,44 @@ void main() {
     expect(disconnect.onPressed, isNull);
     expect(switchProfile.onPressed, isNull);
   });
+
+  testWidgets('renders quick retry (last good) when handler is provided',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: HighFrequencyActionsStrip(
+            onQuickConnect: () {},
+            onQuickDisconnect: () {},
+            onSwitchProfile: () {},
+            onQuickRetryLastGood: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Quick Retry (Last Good)'), findsOneWidget);
+  });
+
+  testWidgets('disables quick retry (last good) when disabled flag is true',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: HighFrequencyActionsStrip(
+            enabled: false,
+            onQuickConnect: () {},
+            onQuickDisconnect: () {},
+            onSwitchProfile: () {},
+            onQuickRetryLastGood: () {},
+          ),
+        ),
+      ),
+    );
+
+    final retry = tester.widget<OutlinedButton>(
+      find.widgetWithText(OutlinedButton, 'Quick Retry (Last Good)'),
+    );
+    expect(retry.onPressed, isNull);
+  });
 }

--- a/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+++ b/client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
@@ -5,10 +5,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:trojan_pro_client/features/controller/application/client_controller_api.dart';
 import 'package:trojan_pro_client/features/controller/application/fake_client_controller.dart';
 import 'package:trojan_pro_client/features/controller/domain/client_connection_status.dart';
+import 'package:trojan_pro_client/features/controller/domain/controller_command_result.dart';
 import 'package:trojan_pro_client/features/controller/domain/controller_runtime_config.dart';
 import 'package:trojan_pro_client/features/controller/domain/controller_runtime_health.dart';
 import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
 import 'package:trojan_pro_client/features/controller/domain/controller_telemetry_snapshot.dart';
+import 'package:trojan_pro_client/features/profiles/domain/client_profile.dart';
 import 'package:trojan_pro_client/features/diagnostics/application/diagnostics_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_export_service.dart';
 import 'package:trojan_pro_client/features/packaging/application/packaging_store.dart';
@@ -196,6 +198,24 @@ class _SafeModeController extends FakeClientController {
         quarantineKey: 'sample-hk-1',
         rollbackReason: 'mini smoke failed on routing rule smoke/direct',
       );
+}
+
+class _LastKnownGoodController extends FakeClientController {
+  _LastKnownGoodController({
+    required this.lastGoodProfileId,
+  });
+
+  final String lastGoodProfileId;
+  String? lastConnectProfileId;
+
+  @override
+  String? get lastKnownGoodProfileId => lastGoodProfileId;
+
+  @override
+  Future<ControllerCommandResult> connect(ClientProfile profile) async {
+    lastConnectProfileId = profile.id;
+    return super.connect(profile);
+  }
 }
 
 ClientServiceRegistry _buildServices({
@@ -459,7 +479,8 @@ void main() {
       'primary connect preflight shows blocked reason + next action copy',
       (WidgetTester tester) async {
     await _setDesktopSurface(tester);
-    final services = _buildServices(controllerOverride: _SlowHealthController());
+    final services =
+        _buildServices(controllerOverride: _SlowHealthController());
     final selected = services.profileStore.selectedProfile!;
 
     await services.profileSecrets.saveTrojanPassword(
@@ -491,14 +512,15 @@ void main() {
       findsOneWidget,
     );
     expect(find.textContaining('Next action: Open Profiles'), findsOneWidget);
-    expect(services.controller.status.phase, ClientConnectionPhase.disconnected);
+    expect(
+        services.controller.status.phase, ClientConnectionPhase.disconnected);
   });
 
-  testWidgets(
-      'quick connect preflight shows blocked reason + next action copy',
+  testWidgets('quick connect preflight shows blocked reason + next action copy',
       (WidgetTester tester) async {
     await _setDesktopSurface(tester);
-    final services = _buildServices(controllerOverride: _SlowHealthController());
+    final services =
+        _buildServices(controllerOverride: _SlowHealthController());
     final selected = services.profileStore.selectedProfile!;
 
     await services.profileSecrets.saveTrojanPassword(
@@ -532,7 +554,8 @@ void main() {
       findsOneWidget,
     );
     expect(find.textContaining('Next action: Open Profiles'), findsOneWidget);
-    expect(services.controller.status.phase, ClientConnectionPhase.disconnected);
+    expect(
+        services.controller.status.phase, ClientConnectionPhase.disconnected);
   });
 
   testWidgets('quick connect stays disabled while already connected',
@@ -569,6 +592,110 @@ void main() {
     expect(quickConnectButton.onPressed, isNull,
         reason: 'Quick Connect must not behave like a toggle when connected.');
     expect(quickDisconnectButton.onPressed, isNotNull);
+  });
+
+  testWidgets('quick retry (last good) switches selected profile then connects',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+
+    final controller =
+        _LastKnownGoodController(lastGoodProfileId: 'sample-us-1');
+    final services = _buildServices(controllerOverride: controller);
+
+    final first = services.profileStore.profiles.first;
+    final lastGood =
+        services.profileStore.profiles.firstWhere((p) => p.id == 'sample-us-1');
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: first.id,
+      password: 'secret-1',
+    );
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: lastGood.id,
+      password: 'secret-2',
+    );
+    services.profileStore
+        .upsertProfile(first.copyWith(hasStoredPassword: true));
+    services.profileStore
+        .upsertProfile(lastGood.copyWith(hasStoredPassword: true));
+
+    services.profileStore.selectProfile(first.id);
+    expect(services.profileStore.selectedProfileId, first.id);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ProfilesPage(services: services)),
+      ),
+    );
+    await tester.pump();
+
+    final retryButton =
+        find.widgetWithText(OutlinedButton, 'Quick Retry (Last Good)');
+    await tester.ensureVisible(retryButton);
+    await tester.tap(retryButton);
+
+    await tester.pump(const Duration(milliseconds: 20));
+
+    expect(services.profileStore.selectedProfileId, lastGood.id);
+    expect(controller.lastConnectProfileId, lastGood.id);
+
+    // Drain pending timers scheduled by FakeClientController.connect() so the
+    // test binding does not fail the invariant check.
+    await tester.pump(const Duration(milliseconds: 900));
+  });
+
+  testWidgets(
+      'quick retry (last good) enforces readiness preflight and blocks connect',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+
+    final controller =
+        _LastKnownGoodController(lastGoodProfileId: 'sample-us-1');
+    final services = _buildServices(controllerOverride: controller);
+
+    final first = services.profileStore.profiles.first;
+    final lastGood =
+        services.profileStore.profiles.firstWhere((p) => p.id == 'sample-us-1');
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: first.id,
+      password: 'secret-1',
+    );
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: lastGood.id,
+      password: 'secret-2',
+    );
+
+    services.profileStore
+        .upsertProfile(first.copyWith(hasStoredPassword: true));
+    services.profileStore.upsertProfile(
+      lastGood.copyWith(
+        hasStoredPassword: true,
+        serverHost: '',
+      ),
+    );
+
+    services.profileStore.selectProfile(first.id);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ProfilesPage(services: services)),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final retryButton =
+        find.widgetWithText(OutlinedButton, 'Quick Retry (Last Good)');
+    await tester.ensureVisible(retryButton);
+    await tester.tap(retryButton);
+    await tester.pump(const Duration(milliseconds: 360));
+
+    expect(find.textContaining('Connect blocked:'), findsOneWidget);
+    expect(find.textContaining('Next action:'), findsOneWidget);
+
+    // Should not have attempted connect.
+    expect(controller.lastConnectProfileId, isNull);
   });
 
   testWidgets(
@@ -663,7 +790,8 @@ void main() {
     expect(openedAdvanced, isTrue);
   });
 
-  testWidgets('readiness recommendation falls back to profiles when settings route is unavailable',
+  testWidgets(
+      'readiness recommendation falls back to profiles when settings route is unavailable',
       (WidgetTester tester) async {
     await _setDesktopSurface(tester);
     final services = _buildServices(

--- a/docs/superpowers/plans/2026-04-22-iter3-last-known-good-retry.md
+++ b/docs/superpowers/plans/2026-04-22-iter3-last-known-good-retry.md
@@ -1,0 +1,531 @@
+# Iter-3: last-known-good quick retry（Profiles HF strip）实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
+
+**目标：** 在 Profiles 页 `HighFrequencyActionsStrip` 增加 `Quick Retry (Last Good)` 入口，并按语义 A 执行（先切 selected → 对 last-good preflight → connect），且不绕过 readiness / runtime truth / action-safety gating；补齐 #51 指定 tests 作为证据。
+
+**架构：** 采用 UI 驱动方案：controller 仅暴露只读 `lastKnownGoodProfileId`，Profiles UI 通过 `profileStore` 找到对应 profile 并执行 gated retry。Readiness preflight 扩展为支持 `profileOverride`，反馈统一走 `buildRuntimeActionFeedback(action: RuntimeActionKind.retry, ...)`。
+
+**技术栈：** Flutter/Dart、widget tests（flutter_test）、现有 domain policy（RuntimeActionSafety/Matrix/Feedback）。
+
+---
+
+## 0) 文件清单与职责（本计划涉及）
+
+**修改：**
+- `client/lib/features/controller/application/client_controller_api.dart`
+  - 新增只读 getter：`String? get lastKnownGoodProfileId`（默认 null）
+- `client/lib/features/controller/application/adapter_backed_client_controller.dart`
+  - override getter，返回 `_lastKnownGoodProfileId`
+- `client/lib/features/controller/application/fake_client_controller.dart`
+  - override getter（测试可控，默认 null）
+- `client/lib/features/profiles/presentation/high_frequency_actions_strip.dart`
+  - 新增按钮与可选回调：`onQuickRetryLastGood`
+- `client/lib/features/profiles/presentation/profiles_page.dart`
+  - 接入 quick retry：计算 last-good profile、切换 selected、preflight(profileOverride)、connect、SnackBar feedback
+  - 改造 `_runConnectReadinessPreflight` 支持 `profileOverride`
+
+**测试：**
+- `client/test/features/profiles/presentation/high_frequency_actions_strip_test.dart`
+  - 覆盖新按钮渲染与 disabled 行为
+- `client/test/features/profiles/presentation/profiles_page_action_gating_test.dart`
+  - 新增 quick retry 行为测试（切 selected + preflight + connect）
+  - 新增 blocked preflight 测试（不触发 connect，copy truth-safe）
+
+---
+
+# 任务 1：先写 HF strip 的失败测试（红）并验证
+
+**文件：**
+- 修改：`client/test/features/profiles/presentation/high_frequency_actions_strip_test.dart`
+- 随后实现会修改：`client/lib/features/profiles/presentation/high_frequency_actions_strip.dart`
+
+- [ ] **步骤 1：编写失败的测试（新增按钮渲染）**
+
+在 `high_frequency_actions_strip_test.dart` 追加：
+
+```dart
+  testWidgets('renders quick retry (last good) when handler is provided',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: HighFrequencyActionsStrip(
+            onQuickConnect: () {},
+            onQuickDisconnect: () {},
+            onSwitchProfile: () {},
+            onQuickRetryLastGood: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Quick Retry (Last Good)'), findsOneWidget);
+  });
+```
+
+- [ ] **步骤 2：编写失败的测试（disabled 时新按钮也禁用）**
+
+继续追加：
+
+```dart
+  testWidgets('disables quick retry (last good) when disabled flag is true',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: HighFrequencyActionsStrip(
+            enabled: false,
+            onQuickConnect: () {},
+            onQuickDisconnect: () {},
+            onSwitchProfile: () {},
+            onQuickRetryLastGood: () {},
+          ),
+        ),
+      ),
+    );
+
+    final retry = tester.widget<OutlinedButton>(
+      find.widgetWithText(OutlinedButton, 'Quick Retry (Last Good)'),
+    );
+    expect(retry.onPressed, isNull);
+  });
+```
+
+- [ ] **步骤 3：运行测试验证失败（红灯）**
+
+运行：
+
+```bash
+cd client
+flutter test test/features/profiles/presentation/high_frequency_actions_strip_test.dart
+```
+
+预期：FAIL，报错类似：
+- `No named parameter with the name 'onQuickRetryLastGood'.`
+- 或找不到 `Quick Retry (Last Good)` 文本。
+
+---
+
+# 任务 2：实现 HF strip 新按钮（绿）并验证
+
+**文件：**
+- 修改：`client/lib/features/profiles/presentation/high_frequency_actions_strip.dart`
+- 测试：`client/test/features/profiles/presentation/high_frequency_actions_strip_test.dart`
+
+- [ ] **步骤 1：最少实现让测试通过**
+
+在 `HighFrequencyActionsStrip`：
+- 构造器新增：`this.onQuickRetryLastGood,`
+- 字段：`final VoidCallback? onQuickRetryLastGood;`
+- build 中新增 handler：`final retryHandler = enabled ? onQuickRetryLastGood : null;`
+- children 里在 Quick Disconnect 之后插入：
+
+```dart
+        OutlinedButton(
+          onPressed: retryHandler,
+          child: const Text('Quick Retry (Last Good)'),
+        ),
+```
+
+并保持当 handler 为 null 时不渲染按钮（避免 UI 噪音）：
+
+```dart
+        if (onQuickRetryLastGood != null)
+          OutlinedButton(
+            onPressed: retryHandler,
+            child: const Text('Quick Retry (Last Good)'),
+          ),
+```
+
+- [ ] **步骤 2：运行测试验证通过（绿灯）**
+
+```bash
+cd client
+flutter test test/features/profiles/presentation/high_frequency_actions_strip_test.dart
+```
+
+预期：PASS。
+
+- [ ] **步骤 3：Commit**
+
+```bash
+cd /root/.openclaw/workspace/trojan-obfuscation
+git add \
+  client/lib/features/profiles/presentation/high_frequency_actions_strip.dart \
+  client/test/features/profiles/presentation/high_frequency_actions_strip_test.dart
+git commit -m "feat(client): add last-good quick retry button to hf strip"
+```
+
+---
+
+# 任务 3：先写 Profiles quick retry 的失败测试（红）并验证
+
+**文件：**
+- 修改：`client/test/features/profiles/presentation/profiles_page_action_gating_test.dart`
+- 随后实现会修改：`client/lib/features/controller/application/client_controller_api.dart`
+  `client/lib/features/controller/application/fake_client_controller.dart`
+  `client/lib/features/profiles/presentation/profiles_page.dart`
+
+## 3.1 测试支撑 controller（在测试文件内新增 stub controller）
+
+- [ ] **步骤 1：在 test 文件内新增一个可控 controller：提供 lastKnownGoodProfileId 且能记录 connect 的 profileId**
+
+在 `profiles_page_action_gating_test.dart`（靠近其他 `_XxxController`）新增：
+
+```dart
+class _LastKnownGoodController extends FakeClientController {
+  _LastKnownGoodController({
+    required this.lastGoodProfileId,
+  });
+
+  final String lastGoodProfileId;
+  String? lastConnectProfileId;
+
+  @override
+  String? get lastKnownGoodProfileId => lastGoodProfileId;
+
+  @override
+  Future<ControllerCommandResult> connect(ClientProfile profile) async {
+    lastConnectProfileId = profile.id;
+    return super.connect(profile);
+  }
+}
+```
+
+- [ ] **步骤 2：编写失败测试：点击 quick retry 会切 selected 并触发 connect(lastGood)**
+
+追加 test：
+
+```dart
+  testWidgets('quick retry (last good) switches selected profile then connects',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+
+    final controller = _LastKnownGoodController(lastGoodProfileId: 'sample-hk-2');
+    final services = _buildServices(controllerOverride: controller);
+
+    final first = services.profileStore.profiles.first;
+    final lastGood = services.profileStore.profiles
+        .firstWhere((p) => p.id == 'sample-hk-2');
+
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: first.id,
+      password: 'secret-1',
+    );
+    await services.profileSecrets.saveTrojanPassword(
+      profileId: lastGood.id,
+      password: 'secret-2',
+    );
+    services.profileStore.upsertProfile(first.copyWith(hasStoredPassword: true));
+    services.profileStore
+        .upsertProfile(lastGood.copyWith(hasStoredPassword: true));
+
+    services.profileStore.selectProfile(first.id);
+    expect(services.profileStore.selectedProfileId, first.id);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ProfilesPage(services: services)),
+      ),
+    );
+    await tester.pump();
+
+    final retryButton = find.widgetWithText(
+      OutlinedButton,
+      'Quick Retry (Last Good)',
+    );
+    await tester.ensureVisible(retryButton);
+    await tester.tap(retryButton);
+
+    // allow controller connect delays in FakeClientController
+    await tester.pump(const Duration(milliseconds: 20));
+
+    // Semantics A: selected must switch immediately.
+    expect(services.profileStore.selectedProfileId, lastGood.id);
+
+    // connect should be invoked for lastGood.
+    expect(controller.lastConnectProfileId, lastGood.id);
+  });
+```
+
+- [ ] **步骤 3：运行测试验证失败（红灯）**
+
+运行：
+
+```bash
+cd client
+flutter test test/features/profiles/presentation/profiles_page_action_gating_test.dart
+```
+
+预期：FAIL，原因之一应为：
+- `ClientControllerApi` 没有 `lastKnownGoodProfileId` getter
+- `ProfilesPage` 未渲染按钮
+- 或未切 selected / 未触发 connect。
+
+---
+
+# 任务 4：实现 controller API 暴露 lastKnownGoodProfileId（绿）并验证
+
+**文件：**
+- 修改：`client/lib/features/controller/application/client_controller_api.dart`
+- 修改：`client/lib/features/controller/application/adapter_backed_client_controller.dart`
+- 修改：`client/lib/features/controller/application/fake_client_controller.dart`
+
+- [ ] **步骤 1：在 ClientControllerApi 增加默认 getter**
+
+在 `ClientControllerApi` 增加：
+
+```dart
+  String? get lastKnownGoodProfileId => null;
+```
+
+- [ ] **步骤 2：AdapterBackedClientController override**
+
+在类内增加：
+
+```dart
+  @override
+  String? get lastKnownGoodProfileId => _lastKnownGoodProfileId;
+```
+
+- [ ] **步骤 3：FakeClientController override（默认 null）**
+
+```dart
+  @override
+  String? get lastKnownGoodProfileId => null;
+```
+
+- [ ] **步骤 4：运行 quick retry 测试验证仍失败但失败点前移正确**
+
+```bash
+cd client
+flutter test test/features/profiles/presentation/profiles_page_action_gating_test.dart
+```
+
+预期：依然 FAIL（因为 UI 还没接入），但不再报“getter 不存在”。
+
+- [ ] **步骤 5：Commit**
+
+```bash
+cd /root/.openclaw/workspace/trojan-obfuscation
+git add \
+  client/lib/features/controller/application/client_controller_api.dart \
+  client/lib/features/controller/application/adapter_backed_client_controller.dart \
+  client/lib/features/controller/application/fake_client_controller.dart
+git commit -m "feat(client): expose last known good profile id on controller api"
+```
+
+---
+
+# 任务 5：实现 ProfilesPage quick retry（含 preflight profileOverride）让测试通过（绿）
+
+**文件：**
+- 修改：`client/lib/features/profiles/presentation/profiles_page.dart`
+
+- [ ] **步骤 1：改造 readiness preflight 支持 profileOverride**
+
+将：
+
+```dart
+Future<bool> _runConnectReadinessPreflight({ required ScaffoldMessengerState messenger })
+```
+
+改成：
+
+```dart
+Future<bool> _runConnectReadinessPreflight({
+  required ScaffoldMessengerState messenger,
+  ClientProfile? profileOverride,
+})
+```
+
+并在内部使用：
+
+```dart
+final targetProfile = profileOverride ?? selected;
+final readinessReport = await services.readiness.buildReport(
+  profileOverride: targetProfile,
+);
+```
+
+- [ ] **步骤 2：在 ProfilesPage 构建 lastGoodProfile + handler**
+
+在 `HighFrequencyActionsStrip(...)` 参数中新增：
+- 计算：
+
+```dart
+final lastGoodId = services.controller.lastKnownGoodProfileId;
+final lastGoodProfile = (lastGoodId == null)
+    ? null
+    : services.profileStore.profiles
+        .cast<ClientProfile?>()
+        .firstWhere((p) => p?.id == lastGoodId, orElse: () => null);
+final canQuickRetryLastGood = lastGoodProfile != null &&
+    lastGoodProfile.id != selected.id &&
+    status.phase != ClientConnectionPhase.connected;
+```
+
+- 传入 strip：
+
+```dart
+onQuickRetryLastGood: !canQuickRetryLastGood
+    ? null
+    : () async {
+        final messenger = ScaffoldMessenger.of(context);
+
+        // Semantics A: switch selected first.
+        services.profileStore.selectProfile(lastGoodProfile.id);
+
+        final allowed = await _runConnectReadinessPreflight(
+          messenger: messenger,
+          profileOverride: lastGoodProfile,
+        );
+        if (!mounted || !allowed) {
+          return;
+        }
+
+        final result = await services.controller.connect(lastGoodProfile);
+        if (!mounted) return;
+        final feedback = buildRuntimeActionFeedback(
+          action: RuntimeActionKind.retry,
+          result: result,
+          status: services.controller.status,
+          session: services.controller.session,
+          posture: _runtimePosture,
+        );
+        messenger.showSnackBar(SnackBar(content: Text(feedback)));
+      },
+```
+
+注意：strip 仍保持 `enabled: connectionPolicy.canToggleConnection`（不绕过 action-safety gating）。
+
+- [ ] **步骤 3：运行 ProfilesPage gating tests 验证通过（绿）**
+
+```bash
+cd client
+flutter test test/features/profiles/presentation/profiles_page_action_gating_test.dart
+```
+
+预期：PASS。
+
+- [ ] **步骤 4：Commit**
+
+```bash
+cd /root/.openclaw/workspace/trojan-obfuscation
+git add client/lib/features/profiles/presentation/profiles_page.dart
+git commit -m "feat(client): quick retry last known good profile from profiles hf strip"
+```
+
+---
+
+# 任务 6：补一条 blocked preflight 的 quick retry 测试（红→绿）
+
+**文件：**
+- 修改：`client/test/features/profiles/presentation/profiles_page_action_gating_test.dart`
+
+- [ ] **步骤 1：新增失败测试：last-good readiness blocked 时不 connect，且出现 blocked copy**
+
+示例（基于 lastGood profile 设置 `serverHost: ''` 触发 readiness blocked）：
+
+```dart
+  testWidgets('quick retry (last good) enforces readiness preflight and blocks connect',
+      (WidgetTester tester) async {
+    await _setDesktopSurface(tester);
+
+    final controller = _LastKnownGoodController(lastGoodProfileId: 'sample-hk-2');
+    final services = _buildServices(controllerOverride: controller);
+
+    final first = services.profileStore.profiles.first;
+    final lastGood = services.profileStore.profiles
+        .firstWhere((p) => p.id == 'sample-hk-2');
+
+    await services.profileSecrets.saveTrojanPassword(profileId: first.id, password: 'secret-1');
+    await services.profileSecrets.saveTrojanPassword(profileId: lastGood.id, password: 'secret-2');
+
+    services.profileStore.upsertProfile(first.copyWith(hasStoredPassword: true));
+    services.profileStore.upsertProfile(
+      lastGood.copyWith(
+        hasStoredPassword: true,
+        serverHost: '',
+      ),
+    );
+
+    services.profileStore.selectProfile(first.id);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: ProfilesPage(services: services)),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Quick Retry (Last Good)'));
+    await tester.pump(const Duration(milliseconds: 360));
+
+    expect(find.textContaining('Connect blocked:'), findsOneWidget);
+    expect(find.textContaining('Next action:'), findsOneWidget);
+
+    // Should not have attempted connect.
+    expect(controller.lastConnectProfileId, isNull);
+  });
+```
+
+- [ ] **步骤 2：运行测试验证失败（红灯）**
+
+```bash
+cd client
+flutter test test/features/profiles/presentation/profiles_page_action_gating_test.dart
+```
+
+- [ ] **步骤 3：最少修正实现让测试通过（若需要）**
+
+若实现已正确 preflight，此步应无需代码变更；如失败，修正 blocked 分支确保 early return。
+
+- [ ] **步骤 4：运行测试验证通过（绿灯）**
+
+同上命令，预期：PASS。
+
+- [ ] **步骤 5：Commit**
+
+```bash
+cd /root/.openclaw/workspace/trojan-obfuscation
+git add client/test/features/profiles/presentation/profiles_page_action_gating_test.dart
+git commit -m "test(client): cover last-good quick retry readiness blocked path"
+```
+
+---
+
+# 任务 7：最终验证与收口
+
+- [ ] **步骤 1：按 issue #51 的证据命令跑全**
+
+```bash
+cd client
+flutter test test/features/profiles/presentation/high_frequency_actions_strip_test.dart
+flutter test test/features/profiles/presentation/profiles_page_action_gating_test.dart
+```
+
+预期：全部 PASS。
+
+- [ ] **步骤 2：flutter analyze（可选但建议）**
+
+```bash
+cd client
+flutter analyze
+```
+
+预期：无 error。
+
+- [ ] **步骤 3：gh issue #51 回填证据并关单（在 PR 阶段做）**
+
+在 PR 描述中粘贴两条测试输出（或 CI 通过链接），确认满足 acceptance criteria。
+
+---
+
+## 自检（writing-plans）
+
+- 覆盖度：计划覆盖 #51 要求的 last-known-good affordance、readiness preflight、truth-safe feedback、两条指定测试证据。
+- 无占位符：所有步骤提供具体代码片段、命令与预期。
+- 类型一致：字段名 `lastKnownGoodProfileId`、回调名 `onQuickRetryLastGood`、文案 `Quick Retry (Last Good)` 在全计划保持一致。

--- a/docs/superpowers/specs/2026-04-22-iter3-last-known-good-retry-design.md
+++ b/docs/superpowers/specs/2026-04-22-iter3-last-known-good-retry-design.md
@@ -1,0 +1,118 @@
+# Iter-3: Profiles 高频动作条的 last-known-good retry 设计规格（Option 1 + Semantics A）
+
+- 日期：2026-04-22
+- 关联 issue：#51（High-frequency actions stability & truthful quick-path closure）
+- 目标：在 Profiles 页 `HighFrequencyActionsStrip` 增加 **Quick Retry (Last Good)** 入口，且在 runtime-truth / readiness / action-safety 约束下 **稳定、可解释、不可误导**。
+
+---
+
+## 1. 背景
+
+Iter-3 的 daily-use 口径要求：高频动作必须 deterministic，且 UI 文案不得在 runtime/session truth 未确认前宣称成功。
+
+当前现状：
+- Profiles 页已存在 `HighFrequencyActionsStrip`（Quick Connect/Disconnect/Switch）。
+- Controller 边界 `AdapterBackedClientController` 内已有 `_lastKnownGoodProfileId`：当 routing mini smoke 成功后写入，并持久化到 routing safety state。
+- 但 UI 尚未暴露一个显式的“回到上次成功配置”快捷入口。
+
+---
+
+## 2. 设计目标（What good looks like）
+
+1) **入口位置固定**：按钮在 Profiles 页的高频动作条（HF strip）出现。
+2) **语义清晰且不漂移**：用户点击后，UI 与连接目标一致（不出现“看着 A 详情连着 B”的漂移）。
+3) **不绕过门禁**：readiness preflight / runtime truth / action-safety gating 均必须执行。
+4) **反馈 truthful**：不在 session truth 未确认前宣称已连接成功。
+5) **可测证据**：补齐/扩展 widget test，形成可复现的 gate evidence。
+
+---
+
+## 3. 方案对比（Decision record）
+
+### 方案 1（采用）：UI 驱动 + controller 只读暴露 `lastKnownGoodProfileId`
+- `ClientControllerApi` 增加只读 getter：`String? get lastKnownGoodProfileId`
+- `AdapterBackedClientController` override 返回 `_lastKnownGoodProfileId`
+- Profiles UI 通过 profileStore 查找对应 profile，并按 gating 执行 retry
+
+**理由**：边界清晰、改动小、controller 不依赖 profileStore，可测性强。
+
+### 方案 2：controller 提供 `connectLastKnownGood()`
+**不采用**：会迫使 controller 了解 profileStore/secret，边界污染。
+
+### 方案 3：lastKnownGood 迁移到 profileStore
+**不采用**：与 routing safety state 重复，容易口径漂移。
+
+---
+
+## 4. 点击语义（User-confirmed Semantics A）
+
+用户确认采用 **A**：
+
+> 点击 `Quick Retry (Last Good)` 后：
+> 1) 先将 selected profile 切换到 last-known-good
+> 2) 对 last-known-good profile 跑 readiness preflight
+> 3) allowed 才执行 connect(last-known-good)
+
+### 为什么必须先切 selected
+- 避免“Profile details 显示 A，但实际连接 B”的语义漂移。
+- 与 Profiles 页现有状态展示与 gating 逻辑保持一致。
+
+---
+
+## 5. UI/可见性规则
+
+### 5.1 按钮渲染条件（建议）
+按钮 `Quick Retry (Last Good)` 出现需满足：
+- `services.controller.lastKnownGoodProfileId != null`
+- profileStore 可找到对应 profile
+- `lastKnownGoodProfileId != selected.id`
+
+### 5.2 按钮启用条件（门禁）
+- 继续服从 HF strip 现有 `enabled: connectionPolicy.canToggleConnection`
+- 额外建议：当 `status.phase == connected` 时，quick retry handler 为 `null`（不提供“连着时重试”的歧义路径）
+
+---
+
+## 6. Readiness preflight 复用（避免绕过）
+
+将 `_runConnectReadinessPreflight()` 扩展为支持 `profileOverride`：
+- 默认使用当前 `selected`
+- quick retry 传入 `profileOverride: lastGoodProfile`
+
+blocked 反馈保持一致（复用既有 copy 结构）：
+- `Connect blocked: <summary> Next action: <label>`
+
+---
+
+## 7. 反馈文案（truth-safe）
+
+快速重试路径完成后：
+- 使用 `buildRuntimeActionFeedback(action: RuntimeActionKind.retry, ...)`
+- 不自行拼“Connected!” 之类文案，避免与 runtime truth 冲突。
+
+---
+
+## 8. 需要修改/新增的文件
+
+- `client/lib/features/controller/application/client_controller_api.dart`
+- `client/lib/features/controller/application/adapter_backed_client_controller.dart`
+- `client/lib/features/profiles/presentation/high_frequency_actions_strip.dart`
+- `client/lib/features/profiles/presentation/profiles_page.dart`
+- `client/test/features/profiles/presentation/high_frequency_actions_strip_test.dart`
+- `client/test/features/profiles/presentation/profiles_page_action_gating_test.dart`
+
+---
+
+## 9. 验证（Evidence commands）
+
+满足 issue #51 证据要求：
+- `flutter test test/features/profiles/presentation/high_frequency_actions_strip_test.dart`
+- `flutter test test/features/profiles/presentation/profiles_page_action_gating_test.dart`
+
+---
+
+## 10. Non-goals（本次不做）
+
+- 不新增 controller 写路径或改变 `_lastKnownGoodProfileId` 写入策略。
+- 不改变 Iter-3 既有 runtime truth 判定口径。
+- 不新增 telemetry 事件（可后续按指标口径再补）。


### PR DESCRIPTION
## 摘要\n- Profiles 高频动作条新增 **Quick Retry (Last Good)**（语义 A：先切 selected → preflight(profileOverride) → connect(lastGood)）\n- Controller API 只读暴露 lastKnownGoodProfileId，UI 侧用 profileStore 解析并执行 gated retry\n- Readiness preflight helper 支持 profileOverride\n- 补齐 widget tests：success 路径 + readiness blocked 路径\n\n## 测试计划\n- [x] cd client && flutter test test/features/profiles/presentation/high_frequency_actions_strip_test.dart\n- [x] cd client && flutter test test/features/profiles/presentation/profiles_page_action_gating_test.dart\n- [x] cd client && flutter analyze\n\n## 关联\n- issue #51\n- spec: docs/superpowers/specs/2026-04-22-iter3-last-known-good-retry-design.md\n