### PR TITLE
ci(iter3): add truthful daily-use validation command bundle (close #54)

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -43,10 +43,9 @@ jobs:
         run: |
           ctest --test-dir build/ci --output-on-failure -j"$(nproc)"
 
-      - name: Python perf baseline gate (synthetic fixtures)
+      - name: Iter-3 truthful daily-use validation bundle
         run: |
-          python3 -m pip install --user pytest
-          python3 -m pytest scripts/tests/test_compute_daily_action_perf_baseline.py -q
+          ./scripts/validate_iter3_truthful_daily_use.sh
 
   flutter-client-gate:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -43,9 +43,6 @@ jobs:
         run: |
           ctest --test-dir build/ci --output-on-failure -j"$(nproc)"
 
-      - name: Iter-3 truthful daily-use validation bundle
-        run: |
-          ./scripts/validate_iter3_truthful_daily_use.sh
 
   flutter-client-gate:
     runs-on: ubuntu-22.04
@@ -60,6 +57,15 @@ jobs:
         with:
           channel: stable
           cache: false
+
+      - name: Install pytest (python)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pytest
+
+      - name: Iter-3 truthful daily-use validation bundle
+        run: |
+          ./scripts/validate_iter3_truthful_daily_use.sh
 
       - name: Flutter analyze + targeted tests
         working-directory: client

--- a/docs/desktop-validation-matrix.md
+++ b/docs/desktop-validation-matrix.md
@@ -12,6 +12,7 @@ Use this matrix to record durable, comparable results for **v1.6+ internal beta*
 - Build and Release (main): <https://github.com/proxy-trojan/trojan-obfuscation/actions/runs/24648027071>
 - Local command bundle (Iter-1): `./scripts/validate_iter1_first_connect.sh` (latest run: PASS)
 - Local command bundle (Iter-2): `./scripts/validate_iter2_recovery_ladder.sh` (latest run: PASS)
+- Local command bundle (Iter-3): `./scripts/validate_iter3_truthful_daily_use.sh` (latest run: PASS)
 
 ---
 

--- a/scripts/validate_iter3_truthful_daily_use.sh
+++ b/scripts/validate_iter3_truthful_daily_use.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLIENT_DIR="$PROJECT_ROOT/client"
+
+started_at_utc="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+branch="$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref HEAD)"
+commit_short="$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)"
+
+echo "== validate_iter3_truthful_daily_use =="
+echo "project_root=$PROJECT_ROOT"
+echo "branch=$branch"
+echo "commit=$commit_short"
+echo "started_at_utc=$started_at_utc"
+echo
+
+echo "[1/4] python tests (daily action perf baseline regression gate)"
+python3 -m pytest "$PROJECT_ROOT/scripts/tests/test_compute_daily_action_perf_baseline.py" -q
+echo "✅ [1/4] pass"
+echo
+
+echo "[2/4] flutter analyze (client)"
+(
+  cd "$CLIENT_DIR"
+  flutter analyze
+)
+echo "✅ [2/4] pass"
+echo
+
+echo "[3/4] flutter test (Iter-3 truthful daily-use key suite)"
+(
+  cd "$CLIENT_DIR"
+  flutter test \
+    test/features/profiles/presentation/high_frequency_actions_strip_test.dart \
+    test/features/controller/domain/controller_runtime_session_test.dart \
+    test/features/dashboard/presentation/dashboard_page_test.dart \
+    test/features/advanced/presentation/advanced_page_test.dart
+)
+echo "✅ [3/4] pass"
+echo
+
+finished_at_utc="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+echo "[4/4] done"
+echo "finished_at_utc=$finished_at_utc"
+echo
+
+echo "---"
+echo "Iter-3 truthful daily-use validation evidence"
+echo "- Script: ./scripts/validate_iter3_truthful_daily_use.sh"
+echo "- Branch: $branch"
+echo "- Commit: $commit_short"
+echo "- Started: $started_at_utc"
+echo "- Finished: $finished_at_utc"

--- a/scripts/validate_iter3_truthful_daily_use.sh
+++ b/scripts/validate_iter3_truthful_daily_use.sh
@@ -17,7 +17,6 @@ echo "started_at_utc=$started_at_utc"
 echo
 
 echo "[1/4] python tests (daily action perf baseline regression gate)"
-python3 -m pip install --user pytest
 python3 -m pytest "$PROJECT_ROOT/scripts/tests/test_compute_daily_action_perf_baseline.py" -q
 echo "✅ [1/4] pass"
 echo

--- a/scripts/validate_iter3_truthful_daily_use.sh
+++ b/scripts/validate_iter3_truthful_daily_use.sh
@@ -17,6 +17,7 @@ echo "started_at_utc=$started_at_utc"
 echo
 
 echo "[1/4] python tests (daily action perf baseline regression gate)"
+python3 -m pip install --user pytest
 python3 -m pytest "$PROJECT_ROOT/scripts/tests/test_compute_daily_action_perf_baseline.py" -q
 echo "✅ [1/4] pass"
 echo


### PR DESCRIPTION
Closes #54.

## What
- Adds Iter-3 one-command validation bundle: `./scripts/validate_iter3_truthful_daily_use.sh`.
- Bundle covers:
  - perf baseline pytest gate
  - flutter analyze
  - key Iter-3 client tests (HF actions + cross-surface truth consistency)
- CI Smoke now runs the bundle directly (single source of truth).

## Evidence
- `./scripts/validate_iter3_truthful_daily_use.sh` (prints branch/commit/start/end)
- CI Smoke run should show the bundle step executed.

## Files
- scripts/validate_iter3_truthful_daily_use.sh
- .github/workflows/ci-smoke.yml
- docs/desktop-validation-matrix.md
