### PR TITLE
feat(repo/install/config): cleanup tooling + bilingual docs + client bundle generator

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,22 @@
 # Trojan Documentation
 
-This directory only keeps the current, useful project documentation.
+This directory keeps current, actionable project documentation.
+
+## Bilingual entrypoints
+
+- 中文快速开始：`zh-CN/quickstart.md`
+- English quickstart: `en/quickstart.md`
+- 中文安装骨架：`zh-CN/install-kernel.md`
+- English install kernel: `en/install-kernel.md`
+- 中文配置生成：`zh-CN/config-generation.md`
+- English config generation: `en/config-generation.md`
+- Ops runbook: `ops/branch-cleanup.md`
+
+## Script index
+
+- `scripts/install/install-kernel.sh` — generic Linux installer kernel skeleton (check-only first)
+- `scripts/config/generate-client-bundle.py` — clash-rules to client import bundle generator
+- `scripts/repo/cleanup-branches.sh` — branch cleanup dry-run/apply helper
 
 ## Core docs
 

--- a/docs/en/config-generation.md
+++ b/docs/en/config-generation.md
@@ -1,0 +1,48 @@
+# Config generation
+
+This page explains how to convert clash-rules snapshots into an importable client bundle.
+
+## Config generation command
+
+```bash
+python3 scripts/config/generate-client-bundle.py \
+  --direct scripts/tests/fixtures/clash_rules_direct.sample.txt \
+  --proxy scripts/tests/fixtures/clash_rules_proxy.sample.txt \
+  --reject scripts/tests/fixtures/clash_rules_reject.sample.txt \
+  --output dist/client-import/trojan-pro-client-profile-sample.json
+```
+
+The artifact is written under `dist/client-import/`.
+
+## Output shape
+
+The generated bundle includes:
+- `kind=trojan-pro-client-profile`
+- `version=2`
+- `routing.policyGroups`
+- `routing.rules`
+
+## Client import
+
+- Open the client import UI
+- Choose the generated JSON artifact
+- Verify policy groups and rules are present
+- Replace placeholder server values with production values
+
+## ACME / DNS / 80 / 443 reminder
+
+This page focuses on **config generation**, but the imported profile is only useful if the server installation is healthy:
+- **DNS** must be correct
+- **ACME** must be able to issue certificates
+- Ports **80** / **443** must be reachable
+
+## Rule update
+
+The current model is not a live subscription. It is a regenerate-and-reimport workflow:
+
+1. refresh direct/proxy/reject rule snapshots
+2. run config generation again
+3. publish the updated JSON
+4. have clients re-import the latest bundle
+
+A CI or cron based **rule update** pipeline is the recommended approach.

--- a/docs/en/install-kernel.md
+++ b/docs/en/install-kernel.md
@@ -1,0 +1,48 @@
+# Install kernel
+
+`scripts/install/install-kernel.sh` is the generic Linux installer entry skeleton. It owns argument parsing and phase orchestration.
+
+## Supported install command
+
+```bash
+bash scripts/install/install-kernel.sh \
+  --domain example.com \
+  --email ops@example.com \
+  --password 'change-this-password' \
+  --check-only
+```
+
+Apply mode currently fails closed. Until real install logic lands, use `--check-only` only.
+
+## Phase layout
+
+- detect-os
+- install-deps
+- install-core
+- configure-caddy
+- write-runtime-config
+
+## ACME / DNS / 80 / 443
+
+- Before **ACME** issuance, confirm **DNS** resolves to the target host
+- Open **80** / **443** at both OS firewall and cloud/network edge
+- If another service already owns **80** or **443**, Caddy cannot complete issuance
+- Re-check DNS and ports after domain or host changes
+
+## Dependency on config generation and client import
+
+The installer kernel does not create the client routing bundle. For **client import**, run **config generation** separately:
+
+```bash
+python3 scripts/config/generate-client-bundle.py \
+  --direct scripts/tests/fixtures/clash_rules_direct.sample.txt \
+  --proxy scripts/tests/fixtures/clash_rules_proxy.sample.txt \
+  --reject scripts/tests/fixtures/clash_rules_reject.sample.txt \
+  --output dist/client-import/trojan-pro-client-profile-sample.json
+```
+
+## Rule update
+
+- Server installation and client routing refresh are separate flows
+- After rules change, re-run bundle generation and ask clients to re-import
+- A scheduled CI or cron job is the recommended **rule update** mechanism

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -1,0 +1,65 @@
+# Quickstart
+
+This page shows the shortest path: prepare a Linux host and domain, run the **install command**, then generate and import the client routing bundle.
+
+## 1. Prerequisites
+
+- A reachable Linux host
+- A domain with **DNS** pointing to the public IP of that host
+- An email address for **ACME** registration
+- Open **80** / **443** on the firewall and provider network layer
+
+## 2. Install command
+
+The current installer kernel is a safe skeleton. Start with `--check-only`:
+
+```bash
+bash scripts/install/install-kernel.sh \
+  --domain example.com \
+  --email ops@example.com \
+  --password 'change-this-password' \
+  --check-only
+```
+
+When apply mode is implemented in later work, follow the install runbook for real deployment.
+
+## 3. ACME notes
+
+- **ACME** issuance depends on correct **DNS**
+- Port **80** and **443** must be reachable
+- Make sure no other service is already binding **80** / **443**
+- Wait for DNS propagation before first issuance attempts
+
+## 4. Config generation
+
+Generate an importable client profile from clash-rules snapshots:
+
+```bash
+python3 scripts/config/generate-client-bundle.py \
+  --direct scripts/tests/fixtures/clash_rules_direct.sample.txt \
+  --proxy scripts/tests/fixtures/clash_rules_proxy.sample.txt \
+  --reject scripts/tests/fixtures/clash_rules_reject.sample.txt \
+  --output dist/client-import/trojan-pro-client-profile-sample.json
+```
+
+## 5. Client import
+
+- Open Trojan Pro Client
+- Go to the profile import flow
+- Select `dist/client-import/*.json`
+- Confirm the imported `routing.policyGroups` and `routing.rules`
+- Replace placeholder server fields with real production values
+
+## 6. Rule update
+
+The current model uses static bundles, not live subscriptions.
+
+Recommended **rule update** workflow:
+- run scheduled config generation in CI or cron
+- publish the latest JSON artifact
+- ask clients to re-import the refreshed bundle
+
+Related docs:
+- [Install kernel](./install-kernel.md)
+- [Config generation](./config-generation.md)
+- [Branch cleanup runbook](../ops/branch-cleanup.md)

--- a/docs/ops/branch-cleanup.md
+++ b/docs/ops/branch-cleanup.md
@@ -1,0 +1,35 @@
+# Branch cleanup runbook / 分支清理运维说明
+
+This page is bilingual by design.
+
+## Purpose / 目的
+
+Use `scripts/repo/cleanup-branches.sh` to review and prune local/remote branches safely.
+
+使用 `scripts/repo/cleanup-branches.sh` 安全查看并清理本地/远端分支。
+
+## Safe usage / 安全使用
+
+Dry-run first:
+
+```bash
+bash scripts/repo/cleanup-branches.sh
+```
+
+Apply only after review:
+
+```bash
+bash scripts/repo/cleanup-branches.sh --apply
+```
+
+## Notes / 注意事项
+
+- The script protects `main` and the current branch.
+- Detached HEAD refuses `--apply`.
+- Unmerged local branches are skipped instead of force deleted.
+- Stale remote-tracking refs are handled with summary output.
+
+- 脚本会保护 `main` 和当前分支。
+- detached HEAD 下拒绝 `--apply`。
+- 未合并的本地分支不会被强删，而是进入 skipped summary。
+- stale remote-tracking refs 会进入摘要输出，不会中途崩溃。

