### PR TITLE
feat(tools): add GitHub Release single-binary installer (linux-amd64/arm64)

### DIFF
--- a/scripts/tests/test_github_release_binary_installer.py
+++ b/scripts/tests/test_github_release_binary_installer.py
@@ -1,0 +1,294 @@
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "tools" / "github-release-binary-installer" / "install-binary.sh"
+
+
+def _run(cmd: list[str], env: dict[str, str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(cmd, cwd=REPO_ROOT, text=True, capture_output=True, env=env, check=False)
+    if check and proc.returncode != 0:
+        raise AssertionError(
+            f"command failed: {' '.join(cmd)}\n"
+            f"exit={proc.returncode}\n"
+            f"stdout:\n{proc.stdout}\n"
+            f"stderr:\n{proc.stderr}\n"
+        )
+    return proc
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_check_only_prints_plan_and_exits_zero(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    proc = _run(
+        [
+            "bash",
+            str(SCRIPT_PATH),
+            "--repo",
+            "owner/repo",
+            "--tool",
+            "mytool",
+            "--target",
+            "linux-amd64",
+            "--check-only",
+        ],
+        env=env,
+        check=True,
+    )
+
+    assert proc.returncode == 0
+    assert "mode=check-only" in proc.stdout
+    assert "asset=mytool-linux-amd64" in proc.stdout
+    assert "sha_url=https://github.com/owner/repo/releases/latest/download/mytool-linux-amd64.sha256" in proc.stdout
+
+
+def test_install_latest_uses_sidecar_sha256_and_installs_atomically(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    # Provide a fake uname so we can force x86_64 -> linux-amd64
+    _write_executable(fake_bin / "uname", "#!/bin/sh\necho x86_64\n")
+
+    # Prepare a fake binary + sha256 sidecar (sha256sum format)
+    payload = tmp_path / "mytool-linux-amd64"
+    payload.write_bytes(b"hello")
+    sha256 = hashlib.sha256(payload.read_bytes()).hexdigest()
+    sidecar = tmp_path / "mytool-linux-amd64.sha256"
+    sidecar.write_text(f"{sha256}  mytool-linux-amd64\n", encoding="utf-8")
+
+    # Fake curl: copy local files into curl -o <out>
+    curl_sh = """#!/bin/sh
+set -eu
+out=""
+url=""
+# accept both: curl <url> -o <out>  and  curl -o <out> <url>
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    http*://*)
+      url="$1"
+      shift
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      # ignore
+      shift
+      ;;
+  esac
+done
+
+base="$(basename "$url")"
+case "$base" in
+  mytool-linux-amd64) src="$FIX_BIN" ;;
+  mytool-linux-amd64.sha256) src="$FIX_SHA" ;;
+  *)
+    echo "unknown url: $url" >&2
+    exit 2
+    ;;
+esac
+
+cp "$src" "$out"
+"""
+
+    curl_path = fake_bin / "curl"
+    curl_path.write_text(
+        curl_sh.replace("$FIX_BIN", str(payload)).replace("$FIX_SHA", str(sidecar)), encoding="utf-8"
+    )
+    curl_path.chmod(0o755)
+
+    install_dir = tmp_path / "install"
+    dest = install_dir / "mytool"
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+    proc = _run(
+        [
+            "bash",
+            str(SCRIPT_PATH),
+            "--repo",
+            "owner/repo",
+            "--tool",
+            "mytool",
+            "--install-dir",
+            str(install_dir),
+        ],
+        env=env,
+        check=True,
+    )
+
+    assert proc.returncode == 0
+    assert "installed=1" in proc.stdout
+    assert dest.exists()
+    assert os.access(dest, os.X_OK)
+    assert dest.read_bytes() == b"hello"
+
+
+def test_sha256_mismatch_fails_closed(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    _write_executable(fake_bin / "uname", "#!/bin/sh\necho x86_64\n")
+
+    payload = tmp_path / "mytool-linux-amd64"
+    payload.write_bytes(b"hello")
+    sidecar = tmp_path / "mytool-linux-amd64.sha256"
+    sidecar.write_text("deadbeef  mytool-linux-amd64\n", encoding="utf-8")
+
+    curl_sh = """#!/bin/sh
+set -eu
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    http*://*)
+      url="$1"
+      shift
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+base="$(basename "$url")"
+case "$base" in
+  mytool-linux-amd64) src="$FIX_BIN" ;;
+  mytool-linux-amd64.sha256) src="$FIX_SHA" ;;
+  *)
+    echo "unknown url: $url" >&2
+    exit 2
+    ;;
+esac
+cp "$src" "$out"
+"""
+
+    curl_path = fake_bin / "curl"
+    curl_path.write_text(
+        curl_sh.replace("$FIX_BIN", str(payload)).replace("$FIX_SHA", str(sidecar)), encoding="utf-8"
+    )
+    curl_path.chmod(0o755)
+
+    install_dir = tmp_path / "install"
+    dest = install_dir / "mytool"
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+    proc = _run(
+        [
+            "bash",
+            str(SCRIPT_PATH),
+            "--repo",
+            "owner/repo",
+            "--tool",
+            "mytool",
+            "--install-dir",
+            str(install_dir),
+        ],
+        env=env,
+        check=False,
+    )
+
+    assert proc.returncode != 0
+    assert "sha256 mismatch" in proc.stderr
+    assert not dest.exists()
+
+
+def test_install_target_key_env_overrides_auto_detection(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    # uname reports x86_64 but we override to linux-arm64
+    _write_executable(fake_bin / "uname", "#!/bin/sh\necho x86_64\n")
+
+    payload = tmp_path / "mytool-linux-arm64"
+    payload.write_bytes(b"hello-arm64")
+    sha256 = hashlib.sha256(payload.read_bytes()).hexdigest()
+    sidecar = tmp_path / "mytool-linux-arm64.sha256"
+    sidecar.write_text(f"{sha256}  mytool-linux-arm64\n", encoding="utf-8")
+
+    curl_sh = """#!/bin/sh
+set -eu
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    http*://*)
+      url="$1"
+      shift
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+base="$(basename "$url")"
+case "$base" in
+  mytool-linux-arm64) src="$FIX_BIN" ;;
+  mytool-linux-arm64.sha256) src="$FIX_SHA" ;;
+  *)
+    echo "unknown url: $url" >&2
+    exit 2
+    ;;
+esac
+cp "$src" "$out"
+"""
+
+    curl_path = fake_bin / "curl"
+    curl_path.write_text(
+        curl_sh.replace("$FIX_BIN", str(payload)).replace("$FIX_SHA", str(sidecar)), encoding="utf-8"
+    )
+    curl_path.chmod(0o755)
+
+    install_dir = tmp_path / "install"
+    dest = install_dir / "mytool"
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["INSTALL_TARGET_KEY"] = "linux-arm64"
+
+    proc = _run(
+        [
+            "bash",
+            str(SCRIPT_PATH),
+            "--repo",
+            "owner/repo",
+            "--tool",
+            "mytool",
+            "--install-dir",
+            str(install_dir),
+        ],
+        env=env,
+        check=True,
+    )
+
+    assert proc.returncode == 0
+    assert dest.exists()
+    assert dest.read_bytes() == b"hello-arm64"

--- a/tools/github-release-binary-installer/README.md
+++ b/tools/github-release-binary-installer/README.md
@@ -1,0 +1,72 @@
+# GitHub Release binary installer (Linux)
+
+A small **generic** installer for a single executable binary distributed via **GitHub Releases**.
+
+This is intended for **normal / legal** software distribution (internal tools, open-source utilities, etc.).
+
+## Assumptions
+
+- Your GitHub Release contains **two** Linux binaries:
+  - `<tool>-linux-amd64`
+  - `<tool>-linux-arm64`
+- Each asset has a matching `sha256sum` sidecar file:
+  - `<asset>.sha256`
+
+The `.sha256` file may be either:
+
+- `sha256sum` format: `<hash>  <filename>`
+- or just the hash on the first line
+
+## Usage
+
+### Check-only (no writes)
+
+```bash
+bash tools/github-release-binary-installer/install-binary.sh \
+  --repo owner/repo \
+  --tool mytool \
+  --check-only
+```
+
+### Install latest to /usr/local/bin
+
+```bash
+sudo bash tools/github-release-binary-installer/install-binary.sh \
+  --repo owner/repo \
+  --tool mytool
+```
+
+### Force target
+
+```bash
+sudo bash tools/github-release-binary-installer/install-binary.sh \
+  --repo owner/repo \
+  --tool mytool \
+  --target linux-arm64
+```
+
+### Install a specific tag
+
+```bash
+sudo bash tools/github-release-binary-installer/install-binary.sh \
+  --repo owner/repo \
+  --tool mytool \
+  --version v1.2.3
+```
+
+## Flags
+
+- `--repo <owner/repo>` (required)
+- `--tool <name>` (required)
+- `--version latest|<tag>` (default: `latest`)
+- `--target auto|linux-amd64|linux-arm64` (default: `auto`)
+- `--install-dir <dir>` (default: `/usr/local/bin`)
+- `--dest-name <name>` (default: `<tool>`)
+- `--check-only`
+
+## Notes
+
+- Latest download URL form:
+  - `https://github.com/<owner>/<repo>/releases/latest/download/<asset>`
+- Tagged URL form:
+  - `https://github.com/<owner>/<repo>/releases/download/<tag>/<asset>`

--- a/tools/github-release-binary-installer/install-binary.sh
+++ b/tools/github-release-binary-installer/install-binary.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_usage() {
+  cat <<'EOF'
+Usage:
+  install-binary.sh --repo <owner/repo> --tool <name> [options]
+
+Generic installer for a single executable binary distributed via GitHub Releases.
+
+Required:
+  --repo <owner/repo>
+  --tool <name>
+
+Options:
+  --version latest|<tag>           (default: latest)
+  --target auto|linux-amd64|linux-arm64  (default: auto)
+  --install-dir <dir>             (default: /usr/local/bin)
+  --dest-name <name>              (default: <tool>)
+  --check-only                    Print plan only; do not write
+  --help
+
+Environment overrides:
+  INSTALL_TARGET_KEY=linux-amd64|linux-arm64
+EOF
+}
+
+require_value() {
+  local flag="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    echo "error: missing value for $flag" >&2
+    exit 2
+  fi
+}
+
+repo=""
+tool=""
+version="latest"
+target="auto"
+install_dir="/usr/local/bin"
+dest_name=""
+check_only=0
+
+while (($# > 0)); do
+  case "$1" in
+    --repo)
+      require_value "$1" "${2:-}"
+      repo="$2"
+      shift 2
+      ;;
+    --tool)
+      require_value "$1" "${2:-}"
+      tool="$2"
+      shift 2
+      ;;
+    --version)
+      require_value "$1" "${2:-}"
+      version="$2"
+      shift 2
+      ;;
+    --target)
+      require_value "$1" "${2:-}"
+      target="$2"
+      shift 2
+      ;;
+    --install-dir)
+      require_value "$1" "${2:-}"
+      install_dir="$2"
+      shift 2
+      ;;
+    --dest-name)
+      require_value "$1" "${2:-}"
+      dest_name="$2"
+      shift 2
+      ;;
+    --check-only)
+      check_only=1
+      shift
+      ;;
+    --help|-h)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      print_usage >&2
+      exit 2
+      ;;
+  esac
+
+done
+
+if [[ -z "$repo" || -z "$tool" ]]; then
+  echo "error: --repo and --tool are required" >&2
+  print_usage >&2
+  exit 2
+fi
+
+if [[ -z "$dest_name" ]]; then
+  dest_name="$tool"
+fi
+
+normalize_target() {
+  local raw="$1"
+  case "$raw" in
+    linux-amd64|linux-arm64) echo "$raw" ;;
+    *)
+      echo "error: unsupported target '$raw' (expected linux-amd64|linux-arm64)" >&2
+      exit 2
+      ;;
+  esac
+}
+
+detect_target() {
+  local arch
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64) echo "linux-amd64" ;;
+    aarch64|arm64) echo "linux-arm64" ;;
+    *)
+      echo "error: unsupported arch '$arch' (expected x86_64 or aarch64/arm64)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+resolved_target=""
+if [[ -n "${INSTALL_TARGET_KEY:-}" ]]; then
+  resolved_target="$(normalize_target "${INSTALL_TARGET_KEY}")"
+elif [[ "$target" == "auto" ]]; then
+  resolved_target="$(detect_target)"
+else
+  resolved_target="$(normalize_target "$target")"
+fi
+
+asset_name="${tool}-${resolved_target}"
+sha_name="${asset_name}.sha256"
+
+base_url="https://github.com/${repo}"
+if [[ "$version" == "latest" ]]; then
+  asset_url="${base_url}/releases/latest/download/${asset_name}"
+  sha_url="${base_url}/releases/latest/download/${sha_name}"
+else
+  asset_url="${base_url}/releases/download/${version}/${asset_name}"
+  sha_url="${base_url}/releases/download/${version}/${sha_name}"
+fi
+
+dest_path="${install_dir}/${dest_name}"
+
+echo "repo=${repo}"
+echo "tool=${tool}"
+echo "version=${version}"
+echo "target=${resolved_target}"
+echo "asset=${asset_name}"
+echo "asset_url=${asset_url}"
+echo "sha_url=${sha_url}"
+echo "dest=${dest_path}"
+
+download() {
+  local url="$1"
+  local out="$2"
+  curl -fsSL "$url" -o "$out"
+}
+
+parse_sha256() {
+  local sha_file="$1"
+  # Accept both:
+  #   <hash>  <filename>
+  # and:
+  #   <hash>
+  awk 'NF{print $1; exit 0}' "$sha_file"
+}
+
+if [[ "$check_only" == "1" ]]; then
+  echo "mode=check-only"
+  exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "error: curl is required" >&2
+  exit 1
+fi
+
+if ! command -v sha256sum >/dev/null 2>&1; then
+  echo "error: sha256sum is required" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+bin_tmp="$tmp_dir/${asset_name}"
+sha_tmp="$tmp_dir/${sha_name}"
+
+download "$sha_url" "$sha_tmp"
+download "$asset_url" "$bin_tmp"
+
+expected_sha="$(parse_sha256 "$sha_tmp")"
+if [[ -z "$expected_sha" ]]; then
+  echo "error: could not parse sha256 from $sha_name" >&2
+  exit 1
+fi
+
+actual_sha="$(sha256sum "$bin_tmp" | awk '{print $1}')"
+if [[ "$actual_sha" != "$expected_sha" ]]; then
+  echo "error: sha256 mismatch" >&2
+  echo "expected=$expected_sha" >&2
+  echo "actual=$actual_sha" >&2
+  exit 1
+fi
+
+install -d "$(dirname "$dest_path")"
+install -m 0755 "$bin_tmp" "${dest_path}.tmp"
+mv "${dest_path}.tmp" "$dest_path"
+
+echo "installed=1"


### PR DESCRIPTION
## Summary
- Add a generic installer script for a single executable binary shipped via GitHub Releases
- Supports linux-amd64 + linux-arm64, auto target detection, and sidecar *.sha256 verification
- Provides check-only mode and atomic install to /usr/local/bin by default

## Tests
- python3 -m pytest scripts/tests/test_github_release_binary_installer.py -q
- python3 -m pytest scripts/tests -q
