### PR TITLE
feat(perf): daily action baseline + regression guardrails

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -43,6 +43,11 @@ jobs:
         run: |
           ctest --test-dir build/ci --output-on-failure -j"$(nproc)"
 
+      - name: Python perf baseline gate (synthetic fixtures)
+        run: |
+          python3 -m pip install --user pytest
+          python3 -m pytest scripts/tests/test_compute_daily_action_perf_baseline.py -q
+
   flutter-client-gate:
     runs-on: ubuntu-22.04
     name: Flutter client gate (domain/application)

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ trojan
 # Config files
 *.json
 
+# Keep test fixtures (scripts/tests/fixtures/*.json) versioned for CI evidence.
+!scripts/tests/fixtures/*.json
+
 # Key and certificate files
 *.pem
 

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ packaging/linux/staging/
 # Python cache
 scripts/__pycache__/
 *.pyc
+
+# Git worktrees
+.worktrees/

--- a/client/test/features/controller/domain/controller_runtime_session_test.dart
+++ b/client/test/features/controller/domain/controller_runtime_session_test.dart
@@ -1,82 +1,24 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
 
+import '../../../testing/runtime_truth_expectations.dart';
+
 void main() {
-  test('marks recently refreshed running session as live', () {
-    final session = ControllerRuntimeSession(
-      isRunning: true,
-      updatedAt: DateTime.now().subtract(const Duration(seconds: 5)),
-      phase: ControllerRuntimePhase.sessionReady,
-      expectedLocalSocksPort: 10808,
-    );
+  for (final truth in iter3TruthStates) {
+    test('truth expectations stay consistent for ${truth.name}', () {
+      final session = buildSessionForTruth(truth);
+      final expectation = runtimeTruthExpectationFor(truth);
 
-    expect(session.truth, ControllerRuntimeSessionTruth.live);
-    expect(session.truth.label, 'Live');
-  });
+      expect(session.truth, truth);
+      expect(session.truth.label, expectation.label);
+      expect(session.needsAttention, expectation.needsAttention);
 
-  test('marks older running session as stale', () {
-    final session = ControllerRuntimeSession(
-      isRunning: true,
-      updatedAt: DateTime.now().subtract(const Duration(minutes: 5)),
-      phase: ControllerRuntimePhase.sessionReady,
-      expectedLocalSocksPort: 10808,
-    );
-
-    expect(session.truth, ControllerRuntimeSessionTruth.stale);
-    expect(session.truthNote, contains('stale'));
-  });
-
-  test('marks non-running non-stopped session as residual snapshot', () {
-    final session = ControllerRuntimeSession(
-      isRunning: false,
-      updatedAt: DateTime.now().subtract(const Duration(minutes: 1)),
-      phase: ControllerRuntimePhase.sessionReady,
-      expectedLocalSocksPort: 10808,
-    );
-
-    expect(session.truth, ControllerRuntimeSessionTruth.residual);
-    expect(session.truth.label, 'Residual snapshot');
-  });
-
-  test('marks stop-requested session as stopping', () {
-    final session = ControllerRuntimeSession(
-      isRunning: true,
-      updatedAt: DateTime.now().subtract(const Duration(seconds: 20)),
-      phase: ControllerRuntimePhase.alive,
-      stopRequested: true,
-      stopRequestedAt: DateTime.now().subtract(const Duration(seconds: 10)),
-      expectedLocalSocksPort: 10808,
-    );
-
-    expect(session.truth, ControllerRuntimeSessionTruth.stopping);
-    expect(session.truthNote, contains('stop request'));
-    expect(session.needsAttention, isTrue);
-    expect(session.recoveryGuidance, contains('exit confirmation'));
-  });
-
-  test('does not mark live session as needing attention', () {
-    final session = ControllerRuntimeSession(
-      isRunning: true,
-      updatedAt: DateTime.now().subtract(const Duration(seconds: 3)),
-      phase: ControllerRuntimePhase.sessionReady,
-      expectedLocalSocksPort: 10808,
-    );
-
-    expect(session.truth, ControllerRuntimeSessionTruth.live);
-    expect(session.needsAttention, isFalse);
-    expect(session.recoveryGuidance, contains('No recovery action'));
-  });
-
-  test('gives recovery guidance for residual snapshot state', () {
-    final session = ControllerRuntimeSession(
-      isRunning: false,
-      updatedAt: DateTime.now().subtract(const Duration(minutes: 1)),
-      phase: ControllerRuntimePhase.sessionReady,
-      expectedLocalSocksPort: 10808,
-    );
-
-    expect(session.truth, ControllerRuntimeSessionTruth.residual);
-    expect(session.needsAttention, isTrue);
-    expect(session.recoveryGuidance, contains('retry from Profiles'));
-  });
+      for (final token in expectation.truthNoteContains) {
+        expect(session.truthNote, contains(token));
+      }
+      for (final token in expectation.recoveryGuidanceContains) {
+        expect(session.recoveryGuidance, contains(token));
+      }
+    });
+  }
 }

--- a/client/test/testing/runtime_truth_expectations.dart
+++ b/client/test/testing/runtime_truth_expectations.dart
@@ -1,0 +1,145 @@
+import 'package:trojan_pro_client/features/controller/domain/controller_runtime_session.dart';
+
+/// Shared expectations for runtime truth messaging.
+///
+/// Iter-3 requires cross-surface truth consistency. Widget/domain tests should
+/// prefer these expectations over hard-coded strings to reduce future drift.
+class RuntimeTruthExpectation {
+  const RuntimeTruthExpectation({
+    required this.truth,
+    required this.label,
+    required this.needsAttention,
+    required this.truthNoteContains,
+    required this.recoveryGuidanceContains,
+  });
+
+  final ControllerRuntimeSessionTruth truth;
+  final String label;
+  final bool needsAttention;
+  final List<String> truthNoteContains;
+  final List<String> recoveryGuidanceContains;
+}
+
+/// Iter-3 truth states that must stay consistent across product surfaces.
+const List<ControllerRuntimeSessionTruth> iter3TruthStates =
+    <ControllerRuntimeSessionTruth>[
+  ControllerRuntimeSessionTruth.live,
+  ControllerRuntimeSessionTruth.aging,
+  ControllerRuntimeSessionTruth.stale,
+  ControllerRuntimeSessionTruth.residual,
+  ControllerRuntimeSessionTruth.stopping,
+];
+
+const Map<ControllerRuntimeSessionTruth, RuntimeTruthExpectation>
+    runtimeTruthExpectations =
+    <ControllerRuntimeSessionTruth, RuntimeTruthExpectation>{
+  ControllerRuntimeSessionTruth.live: RuntimeTruthExpectation(
+    truth: ControllerRuntimeSessionTruth.live,
+    label: 'Live',
+    needsAttention: false,
+    truthNoteContains: <String>[
+      'recently refreshed',
+    ],
+    recoveryGuidanceContains: <String>[
+      'No recovery action',
+    ],
+  ),
+  ControllerRuntimeSessionTruth.aging: RuntimeTruthExpectation(
+    truth: ControllerRuntimeSessionTruth.aging,
+    label: 'Aging',
+    needsAttention: true,
+    truthNoteContains: <String>[
+      'getting older',
+    ],
+    recoveryGuidanceContains: <String>[
+      'open Troubleshooting',
+    ],
+  ),
+  ControllerRuntimeSessionTruth.stale: RuntimeTruthExpectation(
+    truth: ControllerRuntimeSessionTruth.stale,
+    label: 'Stale',
+    needsAttention: true,
+    truthNoteContains: <String>[
+      'stale',
+    ],
+    recoveryGuidanceContains: <String>[
+      'revalidate',
+      'disconnect and reconnect',
+    ],
+  ),
+  ControllerRuntimeSessionTruth.residual: RuntimeTruthExpectation(
+    truth: ControllerRuntimeSessionTruth.residual,
+    label: 'Residual snapshot',
+    needsAttention: true,
+    truthNoteContains: <String>[
+      'residual state',
+    ],
+    recoveryGuidanceContains: <String>[
+      'leftover session state',
+      'retry from Profiles',
+    ],
+  ),
+  ControllerRuntimeSessionTruth.stopping: RuntimeTruthExpectation(
+    truth: ControllerRuntimeSessionTruth.stopping,
+    label: 'Stopping',
+    needsAttention: true,
+    truthNoteContains: <String>[
+      'exit confirmation',
+    ],
+    recoveryGuidanceContains: <String>[
+      'exit confirmation',
+    ],
+  ),
+};
+
+RuntimeTruthExpectation runtimeTruthExpectationFor(
+  ControllerRuntimeSessionTruth truth,
+) {
+  return runtimeTruthExpectations[truth]!;
+}
+
+ControllerRuntimeSession buildSessionForTruth(
+  ControllerRuntimeSessionTruth truth,
+) {
+  final now = DateTime.now();
+
+  return switch (truth) {
+    ControllerRuntimeSessionTruth.live => ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: now.subtract(const Duration(seconds: 5)),
+        phase: ControllerRuntimePhase.sessionReady,
+        expectedLocalSocksPort: 10808,
+      ),
+    ControllerRuntimeSessionTruth.aging => ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: now.subtract(const Duration(seconds: 45)),
+        phase: ControllerRuntimePhase.sessionReady,
+        expectedLocalSocksPort: 10808,
+      ),
+    ControllerRuntimeSessionTruth.stale => ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: now.subtract(const Duration(minutes: 5)),
+        phase: ControllerRuntimePhase.sessionReady,
+        expectedLocalSocksPort: 10808,
+      ),
+    ControllerRuntimeSessionTruth.residual => ControllerRuntimeSession(
+        isRunning: false,
+        updatedAt: now.subtract(const Duration(minutes: 1)),
+        phase: ControllerRuntimePhase.sessionReady,
+        expectedLocalSocksPort: 10808,
+      ),
+    ControllerRuntimeSessionTruth.stopping => ControllerRuntimeSession(
+        isRunning: true,
+        updatedAt: now.subtract(const Duration(seconds: 20)),
+        phase: ControllerRuntimePhase.alive,
+        stopRequested: true,
+        stopRequestedAt: now.subtract(const Duration(seconds: 10)),
+        expectedLocalSocksPort: 10808,
+      ),
+    ControllerRuntimeSessionTruth.stopped => ControllerRuntimeSession(
+        isRunning: false,
+        updatedAt: now,
+        phase: ControllerRuntimePhase.stopped,
+      ),
+  };
+}

--- a/docs/metrics/v1.5.0-ux-metric-computation-spec.md
+++ b/docs/metrics/v1.5.0-ux-metric-computation-spec.md
@@ -82,3 +82,29 @@
 - `SSR/STE` 不退化，且至少一项提升
 
 同时满足连续两个候选窗口，判定本轮优化可收口。
+
+## 7. Daily-action performance baseline（Iter-3 perf guardrails）
+
+本节定义“高频动作性能基线”的证据与回归护栏口径。其目标是：在不依赖真实远端环境的前提下，让连接/切换等日常路径的性能退化能在 PR/CI 中被显式暴露。
+
+### 7.1 Baseline schema
+- 文件：`scripts/perf/compute_daily_action_perf_baseline.py`
+- schema：`PerfBaseline(schema_version=1, profile, samples[])`
+- 当前采样动作：`connect_preflight`
+  - `connect_ready_ms`：进程启动到本地 SOCKS 端口开始监听的耗时（代理“connect ready”）
+  - `cpu_time_ms`：采样时点的进程 CPU time（Linux /proc best-effort）
+  - `rss_kb`：采样时点的进程 RSS（Linux /proc best-effort）
+
+### 7.2 Regression policy (default)
+- `max_ready_ms_regression_ratio = 1.3`
+- `max_cpu_time_regression_ratio = 1.5`
+- `max_rss_regression_ratio = 1.5`
+
+说明：初始版本只做 fail-closed 的最小护栏；未来若需要 warn/soft gate，可在 policy 上扩展而不破坏 schema。
+
+### 7.3 Evidence / CI gate
+- CI 使用 synthetic fixtures 验证 schema + evaluation determinism：
+  - `python3 -m pytest scripts/tests/test_compute_daily_action_perf_baseline.py -q`
+  - fixtures 位于 `scripts/tests/fixtures/*.json`
+- human-run（可选）：本地可通过 `collect` 子命令生成 baseline artifact。
+

--- a/docs/v1.5.0-release-gates.md
+++ b/docs/v1.5.0-release-gates.md
@@ -64,6 +64,17 @@ Release truth validated by `python3 scripts/validate_client_release_truth.py` fo
   - `fcsr`: numerator=1, denominator=2, value=0.5
   - `hfe`: schema present (`t_action`, `n_steps`, `r_rework`, `index`)
   - `guardrails`: schema present (`ssr`, `ste`)
++
++## Gate 7 — Performance baseline + regression guardrails (daily actions)
++- [ ] baseline schema + collection script exists (human-run)
++- [ ] regression evaluation logic is deterministic + CI-visible via synthetic fixtures
++
++### Verification snapshot — 2026-04-23
++- python3 -m pytest `scripts/tests/test_compute_daily_action_perf_baseline.py` ✅
++- fixtures committed under `scripts/tests/fixtures/` ✅
++- optional local baseline collection:
++  - `./scripts/perf/compute_daily_action_perf_baseline.py collect --trojan-bin ./trojan --output /tmp/daily_action_baseline.json`
++  - note: collection is best-effort and intended for operator runs; CI uses synthetic fixtures.
 
 ---
 

--- a/scripts/perf/compute_daily_action_perf_baseline.py
+++ b/scripts/perf/compute_daily_action_perf_baseline.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Compute daily-action performance baselines and evaluate regressions.
+
+This script is deliberately split into two modes:
+
+1) collect: best-effort local measurement intended for human-driven runs.
+   The controlled run uses a Troj an client preflight loop (start process, wait
+   for local SOCKS port to listen), then captures CPU/memory snapshots.
+
+2) evaluate: deterministic regression evaluation used by CI via synthetic
+   fixtures. CI should not depend on a real trojan binary or GUI.
+
+The initial scope targets Iter-3 (Truthful Daily Use) perf guardrails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PerfSample:
+    """A single performance sample for one action."""
+
+    action: str
+    connect_ready_ms: int
+    cpu_time_ms: int
+    rss_kb: int
+    captured_at_utc: str
+
+
+@dataclass(frozen=True)
+class PerfBaseline:
+    schema_version: str
+    profile: str
+    samples: list[PerfSample]
+
+
+@dataclass(frozen=True)
+class ThresholdPolicy:
+    """Thresholds for regression evaluation.
+
+    We keep this policy intentionally small at first. The main goal is to make
+    regressions visible with explicit rationale.
+    """
+
+    schema_version: str
+    max_ready_ms_regression_ratio: float
+    max_cpu_time_regression_ratio: float
+    max_rss_regression_ratio: float
+
+
+@dataclass(frozen=True)
+class RegressionFinding:
+    metric: str
+    baseline: float
+    candidate: float
+    ratio: float
+    status: str  # pass|warn|fail
+    detail: str
+
+
+def _utc_now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _safe_ratio(candidate: float, baseline: float) -> float:
+    if baseline <= 0:
+        return float("inf") if candidate > 0 else 1.0
+    return candidate / baseline
+
+
+def _median(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    values_sorted = sorted(values)
+    mid = len(values_sorted) // 2
+    if len(values_sorted) % 2 == 1:
+        return float(values_sorted[mid])
+    return float(values_sorted[mid - 1] + values_sorted[mid]) / 2.0
+
+
+def _read_proc_stat(pid: int) -> tuple[int, int]:
+    """Return (utime_ticks, stime_ticks) from /proc/<pid>/stat.
+
+    Linux-only; collect mode is best-effort.
+    """
+
+    stat_path = Path(f"/proc/{pid}/stat")
+    parts = stat_path.read_text(encoding="utf-8").split()
+    # Fields: https://man7.org/linux/man-pages/man5/proc.5.html
+    utime = int(parts[13])
+    stime = int(parts[14])
+    return utime, stime
+
+
+def _read_proc_rss_kb(pid: int) -> int:
+    status_path = Path(f"/proc/{pid}/status")
+    for line in status_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("VmRSS:"):
+            # VmRSS:   12345 kB
+            tokens = line.split()
+            for token in tokens:
+                if token.isdigit():
+                    return int(token)
+    return 0
+
+
+def _ticks_to_ms(ticks: int) -> int:
+    hz = os.sysconf(os.sysconf_names["SC_CLK_TCK"])
+    return int((ticks / hz) * 1000)
+
+
+def _wait_port_listen(host: str, port: int, timeout_seconds: float) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.3):
+                return True
+        except OSError:
+            time.sleep(0.05)
+    return False
+
+
+def _choose_free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _terminate_process(proc: subprocess.Popen[bytes]) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        proc.send_signal(signal.SIGTERM)
+        proc.wait(timeout=2)
+        return
+    except Exception:
+        pass
+    try:
+        proc.kill()
+        proc.wait(timeout=2)
+    except Exception:
+        pass
+
+
+def collect_perf_sample(*, trojan_bin: str, timeout_seconds: float = 6.0) -> PerfSample:
+    """Collect one best-effort connect preflight sample.
+
+    We measure time-to-listen on a local SOCKS port as a proxy for "connect
+    ready". This is not the full network connect path (which would require a
+    live endpoint), but it is stable enough for a baseline and regression guard.
+    """
+
+    port = _choose_free_port()
+    tmp_dir = Path("/tmp")
+    config_path = tmp_dir / f"trojan-perf-{os.getpid()}-{int(time.time()*1000)}.json"
+
+    config = {
+        "run_type": "client",
+        "local_addr": "127.0.0.1",
+        "local_port": port,
+        "remote_addr": "example.com",
+        "remote_port": 443,
+        "password": ["demo-pass"],
+        "log_level": 1,
+        "ssl": {
+            "verify": True,
+            "verify_hostname": True,
+            "cert": "",
+            "sni": "example.com",
+            "alpn": ["h2", "http/1.1"],
+            "reuse_session": True,
+            "session_ticket": False,
+            "cipher": "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256",
+            "cipher_tls13": "TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256",
+            "curves": "",
+        },
+        "tcp": {
+            "no_delay": True,
+            "keep_alive": True,
+            "reuse_port": False,
+            "fast_open": False,
+            "fast_open_qlen": 20,
+        },
+    }
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    started = time.monotonic()
+    proc = subprocess.Popen(
+        [trojan_bin, "-c", str(config_path)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        pid = proc.pid
+        ok = _wait_port_listen("127.0.0.1", port, timeout_seconds=timeout_seconds)
+        ready_ms = int((time.monotonic() - started) * 1000)
+
+        # Best-effort snapshots.
+        cpu_ms = 0
+        rss_kb = 0
+        try:
+            utime, stime = _read_proc_stat(pid)
+            cpu_ms = _ticks_to_ms(utime + stime)
+            rss_kb = _read_proc_rss_kb(pid)
+        except Exception:
+            cpu_ms = 0
+            rss_kb = 0
+
+        if not ok:
+            # Still return a sample; caller can decide whether to keep it.
+            # We keep the schema stable for downstream evaluation.
+            pass
+
+        return PerfSample(
+            action="connect_preflight",
+            connect_ready_ms=ready_ms,
+            cpu_time_ms=cpu_ms,
+            rss_kb=rss_kb,
+            captured_at_utc=_utc_now_iso(),
+        )
+    finally:
+        _terminate_process(proc)
+        try:
+            config_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+
+def _baseline_medians(baseline: PerfBaseline) -> dict[str, float]:
+    ready = _median([float(s.connect_ready_ms) for s in baseline.samples])
+    cpu = _median([float(s.cpu_time_ms) for s in baseline.samples])
+    rss = _median([float(s.rss_kb) for s in baseline.samples])
+    return {
+        "connect_ready_ms": ready,
+        "cpu_time_ms": cpu,
+        "rss_kb": rss,
+    }
+
+
+def evaluate_regression(
+    *,
+    baseline: PerfBaseline,
+    candidate: PerfBaseline,
+    policy: ThresholdPolicy,
+) -> list[RegressionFinding]:
+    base = _baseline_medians(baseline)
+    cand = _baseline_medians(candidate)
+
+    findings: list[RegressionFinding] = []
+
+    def check(metric: str, max_ratio: float) -> None:
+        ratio = _safe_ratio(cand[metric], base[metric])
+        status = "pass"
+        if ratio > max_ratio:
+            status = "fail"
+        findings.append(
+            RegressionFinding(
+                metric=metric,
+                baseline=base[metric],
+                candidate=cand[metric],
+                ratio=ratio,
+                status=status,
+                detail=f"candidate/baseline={ratio:.3f} (max {max_ratio:.3f})",
+            )
+        )
+
+    check("connect_ready_ms", policy.max_ready_ms_regression_ratio)
+    check("cpu_time_ms", policy.max_cpu_time_regression_ratio)
+    check("rss_kb", policy.max_rss_regression_ratio)
+
+    return findings
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_baseline(path: Path) -> PerfBaseline:
+    payload = _load_json(path)
+    samples = [PerfSample(**sample) for sample in payload.get("samples", [])]
+    return PerfBaseline(
+        schema_version=str(payload.get("schema_version", "1")),
+        profile=str(payload.get("profile", "unknown")),
+        samples=samples,
+    )
+
+
+def _load_policy(path: Path) -> ThresholdPolicy:
+    payload = _load_json(path)
+    return ThresholdPolicy(
+        schema_version=str(payload.get("schema_version", "1")),
+        max_ready_ms_regression_ratio=float(
+            payload.get("max_ready_ms_regression_ratio", 1.3)
+        ),
+        max_cpu_time_regression_ratio=float(
+            payload.get("max_cpu_time_regression_ratio", 1.5)
+        ),
+        max_rss_regression_ratio=float(payload.get("max_rss_regression_ratio", 1.5)),
+    )
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def cmd_collect(args: argparse.Namespace) -> int:
+    samples: list[PerfSample] = []
+    for _ in range(int(args.runs)):
+        samples.append(
+            collect_perf_sample(
+                trojan_bin=args.trojan_bin,
+                timeout_seconds=float(args.timeout_seconds),
+            )
+        )
+
+    baseline = PerfBaseline(schema_version="1", profile=str(args.profile), samples=samples)
+    _write_json(Path(args.output), asdict(baseline))
+
+    summary = {
+        "schema_version": baseline.schema_version,
+        "profile": baseline.profile,
+        "runs": len(samples),
+        "medians": _baseline_medians(baseline),
+    }
+    if args.summary:
+        _write_json(Path(args.summary), summary)
+
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    return 0
+
+
+def cmd_evaluate(args: argparse.Namespace) -> int:
+    baseline = _load_baseline(Path(args.baseline))
+    candidate = _load_baseline(Path(args.candidate))
+    policy = _load_policy(Path(args.policy))
+
+    findings = evaluate_regression(baseline=baseline, candidate=candidate, policy=policy)
+    out = {
+        "baseline": {
+            "profile": baseline.profile,
+            "medians": _baseline_medians(baseline),
+        },
+        "candidate": {
+            "profile": candidate.profile,
+            "medians": _baseline_medians(candidate),
+        },
+        "policy": asdict(policy),
+        "findings": [asdict(f) for f in findings],
+        "passed": all(f.status == "pass" for f in findings),
+    }
+
+    if args.output:
+        _write_json(Path(args.output), out)
+
+    print(json.dumps(out, indent=2, ensure_ascii=False))
+    return 0 if out["passed"] else 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    collect = sub.add_parser("collect", help="collect a local perf baseline")
+    collect.add_argument("--trojan-bin", required=True, help="path to trojan binary")
+    collect.add_argument("--profile", default="local", help="profile label")
+    collect.add_argument("--runs", type=int, default=5, help="number of samples")
+    collect.add_argument("--timeout-seconds", type=float, default=6.0)
+    collect.add_argument("--output", required=True, help="baseline json output path")
+    collect.add_argument("--summary", help="optional summary json output path")
+    collect.set_defaults(func=cmd_collect)
+
+    evaluate = sub.add_parser("evaluate", help="evaluate regression baseline vs candidate")
+    evaluate.add_argument("--baseline", required=True, help="baseline json path")
+    evaluate.add_argument("--candidate", required=True, help="candidate json path")
+    evaluate.add_argument("--policy", required=True, help="threshold policy json path")
+    evaluate.add_argument("--output", help="optional evaluation output json path")
+    evaluate.set_defaults(func=cmd_evaluate)
+
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/fixtures/daily_action_perf_baseline_candidate_bad.json
+++ b/scripts/tests/fixtures/daily_action_perf_baseline_candidate_bad.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1",
+  "profile": "candidate",
+  "samples": [
+    {
+      "action": "connect_preflight",
+      "connect_ready_ms": 900,
+      "cpu_time_ms": 90,
+      "rss_kb": 40000,
+      "captured_at_utc": "2026-04-23T00:10:00Z"
+    },
+    {
+      "action": "connect_preflight",
+      "connect_ready_ms": 950,
+      "cpu_time_ms": 92,
+      "rss_kb": 41000,
+      "captured_at_utc": "2026-04-23T00:10:10Z"
+    },
+    {
+      "action": "connect_preflight",
+      "connect_ready_ms": 920,
+      "cpu_time_ms": 91,
+      "rss_kb": 40500,
+      "captured_at_utc": "2026-04-23T00:10:20Z"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/daily_action_perf_baseline_candidate_ok.json
+++ b/scripts/tests/fixtures/daily_action_perf_baseline_candidate_ok.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1",
+  "profile": "candidate",
+  "samples": [
+    {
+      "action": "connect_preflight",
+      "connect_ready_ms": 500,
+      "cpu_time_ms": 50,
+      "rss_kb": 20000,
+      "captured_at_utc": "2026-04-23T00:05:00Z"
+    },
+    {
+      "action": "connect_preflight",
+      "connect_ready_ms": 510,
+      "cpu_time_ms": 51,
+      "rss_kb": 20200,
+      "captured_at_utc": "2026-04-23T00:05:10Z"
+    },
+    {
+      "action": "connect_preflight",
+      "connect_ready_ms": 490,
+      "cpu_time_ms": 49,
+      "rss_kb": 20100,
+      "captured_at_utc": "2026-04-23T00:05:20Z"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/daily_action_perf_baseline_sample.json
+++ b/scripts/tests/fixtures/daily_action_perf_baseline_sample.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1",
+  "profile": "baseline",
+  "samples": [
+    {
+      "action": "connect_preflight",
+      "connect_ready_ms": 420,
+      "cpu_time_ms": 40,
+      "rss_kb": 18000,
+      "captured_at_utc": "2026-04-23T00:00:00Z"
+    },
+    {
+      "action": "connect_preflight",
+      "connect_ready_ms": 460,
+      "cpu_time_ms": 42,
+      "rss_kb": 18200,
+      "captured_at_utc": "2026-04-23T00:00:10Z"
+    },
+    {
+      "action": "connect_preflight",
+      "connect_ready_ms": 440,
+      "cpu_time_ms": 39,
+      "rss_kb": 18100,
+      "captured_at_utc": "2026-04-23T00:00:20Z"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/daily_action_perf_threshold_policy.json
+++ b/scripts/tests/fixtures/daily_action_perf_threshold_policy.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": "1",
+  "max_ready_ms_regression_ratio": 1.3,
+  "max_cpu_time_regression_ratio": 1.5,
+  "max_rss_regression_ratio": 1.5
+}

--- a/scripts/tests/test_compute_daily_action_perf_baseline.py
+++ b/scripts/tests/test_compute_daily_action_perf_baseline.py
@@ -1,0 +1,81 @@
+import importlib.util
+import pathlib
+import subprocess
+import sys
+
+_SCRIPT_PATH = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "perf"
+    / "compute_daily_action_perf_baseline.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "compute_daily_action_perf_baseline",
+    _SCRIPT_PATH,
+)
+_MODULE = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+
+# Mimic normal import semantics: insert into sys.modules before exec.
+# This is required for dataclasses + postponed annotations, which rely on
+# sys.modules[__module__] during class processing.
+sys.modules[_SPEC.name] = _MODULE
+
+_SPEC.loader.exec_module(_MODULE)
+
+PerfBaseline = _MODULE.PerfBaseline
+ThresholdPolicy = _MODULE.ThresholdPolicy
+_load_baseline = _MODULE._load_baseline
+_load_policy = _MODULE._load_policy
+_baseline_medians = _MODULE._baseline_medians
+_evaluate_regression = _MODULE.evaluate_regression
+
+_FIXTURES = pathlib.Path(__file__).resolve().parent / "fixtures"
+
+
+def test_fixture_loads_and_has_expected_schema():
+    baseline = _load_baseline(_FIXTURES / "daily_action_perf_baseline_sample.json")
+    assert baseline.schema_version == "1"
+    assert baseline.profile == "baseline"
+    assert len(baseline.samples) == 3
+
+    medians = _baseline_medians(baseline)
+    assert set(medians.keys()) == {"connect_ready_ms", "cpu_time_ms", "rss_kb"}
+
+
+def test_regression_evaluation_passes_within_thresholds():
+    baseline = _load_baseline(_FIXTURES / "daily_action_perf_baseline_sample.json")
+    candidate = _load_baseline(_FIXTURES / "daily_action_perf_baseline_candidate_ok.json")
+    policy = _load_policy(_FIXTURES / "daily_action_perf_threshold_policy.json")
+
+    findings = _evaluate_regression(baseline=baseline, candidate=candidate, policy=policy)
+    assert findings
+    assert all(f.status == "pass" for f in findings)
+
+
+def test_regression_evaluation_fails_when_over_threshold():
+    baseline = _load_baseline(_FIXTURES / "daily_action_perf_baseline_sample.json")
+    candidate = _load_baseline(_FIXTURES / "daily_action_perf_baseline_candidate_bad.json")
+    policy = _load_policy(_FIXTURES / "daily_action_perf_threshold_policy.json")
+
+    findings = _evaluate_regression(baseline=baseline, candidate=candidate, policy=policy)
+    assert any(f.status == "fail" for f in findings)
+
+
+def test_cli_evaluate_returns_nonzero_on_failure(tmp_path):
+    out_path = tmp_path / "eval.json"
+    cmd = [
+        sys.executable,
+        str(_SCRIPT_PATH),
+        "evaluate",
+        "--baseline",
+        str(_FIXTURES / "daily_action_perf_baseline_sample.json"),
+        "--candidate",
+        str(_FIXTURES / "daily_action_perf_baseline_candidate_bad.json"),
+        "--policy",
+        str(_FIXTURES / "daily_action_perf_threshold_policy.json"),
+        "--output",
+        str(out_path),
+    ]
+    proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    assert proc.returncode == 2
+    assert out_path.exists()

--- a/scripts/validate_iter3_perf_baseline.sh
+++ b/scripts/validate_iter3_perf_baseline.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+started_at_utc="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+branch="$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref HEAD)"
+commit_short="$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)"
+
+echo "== validate_iter3_perf_baseline =="
+echo "project_root=$PROJECT_ROOT"
+echo "branch=$branch"
+echo "commit=$commit_short"
+echo "started_at_utc=$started_at_utc"
+echo
+
+echo "[1/2] python tests (daily action perf baseline regression gate)"
+python3 -m pytest "$PROJECT_ROOT/scripts/tests/test_compute_daily_action_perf_baseline.py" -q
+echo "✅ [1/2] pass"
+echo
+
+finished_at_utc="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+echo "[2/2] done"
+echo "finished_at_utc=$finished_at_utc"
+echo
+
+echo "---"
+echo "Iter-3 performance baseline validation evidence"
+echo "- Script: ./scripts/validate_iter3_perf_baseline.sh"
+echo "- Branch: $branch"
+echo "- Commit: $commit_short"
+echo "- Started: $started_at_utc"
+echo "- Finished: $finished_at_utc"


### PR DESCRIPTION
Closes #53.

## What
- Adds a small perf baseline schema + collection/evaluation tool for daily actions.
- Adds deterministic regression evaluation + synthetic fixtures for CI visibility.
- Wires CI Smoke to execute the perf baseline pytest gate.

## Evidence
- python3 -m pytest scripts/tests/test_compute_daily_action_perf_baseline.py -q
- CI Smoke includes a Python perf baseline gate (synthetic fixtures) step.

## Key files
- scripts/perf/compute_daily_action_perf_baseline.py
- scripts/tests/test_compute_daily_action_perf_baseline.py
- scripts/tests/fixtures/daily_action_perf_*.json
- scripts/validate_iter3_perf_baseline.sh

## Docs
- docs/metrics/v1.5.0-ux-metric-computation-spec.md
- docs/v1.5.0-release-gates.md (Gate 7)