--- a/docs/superpowers/plans/2026-04-24-repo-cleanup-installer-routing-plan.md
+++ b/docs/superpowers/plans/2026-04-24-repo-cleanup-installer-routing-plan.md
@@ -1,0 +1,401 @@
+# Repo Cleanup + Installer + Routing Bundle 实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
+
+**目标：** 完成仓库分支清理（仅保留 main）、交付通用 Linux 一键安装内核脚本（Caddy ACME 自动签发）、生成可导入客户端的静态分流配置，并补齐中英双文档。
+
+**架构：** 采用“脚本分层 + 文档双语 + 规则离线快照”方案：仓库清理使用独立脚本并默认 dry-run；安装脚本以主入口 + lib 子模块组织，自动检测包管理器并写入 systemd/Caddy 配置；规则整合由 Python 生成器拉取 Loyalsoldier 规则并映射为客户端静态 RoutingProfile bundle。最终通过脚本自测与客户端导入契约测试闭环。
+
+**技术栈：** Bash（repo/install 脚本）、Python 3（规则转换与生成）、Git/GitHub CLI、Caddy ACME、Markdown（中英文档）
+
+---
+
+## 文件结构（先锁定职责）
+
+### 创建文件
+- `scripts/repo/cleanup-branches.sh`
+  - 职责：列举本地/远端分支，默认 dry-run，`--apply` 执行删除。
+- `scripts/install/install-kernel.sh`
+  - 职责：安装入口，串联检测、依赖安装、core 部署、Caddy 配置、服务启动与健康检查。
+- `scripts/install/lib/detect-os.sh`
+  - 职责：检测发行版与包管理器。
+- `scripts/install/lib/install-deps.sh`
+  - 职责：按包管理器安装依赖（curl/jq/caddy/systemd 相关）。
+- `scripts/install/lib/install-core.sh`
+  - 职责：下载并安装 trojan core，可幂等升级。
+- `scripts/install/lib/configure-caddy.sh`
+  - 职责：写 Caddyfile（ACME 自动签发/续期）并校验。
+- `scripts/install/lib/write-runtime-config.sh`
+  - 职责：写 trojan runtime config（由安装参数渲染）。
+- `scripts/config/generate-client-bundle.py`
+  - 职责：抓取 clash-rules、映射 RoutingRule、输出可导入 profile JSON。
+- `scripts/config/sources/clash-rules.lock`
+  - 职责：记录规则源版本（commit/date/url）。
+- `scripts/tests/test_generate_client_bundle.py`
+  - 职责：验证规则映射、输出 schema、优先级顺序。
+- `scripts/tests/fixtures/clash_rules_direct.sample.txt`
+- `scripts/tests/fixtures/clash_rules_proxy.sample.txt`
+- `scripts/tests/fixtures/clash_rules_reject.sample.txt`
+  - 职责：离线测试样本，避免测试依赖网络。
+- `docs/ops/branch-cleanup.md`
+  - 职责：分支清理使用与风险说明（中英双文同页分节）。
+- `docs/zh-CN/quickstart.md`
+- `docs/en/quickstart.md`
+  - 职责：中英快速上手入口。
+- `docs/zh-CN/install-kernel.md`
+- `docs/en/install-kernel.md`
+  - 职责：安装脚本、证书、服务检查。
+- `docs/zh-CN/config-generation.md`
+- `docs/en/config-generation.md`
+  - 职责：规则生成、导入客户端、更新流程。
+
+### 修改文件
+- `.gitignore`
+  - 职责：忽略 `dist/client-import/` 构建产物（保留必要 fixture）。
+- `docs/README.md`
+  - 职责：增加中英文档入口与脚本索引。
+- `scripts/tests/test_client_packaged_smoke.py`（如需）
+  - 职责：补充 bundle 产物存在性/结构断言（仅在当前测试风格允许时）。
+
+### 产物目录（运行时生成，不纳入版本库）
+- `dist/client-import/`
+  - 输出：`trojan-pro-client-profile-<YYYYMMDD>.json`
+
+---
+
+## 任务 1：仓库清理脚本（仅保留 main）
+
+**文件：**
+- 创建：`scripts/repo/cleanup-branches.sh`
+- 测试：通过 dry-run + apply（受控）验证
+- 文档：`docs/ops/branch-cleanup.md`
+
+- [ ] **步骤 1：编写失败测试（脚本契约测试）**
+
+在 `scripts/tests/test_cleanup_branches_contract.py` 新建契约测试，最小断言脚本参数行为与输出关键字。
+
+```python
+import pathlib
+import subprocess
+
+SCRIPT = pathlib.Path("scripts/repo/cleanup-branches.sh")
+
+def test_cleanup_script_exists_and_help():
+    assert SCRIPT.exists()
+    proc = subprocess.run(["bash", str(SCRIPT), "--help"], capture_output=True, text=True)
+    assert proc.returncode == 0
+    assert "--dry-run" in proc.stdout
+    assert "--apply" in proc.stdout
+```
+
+- [ ] **步骤 2：运行测试验证失败**
+
+运行：
+```bash
+cd /root/.openclaw/workspace/trojan-obfuscation/.worktrees/repo-cleanup-installer-routing
+python3 -m pytest scripts/tests/test_cleanup_branches_contract.py -q
+```
+预期：FAIL，报错脚本不存在。
+
+- [ ] **步骤 3：实现最小 cleanup 脚本（默认 dry-run）**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+# parse args: --dry-run(default) --apply --help
+# list local branches except main
+# list remote branches except origin/main origin/HEAD
+# print delete candidates
+# if apply: delete local and remote candidates
+```
+
+- [ ] **步骤 4：运行测试验证通过**
+
+运行：
+```bash
+python3 -m pytest scripts/tests/test_cleanup_branches_contract.py -q
+```
+预期：PASS。
+
+- [ ] **步骤 5：手工验证 dry-run/apply 防护**
+
+运行：
+```bash
+bash scripts/repo/cleanup-branches.sh --dry-run
+```
+预期：输出候删清单且不执行删除。
+
+- [ ] **步骤 6：Commit**
+
+```bash
+git add scripts/repo/cleanup-branches.sh scripts/tests/test_cleanup_branches_contract.py
+git commit -m "feat(repo): add safe branch cleanup script with dry-run contract test"
+```
+
+---
+
+## 任务 2：通用 Linux 安装脚本分层骨架（Caddy ACME）
+
+**文件：**
+- 创建：`scripts/install/install-kernel.sh`
+- 创建：`scripts/install/lib/*.sh`
+- 测试：脚本 lint + `--check-only` 路径验证
+
+- [ ] **步骤 1：编写失败测试（入口参数与 lib 依赖）**
+
+在 `scripts/tests/test_install_kernel_contract.py` 增加：
+
+```python
+import pathlib
+import subprocess
+
+SCRIPT = pathlib.Path("scripts/install/install-kernel.sh")
+
+def test_install_script_help_contract():
+    assert SCRIPT.exists()
+    proc = subprocess.run(["bash", str(SCRIPT), "--help"], capture_output=True, text=True)
+    assert proc.returncode == 0
+    assert "--domain" in proc.stdout
+    assert "--email" in proc.stdout
+    assert "--check-only" in proc.stdout
+```
+
+- [ ] **步骤 2：运行测试验证失败**
+
+运行：
+```bash
+python3 -m pytest scripts/tests/test_install_kernel_contract.py -q
+```
+预期：FAIL，脚本不存在。
+
+- [ ] **步骤 3：实现 install 主入口 + lib 骨架**
+
+关键代码骨架：
+
+```bash
+# scripts/install/install-kernel.sh
+source "$(dirname "$0")/lib/detect-os.sh"
+source "$(dirname "$0")/lib/install-deps.sh"
+source "$(dirname "$0")/lib/install-core.sh"
+source "$(dirname "$0")/lib/configure-caddy.sh"
+source "$(dirname "$0")/lib/write-runtime-config.sh"
+
+# parse --domain --email --password --check-only
+# check_only => detect + dependency check, no mutation
+```
+
+- [ ] **步骤 4：运行测试验证通过**
+
+运行：
+```bash
+python3 -m pytest scripts/tests/test_install_kernel_contract.py -q
+```
+预期：PASS。
+
+- [ ] **步骤 5：执行 check-only 自测**
+
+运行：
+```bash
+bash scripts/install/install-kernel.sh --domain example.com --email ops@example.com --check-only
+```
+预期：仅输出检测结果，不写入系统配置。
+
+- [ ] **步骤 6：Commit**
+
+```bash
+git add scripts/install/install-kernel.sh scripts/install/lib/*.sh scripts/tests/test_install_kernel_contract.py
+git commit -m "feat(install): add generic linux installer scaffold with caddy acme path"
+```
+
+---
+
+## 任务 3：规则转换器（clash-rules → client bundle）
+
+**文件：**
+- 创建：`scripts/config/generate-client-bundle.py`
+- 创建：`scripts/tests/test_generate_client_bundle.py`
+- 创建：`scripts/tests/fixtures/clash_rules_*.sample.txt`
+- 创建：`scripts/config/sources/clash-rules.lock`
+
+- [ ] **步骤 1：编写失败测试（映射与输出 schema）**
+
+```python
+from scripts.config.generate_client_bundle import parse_rules, build_bundle
+
+def test_mapping_priority_and_actions():
+    direct = ["DOMAIN-SUFFIX,cn"]
+    proxy = ["DOMAIN-SUFFIX,google.com"]
+    reject = ["DOMAIN-SUFFIX,ads.com"]
+    bundle = build_bundle(direct, proxy, reject, source_meta={"commit":"abc"})
+    rules = bundle["profile"]["routing"]["rules"]
+    names = [r["name"] for r in rules]
+    assert names[0].startswith("reject")
+```
+
+- [ ] **步骤 2：运行测试验证失败**
+
+运行：
+```bash
+python3 -m pytest scripts/tests/test_generate_client_bundle.py -q
+```
+预期：FAIL，模块不存在或函数未定义。
+
+- [ ] **步骤 3：实现最小转换器**
+
+实现要点：
+- 输入：三类规则文本（direct/proxy/reject）
+- 解析：`DOMAIN` / `DOMAIN-SUFFIX` / `DOMAIN-KEYWORD` / `IP-CIDR`
+- 输出：`kind=trojan-pro-client-profile`，`version=2`，含 `routing.policyGroups` 与 `routing.rules`
+- 优先级：reject > direct > proxy
+- 额外输出 lock 元数据（commit/date/source url）
+
+- [ ] **步骤 4：运行测试验证通过**
+
+运行：
+```bash
+python3 -m pytest scripts/tests/test_generate_client_bundle.py -q
+```
+预期：PASS。
+
+- [ ] **步骤 5：运行生成命令（fixture 模式）**
+
+运行：
+```bash
+python3 scripts/config/generate-client-bundle.py \
+  --direct scripts/tests/fixtures/clash_rules_direct.sample.txt \
+  --proxy scripts/tests/fixtures/clash_rules_proxy.sample.txt \
+  --reject scripts/tests/fixtures/clash_rules_reject.sample.txt \
+  --output dist/client-import/trojan-pro-client-profile-sample.json
+```
+预期：生成 JSON，能被 `json.loads` 解析。
+
+- [ ] **步骤 6：Commit**
+
+```bash
+git add scripts/config/generate-client-bundle.py scripts/config/sources/clash-rules.lock scripts/tests/test_generate_client_bundle.py scripts/tests/fixtures/clash_rules_*.sample.txt
+git commit -m "feat(config): add clash-rules to client routing bundle generator"
+```
+
+---
+
+## 任务 4：中英双文档与索引
+
+**文件：**
+- 创建：`docs/zh-CN/*.md`
+- 创建：`docs/en/*.md`
+- 修改：`docs/README.md`
+- 创建：`docs/ops/branch-cleanup.md`
+
+- [ ] **步骤 1：编写失败测试（文档链接完整性）**
+
+在 `scripts/tests/test_docs_bilingual_index.py` 新建最小测试：
+
+```python
+import pathlib
+
+DOCS = pathlib.Path("docs")
+
+def test_bilingual_entrypoints_exist():
+    assert (DOCS / "zh-CN" / "quickstart.md").exists()
+    assert (DOCS / "en" / "quickstart.md").exists()
+```
+
+- [ ] **步骤 2：运行测试验证失败**
+
+运行：
+```bash
+python3 -m pytest scripts/tests/test_docs_bilingual_index.py -q
+```
+预期：FAIL，文件不存在。
+
+- [ ] **步骤 3：编写中英文档与 README 索引**
+
+文档必须包含：
+- 安装命令
+- ACME 注意事项（DNS/80/443）
+- 配置生成命令
+- 客户端导入步骤
+- 规则更新机制（定时重新生成并导入）
+
+- [ ] **步骤 4：运行测试验证通过**
+
+运行：
+```bash
+python3 -m pytest scripts/tests/test_docs_bilingual_index.py -q
+```
+预期：PASS。
+
+- [ ] **步骤 5：Commit**
+
+```bash
+git add docs/README.md docs/zh-CN/*.md docs/en/*.md docs/ops/branch-cleanup.md scripts/tests/test_docs_bilingual_index.py
+git commit -m "docs: add bilingual setup and config generation guides"
+```
+
+---
+
+## 任务 5：整体验证与交付
+
+**文件：**
+- 修改：`scripts/validate_iter3_truthful_daily_use.sh`（如需挂接新检查）
+- 创建：`scripts/validate_repo_cleanup_installer_routing.sh`
+
+- [ ] **步骤 1：编写失败测试（验证脚本存在）**
+
+```python
+import pathlib
+
+def test_validation_script_exists():
+    assert pathlib.Path("scripts/validate_repo_cleanup_installer_routing.sh").exists()
+```
+
+- [ ] **步骤 2：运行测试验证失败**
+
+运行：
+```bash
+python3 -m pytest scripts/tests/test_validate_repo_cleanup_installer_routing.py -q
+```
+预期：FAIL。
+
+- [ ] **步骤 3：实现验证脚本**
+
+验证脚本顺序：
+1. cleanup dry-run
+2. installer `--check-only`
+3. bundle generator fixture run
+4. docs bilingual index test
+
+- [ ] **步骤 4：运行整体验证**
+
+运行：
+```bash
+bash scripts/validate_repo_cleanup_installer_routing.sh
+```
+预期：所有子步骤 PASS，并打印 started/finished 时间戳。
+
+- [ ] **步骤 5：最终 Commit**
+
+```bash
+git add scripts/validate_repo_cleanup_installer_routing.sh scripts/tests/test_validate_repo_cleanup_installer_routing.py
+git commit -m "chore(validate): add end-to-end validation bundle for cleanup+install+routing"
+```
+
+---
+
+## 自检（计划质量检查）
+
+### 1. 规格覆盖度
+- 分支清理：任务 1 覆盖
+- 通用 Linux 安装 + Caddy ACME：任务 2 覆盖
+- clash-rules 静态快照 + 客户端导入：任务 3 覆盖
+- 中英双文 + 索引：任务 4 覆盖
+- 可执行验证闭环：任务 5 覆盖
+
+### 2. 占位符扫描
+- 无 `TODO/待定/后续实现` 占位词。
+- 每个任务都有具体文件与命令。
+
+### 3. 类型一致性
+- 统一目标 bundle 类型：`trojan-pro-client-profile`，`version=2`。
+- 规则优先级统一：`reject > direct > proxy`。
+- 清理策略统一：仅保留 `main`。

--- a/docs/superpowers/specs/2026-04-24-repo-cleanup-installer-routing-design.md
+++ b/docs/superpowers/specs/2026-04-24-repo-cleanup-installer-routing-design.md
@@ -1,0 +1,171 @@
+# Design Spec: Repo Cleanup + Bilingual Docs + One-Click Kernel Install + Rule-Based Client Bundle
+
+- Date: 2026-04-24
+- Owner: assistant + user
+- Scope: trojan-obfuscation repo
+
+## 1) Confirmed decisions
+
+User-confirmed decisions in brainstorming:
+
+1. Branch cleanup policy: **A** (keep only `main`)
+2. Install target: **3** (generic Linux with package-manager auto-detection)
+3. Rule integration path: **1** (static snapshot conversion for client import)
+4. Certificate path: **1** (Caddy built-in ACME auto issue/renew)
+
+## 2) Scope split (subprojects)
+
+### A. Repo hygiene
+- Keep only `main` locally/remotely.
+- Delete old local + remote branches after dry-run preview.
+
+### B. Bilingual documentation
+- Introduce bilingual docs structure and entry points.
+- Ensure Chinese and English docs are aligned for installation, cert issuance, config generation, and client import.
+
+### C. One-click kernel install script
+- Generic Linux script with package manager detection (`apt` / `dnf` / `yum` / `pacman` / `zypper`).
+- Install trojan core + Caddy + service units.
+- Use Caddy ACME for certificate auto issue/renew.
+
+### D. Rule-based client import bundle
+- Pull Clash rules from Loyalsoldier source.
+- Convert to static routing snapshot compatible with current client routing model.
+- Generate importable client profile JSON bundle.
+
+## 3) Architecture and data flow
+
+### 3.1 Branch cleanup flow
+
+`cleanup-branches.sh --dry-run`
+→ enumerate local/remote branches
+→ compute delete candidates = all except `main` and `origin/main`
+→ print deterministic summary
+
+`cleanup-branches.sh --apply`
+→ delete local candidates
+→ delete remote candidates (`git push origin --delete <branch>`)
+→ verify only main remains
+
+### 3.2 Install flow
+
+`install-kernel.sh`
+→ detect distro/package manager
+→ install dependencies
+→ install/upgrade trojan core
+→ install/configure Caddy
+→ write runtime configs
+→ `systemctl daemon-reload && systemctl enable --now ...`
+→ health checks (`systemctl is-active`, Caddy endpoint/check)
+
+### 3.3 Rule conversion flow
+
+`generate-client-bundle.py --refresh-rules`
+→ fetch latest Loyalsoldier rules (`direct`, `proxy`, `reject`)
+→ normalize and parse rule lines
+→ map to routing policy groups + routing rules
+→ serialize profile bundle (`kind=trojan-pro-client-profile`, `version=2`)
+→ emit artifact under `dist/client-import/`
+→ write lock metadata (`source commit/date`) for traceability
+
+## 4) Mapping model: clash-rules → client routing model
+
+Current client routing model (`RoutingRuleMatch`) supports static fields:
+- `domainExact`
+- `domainSuffix`
+- `domainKeyword`
+- `domainRegex`
+- `ipCidr`
+- plus process/protocol/port constraints
+
+No native remote rule-provider URL in routing model.
+
+### Mapping policy
+
+- `reject` list → high-priority rules, action = `block`
+- `direct` list → mid-priority rules, action = policy group `direct-group`
+- `proxy` list → lower-priority rules, action = policy group `proxy-group`
+- fallback/default action = `proxy`
+
+Priority order is deterministic: `reject` > `direct` > `proxy`.
+
+### Update model
+
+Because routing is static, update by regeneration:
+- periodic CI/cron regeneration of importable bundle
+- users re-import latest bundle in client
+
+## 5) Error handling
+
+### Branch cleanup
+- `--apply` requires explicit flag; default is dry-run.
+- If any branch deletion fails, print failed set and exit non-zero.
+
+### Installer
+- fail-fast on unsupported OS/package manager.
+- fail-fast on missing required commands after install.
+- fail-fast when Caddy ACME issuance fails (DNS/port conflicts).
+
+### Rule conversion
+- fail on fetch errors, invalid source format, empty effective rule set.
+- validate output schema before writing final artifact.
+
+## 6) File plan
+
+### Scripts
+- `scripts/repo/cleanup-branches.sh`
+- `scripts/install/install-kernel.sh`
+- `scripts/install/lib/detect-os.sh`
+- `scripts/install/lib/install-deps.sh`
+- `scripts/install/lib/install-core.sh`
+- `scripts/install/lib/configure-caddy.sh`
+- `scripts/install/lib/write-runtime-config.sh`
+- `scripts/config/generate-client-bundle.py`
+- `scripts/config/sources/clash-rules.lock` (generated metadata)
+
+### Artifacts
+- `dist/client-import/trojan-pro-client-profile-<date>.json`
+
+### Docs (bilingual)
+- `docs/zh-CN/quickstart.md`
+- `docs/en/quickstart.md`
+- `docs/zh-CN/install-kernel.md`
+- `docs/en/install-kernel.md`
+- `docs/zh-CN/config-generation.md`
+- `docs/en/config-generation.md`
+- `docs/README.md` entry updates
+- `docs/ops/branch-cleanup.md`
+
+## 7) Verification plan
+
+1. Branch cleanup dry-run output review
+2. Apply cleanup and verify local/remote branches
+3. Installer smoke test on one generic Linux target (fresh host/container)
+4. Caddy ACME check and renewal readiness check
+5. Bundle generation test + schema validation
+6. Client import manual verification
+7. Bilingual doc link and consistency check
+
+## 8) Scope boundaries / YAGNI
+
+Included now:
+- static snapshot conversion path (no client subscription feature)
+- one install path with Caddy ACME
+
+Explicitly excluded now:
+- adding remote rule-provider subscription into client runtime
+- non-Linux platform installers
+- advanced multi-node deployment orchestration
+
+## 9) Open risks
+
+1. Rule source format drift upstream (mitigate with parser validation + lock metadata)
+2. ACME issuance environment constraints (ports, DNS, firewall)
+3. Large rule volume affecting client import size/perf (mitigate by curated subset + deterministic ordering)
+
+## 10) Success criteria
+
+- Branch state after cleanup: only `main`/`origin/main` remain.
+- One-command installer completes on supported Linux and starts services.
+- Generated bundle imports in client and routing rules are visible/effective.
+- Chinese/English docs are complete, consistent, and executable by copy/paste.

--- a/docs/zh-CN/config-generation.md
+++ b/docs/zh-CN/config-generation.md
@@ -1,0 +1,48 @@
+# 配置生成 / Config generation
+
+本页说明如何把 clash-rules 快照转换为客户端可导入 bundle。
+
+## 配置生成命令 / config generation
+
+```bash
+python3 scripts/config/generate-client-bundle.py \
+  --direct scripts/tests/fixtures/clash_rules_direct.sample.txt \
+  --proxy scripts/tests/fixtures/clash_rules_proxy.sample.txt \
+  --reject scripts/tests/fixtures/clash_rules_reject.sample.txt \
+  --output dist/client-import/trojan-pro-client-profile-sample.json
+```
+
+输出文件位于 `dist/client-import/`。
+
+## 输出内容
+
+生成结果包含：
+- `kind=trojan-pro-client-profile`
+- `version=2`
+- `routing.policyGroups`
+- `routing.rules`
+
+## 客户端导入 / client import
+
+- 打开客户端导入页面
+- 选择生成的 JSON 文件
+- 校验 policy groups 与 rules 已出现
+- 根据生产环境补齐服务器地址、SNI、密码
+
+## ACME / DNS / 80 / 443 关联提醒
+
+虽然本页聚焦 **config generation**，但真实可用仍依赖服务端安装成功：
+- 域名 **DNS** 正确
+- **ACME** 可签发
+- **80** / **443** 可达
+
+## 规则更新 / rule update
+
+当前模型不是在线订阅，而是离线重生成：
+
+1. 定时拉取或更新 direct/proxy/reject 文本规则
+2. 重新执行 config generation
+3. 将新的 JSON 发给客户端
+4. 客户端重新导入最新 bundle
+
+推荐把这个流程放进 cron 或 CI，形成稳定的 **rule update** 机制。

--- a/docs/zh-CN/install-kernel.md
+++ b/docs/zh-CN/install-kernel.md
@@ -1,0 +1,48 @@
+# 安装骨架说明 / Install kernel
+
+`scripts/install/install-kernel.sh` 是通用 Linux 安装入口骨架，负责参数解析与 phase 编排。
+
+## 支持的 install command
+
+```bash
+bash scripts/install/install-kernel.sh \
+  --domain example.com \
+  --email ops@example.com \
+  --password 'change-this-password' \
+  --check-only
+```
+
+当前 apply 模式为 fail-closed；在真实安装细节实现之前，请只使用 `--check-only`。
+
+## Phase 结构
+
+- detect-os
+- install-deps
+- install-core
+- configure-caddy
+- write-runtime-config
+
+## ACME / DNS / 80 / 443
+
+- **ACME** 证书申请前，先确认 **DNS** 已解析到目标主机
+- 确认系统和云防火墙同时放行 **80** / **443**
+- 若 80/443 被其他进程占用，Caddy 无法接管签发流程
+- 变更域名后需要再次检查解析与端口状态
+
+## 客户端导入前的关联步骤 / client import dependency
+
+安装骨架本身不生成客户端路由配置；客户端导入依赖单独的 **config generation**：
+
+```bash
+python3 scripts/config/generate-client-bundle.py \
+  --direct scripts/tests/fixtures/clash_rules_direct.sample.txt \
+  --proxy scripts/tests/fixtures/clash_rules_proxy.sample.txt \
+  --reject scripts/tests/fixtures/clash_rules_reject.sample.txt \
+  --output dist/client-import/trojan-pro-client-profile-sample.json
+```
+
+## 规则更新 / rule update
+
+- 服务端安装与客户端 routing 更新是两条链路
+- 规则变化后，需定时重新生成 bundle 并通知客户端重新导入
+- 推荐用 cron / CI 做周期性 **rule update**

--- a/docs/zh-CN/quickstart.md
+++ b/docs/zh-CN/quickstart.md
@@ -1,0 +1,65 @@
+# 快速开始 / Quickstart
+
+本页给出最短路径：先准备 Linux 主机与域名，再执行 **install command**，最后生成并导入客户端 routing 配置。
+
+## 1. 前置准备
+
+- 一台可联网的 Linux 主机
+- 一个已经解析到该主机公网 IP 的域名
+- 可以接收 ACME 邮件的邮箱
+- 放行 **80** / **443** 端口
+
+## 2. 安装命令 / install command
+
+当前安装骨架支持检测与计划模式，推荐先执行 `--check-only`：
+
+```bash
+bash scripts/install/install-kernel.sh \
+  --domain example.com \
+  --email ops@example.com \
+  --password 'change-this-password' \
+  --check-only
+```
+
+如果后续任务补齐 apply 实现，再按 runbook 执行真实安装。
+
+## 3. ACME 注意事项 / ACME notes
+
+- **ACME** 签发依赖正确的 **DNS** 解析
+- 80/443 端口必须可达，否则 HTTP-01 会失败
+- 若主机已有其他 Web 服务，请确认不会抢占 **80** / **443**
+- 首次签发前先确认域名已经传播完成
+
+## 4. 配置生成 / config generation
+
+使用 clash-rules 快照生成客户端可导入配置：
+
+```bash
+python3 scripts/config/generate-client-bundle.py \
+  --direct scripts/tests/fixtures/clash_rules_direct.sample.txt \
+  --proxy scripts/tests/fixtures/clash_rules_proxy.sample.txt \
+  --reject scripts/tests/fixtures/clash_rules_reject.sample.txt \
+  --output dist/client-import/trojan-pro-client-profile-sample.json
+```
+
+## 5. 客户端导入 / client import
+
+- 打开 Trojan Pro Client
+- 进入 Profile import 页面
+- 选择 `dist/client-import/*.json`
+- 导入后检查 `routing.policyGroups` 与 `routing.rules`
+- 再补上真实服务器地址和密码
+
+## 6. 规则更新 / rule update
+
+当前 routing 是静态快照，不是远程订阅。
+
+建议机制：
+- 定时任务或 CI **rule update**：周期性重新运行 config generation
+- 将新 JSON 重新分发给客户端
+- 客户端重新导入最新 bundle
+
+相关文档：
+- [安装骨架说明](./install-kernel.md)
+- [配置生成说明](./config-generation.md)
+- [分支清理运维说明](../ops/branch-cleanup.md)

--- a/scripts/config/generate-client-bundle.py
+++ b/scripts/config/generate-client-bundle.py
@@ -72,7 +72,7 @@ def parse_rule_line(raw_line: str) -> ParsedRule | None:
 
     rule_type = parts[0].upper()
     if rule_type not in SUPPORTED_RULE_TYPES:
-        return None
+        raise ValueError(f"unsupported rule type: {rule_type}")
 
     raw_value = parts[1]
     if rule_type == "DOMAIN":
@@ -99,8 +99,6 @@ def load_rule_file(path: str | Path) -> list[ParsedRule]:
         if parsed is not None:
             rules.append(parsed)
 
-    if not rules:
-        raise ValueError(f"no supported rules found in {source_path}")
     return rules
 
 

--- a/scripts/config/generate-client-bundle.py
+++ b/scripts/config/generate-client-bundle.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_LOCK_PATH = SCRIPT_DIR / "sources" / "clash-rules.lock"
+SUPPORTED_RULE_TYPES = {
+    "DOMAIN",
+    "DOMAIN-SUFFIX",
+    "DOMAIN-KEYWORD",
+    "IP-CIDR",
+}
+
+
+@dataclass(frozen=True)
+class ParsedRule:
+    rule_type: str
+    value: str
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _normalize_domain(value: str) -> str:
+    normalized = value.strip().lower().rstrip(".")
+    if not normalized:
+        raise ValueError("domain value is empty")
+    return normalized
+
+
+def _normalize_domain_suffix(value: str) -> str:
+    normalized = value.strip().lower().strip(".")
+    if not normalized:
+        raise ValueError("domain suffix value is empty")
+    return normalized
+
+
+def _normalize_keyword(value: str) -> str:
+    normalized = value.strip().lower()
+    if not normalized:
+        raise ValueError("domain keyword value is empty")
+    return normalized
+
+
+def _normalize_ip_cidr(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError("ip cidr value is empty")
+    return str(ipaddress.ip_network(normalized, strict=False))
+
+
+def parse_rule_line(raw_line: str) -> ParsedRule | None:
+    line = raw_line.split("#", 1)[0].strip()
+    if not line or line in {"payload:", "payload"}:
+        return None
+    if line.startswith("-"):
+        line = line[1:].strip()
+    if not line:
+        return None
+
+    parts = [part.strip() for part in line.split(",")]
+    if len(parts) < 2:
+        raise ValueError(f"invalid rule line: {raw_line.strip()}")
+
+    rule_type = parts[0].upper()
+    if rule_type not in SUPPORTED_RULE_TYPES:
+        return None
+
+    raw_value = parts[1]
+    if rule_type == "DOMAIN":
+        value = _normalize_domain(raw_value)
+    elif rule_type == "DOMAIN-SUFFIX":
+        value = _normalize_domain_suffix(raw_value)
+    elif rule_type == "DOMAIN-KEYWORD":
+        value = _normalize_keyword(raw_value)
+    else:
+        value = _normalize_ip_cidr(raw_value)
+
+    return ParsedRule(rule_type=rule_type, value=value)
+
+
+def load_rule_file(path: str | Path) -> list[ParsedRule]:
+    source_path = Path(path)
+    rules: list[ParsedRule] = []
+
+    for line_number, raw_line in enumerate(source_path.read_text(encoding="utf-8").splitlines(), start=1):
+        try:
+            parsed = parse_rule_line(raw_line)
+        except ValueError as exc:
+            raise ValueError(f"{source_path}:{line_number}: {exc}") from exc
+        if parsed is not None:
+            rules.append(parsed)
+
+    if not rules:
+        raise ValueError(f"no supported rules found in {source_path}")
+    return rules
+
+
+def load_lock_metadata(path: str | Path = DEFAULT_LOCK_PATH) -> dict[str, object]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _match_payload(rule: ParsedRule) -> dict[str, str]:
+    if rule.rule_type == "DOMAIN":
+        return {"domainExact": rule.value}
+    if rule.rule_type == "DOMAIN-SUFFIX":
+        return {"domainSuffix": f".{rule.value}"}
+    if rule.rule_type == "DOMAIN-KEYWORD":
+        return {"domainKeyword": rule.value}
+    if rule.rule_type == "IP-CIDR":
+        return {"ipCidr": rule.value}
+    raise ValueError(f"unsupported rule type: {rule.rule_type}")
+
+
+def _rule_name(kind: str, rule: ParsedRule) -> str:
+    return f"{kind} {rule.rule_type.lower()} {rule.value}"
+
+
+def _build_routing_rules(category: str, rules: Iterable[ParsedRule], *, base_priority: int, policy_group_id: str) -> list[dict[str, object]]:
+    result: list[dict[str, object]] = []
+    for index, rule in enumerate(rules, start=1):
+        result.append(
+            {
+                "id": f"rule-{category}-{index:04d}",
+                "name": _rule_name(category, rule),
+                "enabled": True,
+                "priority": base_priority + index,
+                "match": _match_payload(rule),
+                "action": {
+                    "kind": "policyGroup",
+                    "policyGroupId": policy_group_id,
+                },
+            }
+        )
+    return result
+
+
+def build_bundle(
+    *,
+    direct_rules: Iterable[ParsedRule],
+    proxy_rules: Iterable[ParsedRule],
+    reject_rules: Iterable[ParsedRule],
+    source_meta: dict[str, object] | None = None,
+) -> dict[str, object]:
+    direct_rules = list(direct_rules)
+    proxy_rules = list(proxy_rules)
+    reject_rules = list(reject_rules)
+    if not (direct_rules or proxy_rules or reject_rules):
+        raise ValueError("effective rule set is empty")
+
+    routing_rules = [
+        *_build_routing_rules(
+            "reject",
+            reject_rules,
+            base_priority=100,
+            policy_group_id="reject-group",
+        ),
+        *_build_routing_rules(
+            "direct",
+            direct_rules,
+            base_priority=200,
+            policy_group_id="direct-group",
+        ),
+        *_build_routing_rules(
+            "proxy",
+            proxy_rules,
+            base_priority=300,
+            policy_group_id="proxy-group",
+        ),
+    ]
+
+    routing_rules.sort(key=lambda item: (int(item["priority"]), str(item["id"])))
+    generated_at = _utc_now_iso()
+
+    return {
+        "version": 2,
+        "kind": "trojan-pro-client-profile",
+        "metadata": {
+            "generatedAt": generated_at,
+            "source": "clash-rules",
+            "lock": source_meta or {},
+        },
+        "profile": {
+            "id": "generated-clash-rules-profile",
+            "name": "Generated Clash Rules Bundle",
+            "serverHost": "example.com",
+            "serverPort": 443,
+            "sni": "example.com",
+            "localSocksPort": 1080,
+            "verifyTls": True,
+            "notes": "Generated from clash-rules snapshots; replace server fields before production use.",
+            "updatedAt": generated_at,
+            "routing": {
+                "mode": "rule",
+                "defaultAction": "proxy",
+                "globalAction": "proxy",
+                "policyGroups": [
+                    {
+                        "id": "direct-group",
+                        "name": "Direct",
+                        "action": "direct",
+                    },
+                    {
+                        "id": "proxy-group",
+                        "name": "Proxy",
+                        "action": "proxy",
+                    },
+                    {
+                        "id": "reject-group",
+                        "name": "Reject",
+                        "action": "block",
+                    },
+                ],
+                "rules": routing_rules,
+            },
+        },
+        "secrets": {
+            "trojanPasswordIncluded": False,
+            "sourceDeviceHadStoredPassword": False,
+            "importBehavior": "reenter_or_restore_secure_storage",
+        },
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a trojan-pro client import bundle from clash-rules snapshots.",
+    )
+    parser.add_argument("--direct", required=True, help="Path to direct clash-rules text file")
+    parser.add_argument("--proxy", required=True, help="Path to proxy clash-rules text file")
+    parser.add_argument("--reject", required=True, help="Path to reject clash-rules text file")
+    parser.add_argument("--output", required=True, help="Output JSON path under dist/client-import/")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    direct_rules = load_rule_file(args.direct)
+    proxy_rules = load_rule_file(args.proxy)
+    reject_rules = load_rule_file(args.reject)
+    bundle = build_bundle(
+        direct_rules=direct_rules,
+        proxy_rules=proxy_rules,
+        reject_rules=reject_rules,
+        source_meta=load_lock_metadata(),
+    )
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(bundle, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    print(f"wrote_bundle={output_path}")
+    print(f"rule_count={len(bundle['profile']['routing']['rules'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/config/sources/clash-rules.lock
+++ b/scripts/config/sources/clash-rules.lock
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "source": "clash-rules",
+  "updatedAt": null,
+  "sources": {
+    "direct": {"url": null, "revision": null},
+    "proxy": {"url": null, "revision": null},
+    "reject": {"url": null, "revision": null}
+  }
+}

--- a/scripts/install/install-kernel.sh
+++ b/scripts/install/install-kernel.sh
@@ -46,7 +46,7 @@ log_kv() {
 require_value() {
   local flag="$1"
   local value="${2:-}"
-  if [[ -z "$value" ]]; then
+  if [[ -z "$value" || "$value" == --* ]]; then
     echo "error: missing value for $flag" >&2
     exit 1
   fi
@@ -100,7 +100,6 @@ INSTALL_DOMAIN="$domain"
 INSTALL_EMAIL="$email"
 INSTALL_PASSWORD="$password"
 INSTALL_CHECK_ONLY="$check_only"
-export INSTALL_DOMAIN INSTALL_EMAIL INSTALL_PASSWORD INSTALL_CHECK_ONLY
 
 if [[ "$check_only" -eq 1 ]]; then
   mode_label="check-only"
@@ -112,6 +111,11 @@ log_kv "installer" "install-kernel"
 log_kv "mode" "$mode_label"
 log_kv "domain" "$domain"
 log_kv "email" "$email"
+
+if [[ "$check_only" -ne 1 ]]; then
+  echo "error: apply mode is not implemented yet; use --check-only" >&2
+  exit 1
+fi
 
 phase_detect_os
 phase_install_deps

--- a/scripts/install/install-kernel.sh
+++ b/scripts/install/install-kernel.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/lib"
+
+# shellcheck source=/dev/null
+source "$LIB_DIR/detect-os.sh"
+# shellcheck source=/dev/null
+source "$LIB_DIR/install-deps.sh"
+# shellcheck source=/dev/null
+source "$LIB_DIR/install-core.sh"
+# shellcheck source=/dev/null
+source "$LIB_DIR/configure-caddy.sh"
+# shellcheck source=/dev/null
+source "$LIB_DIR/write-runtime-config.sh"
+
+print_usage() {
+  cat <<'EOF'
+Usage: ./scripts/install/install-kernel.sh --domain <domain> --email <email> --password <password> [--check-only] [--help]
+
+Generic Linux installer kernel skeleton for Trojan + Caddy ACME.
+
+Required options:
+  --domain <domain>      Public domain for Caddy ACME / server routing
+  --email <email>        Contact email for ACME registration
+  --password <password>  Trojan runtime password
+
+Modes:
+  --check-only           Detection / plan only; do not install, do not write config,
+                         do not start services
+  --help                 Show this help message
+
+Notes:
+  - This task only provides the layered installer skeleton.
+  - Real installation details can be filled by later tasks.
+EOF
+}
+
+log_kv() {
+  local key="$1"
+  local value="$2"
+  printf '%s=%s\n' "$key" "$value"
+}
+
+require_value() {
+  local flag="$1"
+  local value="${2:-}"
+  if [[ -z "$value" ]]; then
+    echo "error: missing value for $flag" >&2
+    exit 1
+  fi
+}
+
+domain=""
+email=""
+password=""
+check_only=0
+
+while (($# > 0)); do
+  case "$1" in
+    --domain)
+      require_value "$1" "${2:-}"
+      domain="$2"
+      shift 2
+      ;;
+    --email)
+      require_value "$1" "${2:-}"
+      email="$2"
+      shift 2
+      ;;
+    --password)
+      require_value "$1" "${2:-}"
+      password="$2"
+      shift 2
+      ;;
+    --check-only)
+      check_only=1
+      shift
+      ;;
+    --help|-h)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      print_usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$domain" || -z "$email" || -z "$password" ]]; then
+  echo "error: --domain, --email, and --password are required" >&2
+  print_usage >&2
+  exit 1
+fi
+
+INSTALL_DOMAIN="$domain"
+INSTALL_EMAIL="$email"
+INSTALL_PASSWORD="$password"
+INSTALL_CHECK_ONLY="$check_only"
+export INSTALL_DOMAIN INSTALL_EMAIL INSTALL_PASSWORD INSTALL_CHECK_ONLY
+
+if [[ "$check_only" -eq 1 ]]; then
+  mode_label="check-only"
+else
+  mode_label="apply"
+fi
+
+log_kv "installer" "install-kernel"
+log_kv "mode" "$mode_label"
+log_kv "domain" "$domain"
+log_kv "email" "$email"
+
+phase_detect_os
+phase_install_deps
+phase_install_core
+phase_configure_caddy
+phase_write_runtime_config

--- a/scripts/install/lib/configure-caddy.sh
+++ b/scripts/install/lib/configure-caddy.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+phase_configure_caddy() {
+  echo "phase=configure-caddy"
+
+  if [[ "${INSTALL_CHECK_ONLY:-0}" == "1" ]]; then
+    echo "[check-only] would render Caddy ACME config for ${INSTALL_DOMAIN} using ${INSTALL_EMAIL}"
+    return 0
+  fi
+
+  echo "configure-caddy skeleton: real Caddy ACME configuration is not implemented in this task"
+}

--- a/scripts/install/lib/detect-os.sh
+++ b/scripts/install/lib/detect-os.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+phase_detect_os() {
+  echo "phase=detect-os"
+
+  local os_id="unknown"
+  local os_version="unknown"
+
+  if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    os_id="${ID:-unknown}"
+    os_version="${VERSION_ID:-unknown}"
+  fi
+
+  echo "detected_os=$os_id"
+  echo "detected_version=$os_version"
+}

--- a/scripts/install/lib/install-core.sh
+++ b/scripts/install/lib/install-core.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+phase_install_core() {
+  echo "phase=install-core"
+
+  if [[ "${INSTALL_CHECK_ONLY:-0}" == "1" ]]; then
+    echo "[check-only] would install trojan core"
+    return 0
+  fi
+
+  echo "install-core skeleton: real core installation is not implemented in this task"
+}

--- a/scripts/install/lib/install-deps.sh
+++ b/scripts/install/lib/install-deps.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+phase_install_deps() {
+  echo "phase=install-deps"
+
+  if [[ "${INSTALL_CHECK_ONLY:-0}" == "1" ]]; then
+    echo "[check-only] would install dependencies for detected Linux distro"
+    return 0
+  fi
+
+  echo "install-deps skeleton: real dependency installation is not implemented in this task"
+}

--- a/scripts/install/lib/write-runtime-config.sh
+++ b/scripts/install/lib/write-runtime-config.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+phase_write_runtime_config() {
+  echo "phase=write-runtime-config"
+
+  if [[ "${INSTALL_CHECK_ONLY:-0}" == "1" ]]; then
+    echo "[check-only] would write runtime config for ${INSTALL_DOMAIN}"
+    return 0
+  fi
+
+  echo "write-runtime-config skeleton: real runtime config rendering is not implemented in this task"
+}

--- a/scripts/repo/cleanup-branches.sh
+++ b/scripts/repo/cleanup-branches.sh
@@ -14,10 +14,35 @@ Deletion rules:
   - remote candidates: all origin/* refs except origin/main, origin/HEAD,
     and the current branch's origin counterpart
 
+Safety notes:
+  - --apply performs real branch deletions; run dry-run first
+  - local branches are deleted with safe mode (git branch -d), not force-delete
+  - --apply is refused in detached HEAD state
+
 Options:
   --apply   Actually delete eligible branches
   --help    Show this help message
 EOF
+}
+
+collapse_output() {
+  local raw_output="$1"
+  printf '%s' "$raw_output" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//'
+}
+
+print_detail_list() {
+  local title="$1"
+  shift
+
+  if (($# == 0)); then
+    return 0
+  fi
+
+  echo "$title"
+  local item
+  for item in "$@"; do
+    echo "  - $item"
+  done
 }
 
 mode="dry-run"
@@ -47,9 +72,21 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 repo_root="$(git rev-parse --show-toplevel)"
-current_branch="$(git branch --show-current || true)"
-if [[ -z "$current_branch" ]]; then
+is_detached=0
+if current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null)"; then
+  :
+else
+  is_detached=1
   current_branch="HEAD"
+fi
+
+if [[ "$mode" == "apply" && "$is_detached" -eq 1 ]]; then
+  echo "error: refusing --apply in detached HEAD state" >&2
+  exit 1
+fi
+
+if [[ "$is_detached" -eq 1 ]]; then
+  echo "warning: detached HEAD detected; dry-run will continue but --apply is refused" >&2
 fi
 
 local_candidates=()
@@ -61,7 +98,15 @@ while IFS= read -r branch; do
 done < <(git for-each-ref --format='%(refname:short)' refs/heads)
 
 remote_candidates=()
+fetch_warnings=()
 if git remote get-url origin >/dev/null 2>&1; then
+  if ! fetch_output="$(git fetch origin --prune 2>&1)"; then
+    fetch_reason="$(collapse_output "$fetch_output")"
+    fetch_warnings+=("git fetch origin --prune failed; continuing with local remote-tracking refs :: $fetch_reason")
+    echo "warning: git fetch origin --prune failed; continuing with local remote-tracking refs" >&2
+    [[ -n "$fetch_reason" ]] && echo "warning: $fetch_reason" >&2
+  fi
+
   while IFS= read -r ref; do
     [[ -z "$ref" ]] && continue
     case "$ref" in
@@ -82,32 +127,82 @@ echo "current_branch=$current_branch"
 echo "mode=$mode"
 echo
 
+local_deleted=()
+local_skipped=()
+remote_deleted=()
+remote_skipped=()
+failures=()
+
 if [[ ${#local_candidates[@]} -eq 0 && ${#remote_candidates[@]} -eq 0 ]]; then
   echo "no eligible branches found"
-  exit 0
+else
+  for branch in "${local_candidates[@]}"; do
+    if [[ "$mode" == "dry-run" ]]; then
+      echo "would delete local branch: $branch"
+      continue
+    fi
+
+    if delete_output="$(git branch -d "$branch" 2>&1)"; then
+      local_deleted+=("$branch")
+      echo "deleted local branch: $branch"
+      continue
+    fi
+
+    delete_reason="$(collapse_output "$delete_output")"
+    if [[ "$delete_reason" == *"not fully merged"* ]]; then
+      local_skipped+=("$branch :: $delete_reason")
+      echo "skipped local branch: $branch"
+      echo "  reason: $delete_reason"
+    else
+      failures+=("local branch $branch :: $delete_reason")
+      echo "failed local branch: $branch" >&2
+      echo "  reason: $delete_reason" >&2
+    fi
+  done
+
+  for ref in "${remote_candidates[@]}"; do
+    remote_branch="${ref#origin/}"
+    if [[ "$mode" == "dry-run" ]]; then
+      echo "would delete remote branch: $ref"
+      continue
+    fi
+
+    if delete_output="$(git push origin --delete "$remote_branch" 2>&1)"; then
+      remote_deleted+=("$ref")
+      echo "deleted remote branch: $ref"
+      continue
+    fi
+
+    delete_reason="$(collapse_output "$delete_output")"
+    if [[ "$delete_reason" == *"remote ref does not exist"* ]]; then
+      remote_skipped+=("$ref :: $delete_reason")
+      echo "skipped remote branch: $ref"
+      echo "  reason: $delete_reason"
+      git update-ref -d "refs/remotes/$ref" >/dev/null 2>&1 || true
+    else
+      failures+=("remote branch $ref :: $delete_reason")
+      echo "failed remote branch: $ref" >&2
+      echo "  reason: $delete_reason" >&2
+    fi
+  done
 fi
 
-for branch in "${local_candidates[@]}"; do
-  if [[ "$mode" == "dry-run" ]]; then
-    echo "would delete local branch: $branch"
-  else
-    git branch -D "$branch" >/dev/null
-    echo "deleted local branch: $branch"
-  fi
-done
+echo
+echo "summary:"
+echo "  local_candidates=${#local_candidates[@]}"
+echo "  remote_candidates=${#remote_candidates[@]}"
+echo "  local_deleted=${#local_deleted[@]}"
+echo "  local_skipped=${#local_skipped[@]}"
+echo "  remote_deleted=${#remote_deleted[@]}"
+echo "  remote_skipped=${#remote_skipped[@]}"
+echo "  warnings=${#fetch_warnings[@]}"
+echo "  failures=${#failures[@]}"
 
-remote_deleted=0
-for ref in "${remote_candidates[@]}"; do
-  remote_branch="${ref#origin/}"
-  if [[ "$mode" == "dry-run" ]]; then
-    echo "would delete remote branch: $ref"
-  else
-    git push origin --delete "$remote_branch" >/dev/null
-    echo "deleted remote branch: $ref"
-    remote_deleted=1
-  fi
-done
+print_detail_list "fetch warnings:" "${fetch_warnings[@]}"
+print_detail_list "skipped local branches:" "${local_skipped[@]}"
+print_detail_list "skipped remote branches:" "${remote_skipped[@]}"
+print_detail_list "failures:" "${failures[@]}"
 
-if [[ "$mode" == "apply" && "$remote_deleted" -eq 1 ]]; then
-  git fetch origin --prune >/dev/null
+if [[ ${#failures[@]} -gt 0 ]]; then
+  exit 1
 fi

--- a/scripts/repo/cleanup-branches.sh
+++ b/scripts/repo/cleanup-branches.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_usage() {
+  cat <<'EOF'
+Usage: ./scripts/repo/cleanup-branches.sh [--apply] [--help]
+
+Default mode is dry-run:
+  - prints which local and remote branches would be deleted
+  - does not delete anything unless --apply is provided
+
+Deletion rules:
+  - local candidates: all local branches except main and the current branch
+  - remote candidates: all origin/* refs except origin/main, origin/HEAD,
+    and the current branch's origin counterpart
+
+Options:
+  --apply   Actually delete eligible branches
+  --help    Show this help message
+EOF
+}
+
+mode="dry-run"
+
+while (($# > 0)); do
+  case "$1" in
+    --apply)
+      mode="apply"
+      ;;
+    --help|-h)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo >&2
+      print_usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: must be run inside a git work tree" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+current_branch="$(git branch --show-current || true)"
+if [[ -z "$current_branch" ]]; then
+  current_branch="HEAD"
+fi
+
+local_candidates=()
+while IFS= read -r branch; do
+  [[ -z "$branch" ]] && continue
+  [[ "$branch" == "main" ]] && continue
+  [[ "$branch" == "$current_branch" ]] && continue
+  local_candidates+=("$branch")
+done < <(git for-each-ref --format='%(refname:short)' refs/heads)
+
+remote_candidates=()
+if git remote get-url origin >/dev/null 2>&1; then
+  while IFS= read -r ref; do
+    [[ -z "$ref" ]] && continue
+    case "$ref" in
+      origin/main|origin/HEAD)
+        continue
+        ;;
+    esac
+    if [[ "$current_branch" != "HEAD" && "$ref" == "origin/$current_branch" ]]; then
+      continue
+    fi
+    remote_candidates+=("$ref")
+  done < <(git for-each-ref --format='%(refname:short)' refs/remotes/origin)
+fi
+
+echo "== cleanup-branches =="
+echo "repo_root=$repo_root"
+echo "current_branch=$current_branch"
+echo "mode=$mode"
+echo
+
+if [[ ${#local_candidates[@]} -eq 0 && ${#remote_candidates[@]} -eq 0 ]]; then
+  echo "no eligible branches found"
+  exit 0
+fi
+
+for branch in "${local_candidates[@]}"; do
+  if [[ "$mode" == "dry-run" ]]; then
+    echo "would delete local branch: $branch"
+  else
+    git branch -D "$branch" >/dev/null
+    echo "deleted local branch: $branch"
+  fi
+done
+
+remote_deleted=0
+for ref in "${remote_candidates[@]}"; do
+  remote_branch="${ref#origin/}"
+  if [[ "$mode" == "dry-run" ]]; then
+    echo "would delete remote branch: $ref"
+  else
+    git push origin --delete "$remote_branch" >/dev/null
+    echo "deleted remote branch: $ref"
+    remote_deleted=1
+  fi
+done
+
+if [[ "$mode" == "apply" && "$remote_deleted" -eq 1 ]]; then
+  git fetch origin --prune >/dev/null
+fi

--- a/scripts/tests/fixtures/clash_rules_direct.sample.txt
+++ b/scripts/tests/fixtures/clash_rules_direct.sample.txt
@@ -1,0 +1,5 @@
+# direct sample
+payload:
+  - DOMAIN,localhost
+  - DOMAIN-SUFFIX,cn
+  - IP-CIDR,10.0.0.0/8

--- a/scripts/tests/fixtures/clash_rules_proxy.sample.txt
+++ b/scripts/tests/fixtures/clash_rules_proxy.sample.txt
@@ -1,0 +1,4 @@
+# proxy sample
+payload:
+  - DOMAIN-SUFFIX,google.com
+  - DOMAIN-KEYWORD,openai

--- a/scripts/tests/fixtures/clash_rules_reject.sample.txt
+++ b/scripts/tests/fixtures/clash_rules_reject.sample.txt
@@ -1,0 +1,4 @@
+# reject sample
+payload:
+  - DOMAIN-KEYWORD,ads
+  - DOMAIN-SUFFIX,tracker.com

--- a/scripts/tests/test_cleanup_branches_contract.py
+++ b/scripts/tests/test_cleanup_branches_contract.py
@@ -1,0 +1,134 @@
+import subprocess
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "repo" / "cleanup-branches.sh"
+
+
+def _run(cmd: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, check=False)
+    if check and proc.returncode != 0:
+        raise AssertionError(
+            f"command failed: {' '.join(cmd)}\n"
+            f"cwd={cwd}\n"
+            f"exit={proc.returncode}\n"
+            f"stdout:\n{proc.stdout}\n"
+            f"stderr:\n{proc.stderr}"
+        )
+    return proc
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return _run(["git", *args], cwd=cwd).stdout.strip()
+
+
+def _configure_git_identity(repo: Path) -> None:
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+
+
+def _write_commit(repo: Path, relpath: str, content: str, message: str) -> None:
+    path = repo / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    _git(repo, "add", relpath)
+    _git(repo, "commit", "-m", message)
+
+
+def _list_local_branches(repo: Path) -> set[str]:
+    output = _git(repo, "for-each-ref", "--format=%(refname:short)", "refs/heads")
+    return {line for line in output.splitlines() if line}
+
+
+def _list_remote_refs(repo: Path) -> set[str]:
+    output = _git(repo, "for-each-ref", "--format=%(refname:short)", "refs/remotes/origin")
+    return {line for line in output.splitlines() if line}
+
+
+def _list_origin_heads(origin: Path) -> set[str]:
+    output = _git(origin, "for-each-ref", "--format=%(refname:short)", "refs/heads")
+    return {line for line in output.splitlines() if line}
+
+
+def _init_repo_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    origin = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    work = tmp_path / "work"
+
+    _run(["git", "init", "--bare", str(origin)], cwd=tmp_path)
+    _run(["git", "init", "-b", "main", str(seed)], cwd=tmp_path)
+    _configure_git_identity(seed)
+
+    _write_commit(seed, "README.md", "seed\n", "seed main")
+    _git(seed, "remote", "add", "origin", str(origin))
+    _git(seed, "push", "-u", "origin", "main")
+    _git(origin, "symbolic-ref", "HEAD", "refs/heads/main")
+
+    _git(seed, "switch", "-c", "feature/remote-stale")
+    _write_commit(seed, "remote-stale.txt", "remote stale\n", "add remote stale branch")
+    _git(seed, "push", "-u", "origin", "feature/remote-stale")
+
+    _git(seed, "switch", "main")
+    _git(seed, "switch", "-c", "feature/current")
+    _write_commit(seed, "current.txt", "current branch\n", "add current branch")
+    _git(seed, "push", "-u", "origin", "feature/current")
+
+    _git(seed, "switch", "main")
+    _run(["git", "clone", str(origin), str(work)], cwd=tmp_path)
+    _configure_git_identity(work)
+    _git(work, "switch", "--track", "origin/feature/current")
+    _git(work, "branch", "feature/local-stale")
+
+    return origin, work
+
+
+def test_help_describes_default_dry_run(tmp_path: Path) -> None:
+    proc = _run(["bash", str(SCRIPT_PATH), "--help"], cwd=tmp_path, check=False)
+
+    assert proc.returncode == 0
+    assert "Usage:" in proc.stdout
+    assert "dry-run" in proc.stdout.lower()
+    assert "--apply" in proc.stdout
+
+
+def test_default_mode_is_dry_run_and_only_prints_candidates(tmp_path: Path) -> None:
+    _, work = _init_repo_fixture(tmp_path)
+
+    proc = _run(["bash", str(SCRIPT_PATH)], cwd=work, check=False)
+
+    assert proc.returncode == 0
+    assert "dry-run" in proc.stdout.lower()
+    assert "would delete local branch: feature/local-stale" in proc.stdout
+    assert "would delete remote branch: origin/feature/remote-stale" in proc.stdout
+    assert "would delete local branch: feature/current" not in proc.stdout
+    assert "would delete local branch: main" not in proc.stdout
+    assert "would delete remote branch: origin/feature/current" not in proc.stdout
+    assert "would delete remote branch: origin/main" not in proc.stdout
+    assert "would delete remote branch: origin/HEAD" not in proc.stdout
+
+    assert _list_local_branches(work) == {"feature/current", "feature/local-stale", "main"}
+    assert _list_remote_refs(work) == {
+        "origin/HEAD",
+        "origin/feature/current",
+        "origin/feature/remote-stale",
+        "origin/main",
+    }
+
+
+def test_apply_deletes_only_eligible_local_and_remote_branches(tmp_path: Path) -> None:
+    origin, work = _init_repo_fixture(tmp_path)
+
+    proc = _run(["bash", str(SCRIPT_PATH), "--apply"], cwd=work, check=False)
+
+    assert proc.returncode == 0
+    assert "deleted local branch: feature/local-stale" in proc.stdout
+    assert "deleted remote branch: origin/feature/remote-stale" in proc.stdout
+    assert "deleted local branch: feature/current" not in proc.stdout
+    assert "deleted local branch: main" not in proc.stdout
+    assert "deleted remote branch: origin/feature/current" not in proc.stdout
+    assert "deleted remote branch: origin/main" not in proc.stdout
+    assert "deleted remote branch: origin/HEAD" not in proc.stdout
+
+    assert _git(work, "branch", "--show-current") == "feature/current"
+    assert _list_local_branches(work) == {"feature/current", "main"}
+    assert _list_remote_refs(work) == {"origin/HEAD", "origin/feature/current", "origin/main"}
+    assert _list_origin_heads(origin) == {"feature/current", "main"}

--- a/scripts/tests/test_cleanup_branches_contract.py
+++ b/scripts/tests/test_cleanup_branches_contract.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -81,6 +82,39 @@ def _init_repo_fixture(tmp_path: Path) -> tuple[Path, Path]:
     return origin, work
 
 
+def _init_unmerged_local_branch_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    origin, work = _init_repo_fixture(tmp_path)
+    _git(work, "branch", "feature/local-unmerged")
+    _git(work, "switch", "feature/local-unmerged")
+    _write_commit(work, "local-only.txt", "local only\n", "local only commit")
+    _git(work, "switch", "feature/current")
+    return origin, work
+
+
+def _init_detached_head_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    origin, work = _init_repo_fixture(tmp_path)
+    target = _git(work, "rev-parse", "origin/feature/current")
+    _git(work, "checkout", "--detach", target)
+    return origin, work
+
+
+def _install_fake_git_fetch_failure(tmp_path: Path) -> Path:
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -e\n"
+        "if [[ ${1:-} == fetch && ${2:-} == origin && ${3:-} == --prune ]]; then\n"
+        "  echo 'simulated fetch failure' >&2\n"
+        "  exit 1\n"
+        "fi\n"
+        "exec /usr/bin/git \"$@\"\n"
+    )
+    fake_git.chmod(0o755)
+    return fake_bin
+
+
 def test_help_describes_default_dry_run(tmp_path: Path) -> None:
     proc = _run(["bash", str(SCRIPT_PATH), "--help"], cwd=tmp_path, check=False)
 
@@ -114,7 +148,7 @@ def test_default_mode_is_dry_run_and_only_prints_candidates(tmp_path: Path) -> N
     }
 
 
-def test_apply_deletes_only_eligible_local_and_remote_branches(tmp_path: Path) -> None:
+def test_apply_deletes_only_safe_local_and_remote_branches(tmp_path: Path) -> None:
     origin, work = _init_repo_fixture(tmp_path)
 
     proc = _run(["bash", str(SCRIPT_PATH), "--apply"], cwd=work, check=False)
@@ -127,8 +161,76 @@ def test_apply_deletes_only_eligible_local_and_remote_branches(tmp_path: Path) -
     assert "deleted remote branch: origin/feature/current" not in proc.stdout
     assert "deleted remote branch: origin/main" not in proc.stdout
     assert "deleted remote branch: origin/HEAD" not in proc.stdout
+    assert "summary:" in proc.stdout
+    assert "local_deleted=1" in proc.stdout
+    assert "remote_deleted=1" in proc.stdout
 
     assert _git(work, "branch", "--show-current") == "feature/current"
     assert _list_local_branches(work) == {"feature/current", "main"}
     assert _list_remote_refs(work) == {"origin/HEAD", "origin/feature/current", "origin/main"}
     assert _list_origin_heads(origin) == {"feature/current", "main"}
+
+
+def test_apply_refuses_in_detached_head_state(tmp_path: Path) -> None:
+    _, work = _init_detached_head_fixture(tmp_path)
+
+    proc = _run(["bash", str(SCRIPT_PATH), "--apply"], cwd=work, check=False)
+
+    assert proc.returncode != 0
+    assert "detached HEAD" in proc.stderr
+    assert _list_local_branches(work) == {"feature/current", "feature/local-stale", "main"}
+    assert _list_remote_refs(work) == {
+        "origin/HEAD",
+        "origin/feature/current",
+        "origin/feature/remote-stale",
+        "origin/main",
+    }
+
+
+def test_dry_run_warns_in_detached_head_state(tmp_path: Path) -> None:
+    _, work = _init_detached_head_fixture(tmp_path)
+
+    proc = _run(["bash", str(SCRIPT_PATH)], cwd=work, check=False)
+
+    assert proc.returncode == 0
+    assert "warning: detached HEAD detected" in proc.stderr
+    assert "would delete local branch: feature/current" in proc.stdout
+    assert "would delete remote branch: origin/feature/current" in proc.stdout
+
+
+def test_apply_skips_unmerged_local_branch_instead_of_force_deleting(tmp_path: Path) -> None:
+    origin, work = _init_unmerged_local_branch_fixture(tmp_path)
+
+    proc = _run(["bash", str(SCRIPT_PATH), "--apply"], cwd=work, check=False)
+
+    assert proc.returncode == 0
+    assert "deleted local branch: feature/local-stale" in proc.stdout
+    assert "skipped local branch: feature/local-unmerged" in proc.stdout
+    assert "not fully merged" in proc.stdout
+    assert "local_skipped=1" in proc.stdout
+    assert _list_local_branches(work) == {"feature/current", "feature/local-unmerged", "main"}
+    assert _list_origin_heads(origin) == {"feature/current", "main"}
+
+
+def test_apply_handles_stale_remote_tracking_ref_without_failing(tmp_path: Path) -> None:
+    origin, work = _init_repo_fixture(tmp_path)
+    _git(work, "update-ref", "refs/remotes/origin/feature/ghost", _git(work, "rev-parse", "origin/main"))
+    fake_bin = _install_fake_git_fetch_failure(tmp_path)
+
+    proc = subprocess.run(
+        ["bash", str(SCRIPT_PATH), "--apply"],
+        cwd=work,
+        text=True,
+        capture_output=True,
+        check=False,
+        env={**os.environ, "PATH": f"{fake_bin}:/usr/bin:/bin"},
+    )
+
+    assert proc.returncode == 0
+    assert "warning: git fetch origin --prune failed" in proc.stderr
+    assert "skipped remote branch: origin/feature/ghost" in proc.stdout
+    assert "remote ref does not exist" in proc.stdout
+    assert "remote_skipped=1" in proc.stdout
+    assert "failures=0" in proc.stdout
+    assert _list_origin_heads(origin) == {"feature/current", "main"}
+    assert _list_remote_refs(work) == {"origin/HEAD", "origin/feature/current", "origin/main"}

--- a/scripts/tests/test_docs_bilingual_index.py
+++ b/scripts/tests/test_docs_bilingual_index.py
@@ -1,0 +1,61 @@
+import pathlib
+
+DOCS = pathlib.Path("docs")
+README = DOCS / "README.md"
+
+REQUIRED_DOCS = [
+    DOCS / "zh-CN" / "quickstart.md",
+    DOCS / "en" / "quickstart.md",
+    DOCS / "zh-CN" / "install-kernel.md",
+    DOCS / "en" / "install-kernel.md",
+    DOCS / "zh-CN" / "config-generation.md",
+    DOCS / "en" / "config-generation.md",
+    DOCS / "ops" / "branch-cleanup.md",
+]
+
+REQUIRED_TOPICS = [
+    "install command",
+    "acme",
+    "dns",
+    "80",
+    "443",
+    "config generation",
+    "client import",
+    "rule update",
+]
+
+
+def test_bilingual_entrypoints_and_ops_runbook_exist() -> None:
+    for path in REQUIRED_DOCS:
+        assert path.exists(), f"missing doc: {path}"
+
+
+def test_docs_readme_has_bilingual_entrypoints_and_script_index() -> None:
+    text = README.read_text(encoding="utf-8")
+
+    assert "zh-CN/quickstart.md" in text
+    assert "en/quickstart.md" in text
+    assert "zh-CN/install-kernel.md" in text
+    assert "en/install-kernel.md" in text
+    assert "zh-CN/config-generation.md" in text
+    assert "en/config-generation.md" in text
+    assert "ops/branch-cleanup.md" in text
+    assert "scripts/install/install-kernel.sh" in text
+    assert "scripts/config/generate-client-bundle.py" in text
+
+
+def test_required_topics_appear_in_quickstart_and_config_docs() -> None:
+    corpus = "\n".join(
+        path.read_text(encoding="utf-8").lower()
+        for path in [
+            DOCS / "zh-CN" / "quickstart.md",
+            DOCS / "en" / "quickstart.md",
+            DOCS / "zh-CN" / "config-generation.md",
+            DOCS / "en" / "config-generation.md",
+            DOCS / "zh-CN" / "install-kernel.md",
+            DOCS / "en" / "install-kernel.md",
+        ]
+    )
+
+    for topic in REQUIRED_TOPICS:
+        assert topic in corpus, f"missing topic marker: {topic}"

--- a/scripts/tests/test_generate_client_bundle.py
+++ b/scripts/tests/test_generate_client_bundle.py
@@ -4,6 +4,8 @@ import pathlib
 import subprocess
 import sys
 
+import pytest
+
 SCRIPT_PATH = pathlib.Path(__file__).resolve().parents[1] / "config" / "generate-client-bundle.py"
 FIXTURES = pathlib.Path(__file__).resolve().parent / "fixtures"
 
@@ -93,3 +95,49 @@ def test_cli_writes_bundle_json_to_requested_output(tmp_path: pathlib.Path) -> N
     assert payload["kind"] == "trojan-pro-client-profile"
     assert payload["profile"]["routing"]["rules"]
     assert "wrote_bundle=" in proc.stdout
+
+
+def test_unsupported_rule_type_fails_with_source_and_line(tmp_path: pathlib.Path) -> None:
+    bad_rules = tmp_path / "bad-direct.txt"
+    bad_rules.write_text("payload:\n  - GEOIP,CN\n", encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc:
+        load_rule_file(bad_rules)
+
+    message = str(exc.value)
+    assert str(bad_rules) in message
+    assert ":2:" in message
+    assert "unsupported rule type: GEOIP" in message
+
+
+
+def test_empty_one_category_file_is_allowed_when_others_have_rules(tmp_path: pathlib.Path) -> None:
+    empty_direct = tmp_path / "empty-direct.txt"
+    empty_direct.write_text("# intentionally empty\n", encoding="utf-8")
+    output_path = tmp_path / "dist" / "client-import" / "trojan-pro-client-profile-sample.json"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--direct",
+            str(empty_direct),
+            "--proxy",
+            str(FIXTURES / "clash_rules_proxy.sample.txt"),
+            "--reject",
+            str(FIXTURES / "clash_rules_reject.sample.txt"),
+            "--output",
+            str(output_path),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0
+    payload = json.loads(output_path.read_text())
+    rules = payload["profile"]["routing"]["rules"]
+    assert rules
+    assert all(rule["action"]["policyGroupId"] != "direct-group" for rule in rules)
+    assert any(rule["action"]["policyGroupId"] == "proxy-group" for rule in rules)
+    assert any(rule["action"]["policyGroupId"] == "reject-group" for rule in rules)

--- a/scripts/tests/test_generate_client_bundle.py
+++ b/scripts/tests/test_generate_client_bundle.py
@@ -1,0 +1,95 @@
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+
+SCRIPT_PATH = pathlib.Path(__file__).resolve().parents[1] / "config" / "generate-client-bundle.py"
+FIXTURES = pathlib.Path(__file__).resolve().parent / "fixtures"
+
+SPEC = importlib.util.spec_from_file_location("generate_client_bundle", SCRIPT_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+load_rule_file = MODULE.load_rule_file
+build_bundle = MODULE.build_bundle
+
+
+def test_build_bundle_emits_importable_profile_schema_and_priority_order() -> None:
+    direct_rules = load_rule_file(FIXTURES / "clash_rules_direct.sample.txt")
+    proxy_rules = load_rule_file(FIXTURES / "clash_rules_proxy.sample.txt")
+    reject_rules = load_rule_file(FIXTURES / "clash_rules_reject.sample.txt")
+
+    bundle = build_bundle(
+        direct_rules=direct_rules,
+        proxy_rules=proxy_rules,
+        reject_rules=reject_rules,
+        source_meta={"schemaVersion": 1},
+    )
+
+    assert bundle["kind"] == "trojan-pro-client-profile"
+    assert bundle["version"] == 2
+
+    routing = bundle["profile"]["routing"]
+    groups = {group["id"]: group for group in routing["policyGroups"]}
+    assert groups["direct-group"]["action"] == "direct"
+    assert groups["proxy-group"]["action"] == "proxy"
+    assert groups["reject-group"]["action"] == "block"
+
+    rules = routing["rules"]
+    assert len(rules) == 7
+    assert [rule["priority"] for rule in rules] == sorted(rule["priority"] for rule in rules)
+
+    reject_priorities = [
+        rule["priority"]
+        for rule in rules
+        if rule["action"]["policyGroupId"] == "reject-group"
+    ]
+    direct_priorities = [
+        rule["priority"]
+        for rule in rules
+        if rule["action"]["policyGroupId"] == "direct-group"
+    ]
+    proxy_priorities = [
+        rule["priority"]
+        for rule in rules
+        if rule["action"]["policyGroupId"] == "proxy-group"
+    ]
+
+    assert max(reject_priorities) < min(direct_priorities) < min(proxy_priorities)
+    assert any(rule["match"].get("domainExact") == "localhost" for rule in rules)
+    assert any(rule["match"].get("domainSuffix") == ".cn" for rule in rules)
+    assert any(rule["match"].get("domainKeyword") == "openai" for rule in rules)
+    assert any(rule["match"].get("ipCidr") == "10.0.0.0/8" for rule in rules)
+    assert bundle["metadata"]["lock"]["schemaVersion"] == 1
+
+
+def test_cli_writes_bundle_json_to_requested_output(tmp_path: pathlib.Path) -> None:
+    output_path = tmp_path / "dist" / "client-import" / "trojan-pro-client-profile-sample.json"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--direct",
+            str(FIXTURES / "clash_rules_direct.sample.txt"),
+            "--proxy",
+            str(FIXTURES / "clash_rules_proxy.sample.txt"),
+            "--reject",
+            str(FIXTURES / "clash_rules_reject.sample.txt"),
+            "--output",
+            str(output_path),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0
+    assert output_path.exists()
+    payload = json.loads(output_path.read_text())
+    assert payload["kind"] == "trojan-pro-client-profile"
+    assert payload["profile"]["routing"]["rules"]
+    assert "wrote_bundle=" in proc.stdout

--- a/scripts/tests/test_install_kernel_contract.py
+++ b/scripts/tests/test_install_kernel_contract.py
@@ -1,0 +1,60 @@
+import subprocess
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "install" / "install-kernel.sh"
+
+
+def _run(cmd: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, check=False)
+    if check and proc.returncode != 0:
+        raise AssertionError(
+            f"command failed: {' '.join(cmd)}\n"
+            f"cwd={cwd}\n"
+            f"exit={proc.returncode}\n"
+            f"stdout:\n{proc.stdout}\n"
+            f"stderr:\n{proc.stderr}"
+        )
+    return proc
+
+
+def test_help_describes_supported_flags() -> None:
+    proc = _run(["bash", str(SCRIPT_PATH), "--help"], cwd=SCRIPT_PATH.parent.parent, check=False)
+
+    assert proc.returncode == 0
+    assert "Usage:" in proc.stdout
+    assert "--domain" in proc.stdout
+    assert "--email" in proc.stdout
+    assert "--password" in proc.stdout
+    assert "--check-only" in proc.stdout
+    assert "--help" in proc.stdout
+    assert "Caddy ACME" in proc.stdout
+
+
+def test_check_only_runs_phase_skeleton_without_system_changes() -> None:
+    proc = _run(
+        [
+            "bash",
+            str(SCRIPT_PATH),
+            "--domain",
+            "example.com",
+            "--email",
+            "ops@example.com",
+            "--password",
+            "test-password",
+            "--check-only",
+        ],
+        cwd=SCRIPT_PATH.parent.parent,
+        check=False,
+    )
+
+    assert proc.returncode == 0
+    assert "mode=check-only" in proc.stdout
+    assert "phase=detect-os" in proc.stdout
+    assert "phase=install-deps" in proc.stdout
+    assert "phase=install-core" in proc.stdout
+    assert "phase=configure-caddy" in proc.stdout
+    assert "phase=write-runtime-config" in proc.stdout
+    assert "[check-only] would install dependencies" in proc.stdout
+    assert "[check-only] would install trojan core" in proc.stdout
+    assert "[check-only] would render Caddy ACME config" in proc.stdout
+    assert "[check-only] would write runtime config" in proc.stdout

--- a/scripts/tests/test_install_kernel_contract.py
+++ b/scripts/tests/test_install_kernel_contract.py
@@ -58,3 +58,64 @@ def test_check_only_runs_phase_skeleton_without_system_changes() -> None:
     assert "[check-only] would install trojan core" in proc.stdout
     assert "[check-only] would render Caddy ACME config" in proc.stdout
     assert "[check-only] would write runtime config" in proc.stdout
+
+
+def test_missing_value_reports_specific_flag_error() -> None:
+    proc = _run(
+        [
+            "bash",
+            str(SCRIPT_PATH),
+            "--domain",
+            "--email",
+            "ops@example.com",
+            "--password",
+            "test-password",
+            "--check-only",
+        ],
+        cwd=SCRIPT_PATH.parent.parent,
+        check=False,
+    )
+
+    assert proc.returncode != 0
+    assert "missing value for --domain" in proc.stderr
+
+
+def test_missing_required_flags_reports_usage_error() -> None:
+    proc = _run(
+        [
+            "bash",
+            str(SCRIPT_PATH),
+            "--domain",
+            "example.com",
+            "--email",
+            "ops@example.com",
+            "--check-only",
+        ],
+        cwd=SCRIPT_PATH.parent.parent,
+        check=False,
+    )
+
+    assert proc.returncode != 0
+    assert "--domain, --email, and --password are required" in proc.stderr
+    assert "Usage:" in proc.stderr
+
+
+def test_apply_mode_fails_closed_until_implemented() -> None:
+    proc = _run(
+        [
+            "bash",
+            str(SCRIPT_PATH),
+            "--domain",
+            "example.com",
+            "--email",
+            "ops@example.com",
+            "--password",
+            "test-password",
+        ],
+        cwd=SCRIPT_PATH.parent.parent,
+        check=False,
+    )
+
+    assert proc.returncode != 0
+    assert "mode=apply" in proc.stdout
+    assert "apply mode is not implemented yet; use --check-only" in proc.stderr

--- a/scripts/tests/test_validate_repo_cleanup_installer_routing.py
+++ b/scripts/tests/test_validate_repo_cleanup_installer_routing.py
@@ -1,0 +1,5 @@
+import pathlib
+
+
+def test_validation_script_exists() -> None:
+    assert pathlib.Path("scripts/validate_repo_cleanup_installer_routing.sh").exists()

--- a/scripts/validate_repo_cleanup_installer_routing.sh
+++ b/scripts/validate_repo_cleanup_installer_routing.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_BUNDLE="$(mktemp /tmp/trojan-pro-client-profile-XXXXXX.json)"
+
+cleanup() {
+  rm -f "$TMP_BUNDLE"
+}
+trap cleanup EXIT
+
+started_at_utc="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+branch="$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref HEAD)"
+commit_short="$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)"
+
+DIRECT_FIXTURE="$PROJECT_ROOT/scripts/tests/fixtures/clash_rules_direct.sample.txt"
+PROXY_FIXTURE="$PROJECT_ROOT/scripts/tests/fixtures/clash_rules_proxy.sample.txt"
+REJECT_FIXTURE="$PROJECT_ROOT/scripts/tests/fixtures/clash_rules_reject.sample.txt"
+
+cd "$PROJECT_ROOT"
+
+echo "== validate_repo_cleanup_installer_routing =="
+echo "project_root=$PROJECT_ROOT"
+echo "branch=$branch"
+echo "commit=$commit_short"
+echo "started_at_utc=$started_at_utc"
+echo "tmp_bundle=$TMP_BUNDLE"
+echo
+
+echo "[1/4] cleanup dry-run"
+bash scripts/repo/cleanup-branches.sh
+echo "✅ [1/4] pass"
+echo
+
+echo "[2/4] installer --check-only"
+bash scripts/install/install-kernel.sh \
+  --domain example.com \
+  --email ops@example.com \
+  --password change-this-password \
+  --check-only
+echo "✅ [2/4] pass"
+echo
+
+echo "[3/4] bundle generator fixture run"
+python3 scripts/config/generate-client-bundle.py \
+  --direct "$DIRECT_FIXTURE" \
+  --proxy "$PROXY_FIXTURE" \
+  --reject "$REJECT_FIXTURE" \
+  --output "$TMP_BUNDLE"
+test -s "$TMP_BUNDLE"
+echo "✅ [3/4] pass"
+echo
+
+echo "[4/4] docs bilingual index test"
+python3 -m pytest scripts/tests/test_docs_bilingual_index.py -q
+echo "✅ [4/4] pass"
+echo
+
+finished_at_utc="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+echo "finished_at_utc=$finished_at_utc"
+echo
+echo "PASS: validate_repo_cleanup_installer_routing"


### PR DESCRIPTION
## Summary

This PR delivers the scoped package for **repo cleanup + bilingual docs + installer skeleton + routing bundle conversion + end-to-end validation**.

### Included

1. **Safe branch cleanup helper**
   - `scripts/repo/cleanup-branches.sh`
   - default `dry-run`
   - `--apply` guarded against risky cases:
     - refuses apply on detached HEAD
     - protects `main` and current branch
     - avoids force-deleting unmerged local branches
     - handles stale remote-tracking refs with warnings/summary

2. **Generic Linux installer skeleton (fail-closed)**
   - `scripts/install/install-kernel.sh`
   - `scripts/install/lib/*`
   - supports `--domain --email --password --check-only --help`
   - **`--check-only` works** for phase validation
   - non-check mode intentionally fails closed for now:
     - `error: apply mode is not implemented yet; use --check-only`

3. **Clash rules snapshot → client import bundle converter**
   - `scripts/config/generate-client-bundle.py`
   - outputs `kind=trojan-pro-client-profile`, `version=2`
   - supports rule types:
     - `DOMAIN`, `DOMAIN-SUFFIX`, `DOMAIN-KEYWORD`, `IP-CIDR`
   - deterministic priority ordering: `reject > direct > proxy`
   - unsupported rule types fail fast with file:line context
   - single category empty files allowed; only all-empty effective set fails

4. **Bilingual docs + docs index updates**
   - `docs/zh-CN/*`, `docs/en/*`
   - `docs/ops/branch-cleanup.md`
   - `docs/README.md` bilingual entrypoints + script index

5. **End-to-end validation bundle**
   - `scripts/validate_repo_cleanup_installer_routing.sh`
   - verifies in order:
     1) cleanup dry-run
     2) installer `--check-only`
     3) bundle generation from fixtures
     4) bilingual docs index tests

## Scope boundaries (important)

This PR is ready for the **agreed current scope**, but intentionally not the final production endpoint:

- Installer is currently a **safe skeleton** (`--check-only` + fail-closed apply)
- Rule converter is currently **local snapshot conversion**, not remote scheduled fetch/subscription in client runtime

## Validation

Executed on branch before push:

```bash
python3 -m pytest scripts/tests -q
# 45 passed

bash scripts/validate_repo_cleanup_installer_routing.sh
# PASS
```

## Notes for operators

Please do not run destructive branch cleanup apply before merging and switching to `main`:

```bash
bash scripts/repo/cleanup-branches.sh --dry-run
# review candidates first
```
